### PR TITLE
Fixed #20: Install-branding.sh does not work on Ubuntu.

### DIFF
--- a/src/assets/branding/install-branding.sh
+++ b/src/assets/branding/install-branding.sh
@@ -1,16 +1,11 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Install default logos and theme
 cp ./src/assets/brand*.png ./src/assets/branding/
 cp ./src/assets/styles/brand-theme.scss ./src/assets/branding/
 
 # Install possible assets customization
-if [[ -z "${BRANDING_LOCATION}" ]]; then
-  BRANDING_DIR="./branding"
-else
-  BRANDING_DIR="${BRANDING_LOCATION}"
-fi
-
+BRANDING_DIR="${BRANDING_LOCATION:-./branding}"
 cp ${BRANDING_DIR}/assets/* ./src/assets/branding/ 2>/dev/null | :
 cp ${BRANDING_DIR}/public/* ./public 2>/dev/null | :
 


### PR DESCRIPTION
Signed-off-by: Simon Viénot <simon.vienot@icloud.com>

**Description**:

Changed the test for existence of environment variable $BRANDING_LOCATION such that it works on ubuntu.

**Related issue(s)**:

Fixes #20

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
