### PR TITLE
Fixed #22: Incorrect font used in title of transactionsById page

### DIFF
--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -34,7 +34,7 @@
         <span class="h-is-secondary-text">{{ transaction ? convertTransactionId(transactionId) : "" }}</span>
         <span v-if="showAllTransactionVisible" class="ml-4" id="allTransactionsLink">
           <router-link :to="{name: 'TransactionsById', params: {transactionId: transactionId}}">
-            <span class="h-is-text-size-3 has-text-grey">All transactions with the same ID</span>
+            <span class="h-is-property-text has-text-grey">See all transactions with the same ID</span>
           </router-link>
         </span>
      </template>

--- a/src/pages/TransactionsById.vue
+++ b/src/pages/TransactionsById.vue
@@ -30,7 +30,8 @@
 
     <DashboardCard>
       <template v-slot:title>
-        <span class="h-is-primary-title">Transactions with ID {{ normalizedTransactionId }}</span>
+        <span class="h-is-primary-title">Transactions with ID </span>
+        <span class="h-is-secondary-text">{{ normalizedTransactionId }}</span>
       </template>
       <template v-slot:control>
         <div class="is-flex is-align-items-flex-end">


### PR DESCRIPTION
**Description**:

Trivial changes:
- h-is-secondary-text style applied to the ID  to make it lighter than the rest of the title
- wording and slightly bigger font for the "See all transactions with same ID" link in the Transaction details page

**Related issue(s)**:

Fixes #22

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
