### PR TITLE
00027 error diagnostic misleading

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -124,7 +124,7 @@ export default defineComponent({
               router.push({name: 'TopicDetails', params: { topicId: r.topicMessages[0].topic_id}})
               searchDidEnd(true)
             } else {
-              router.push({name: 'NoSearchResult', params: { searchedId: searchedId.value}})
+              router.push({name: 'NoSearchResult', params: { searchedId: searchedId.value}, query: { errorCount: r.getErrorCount()}})
               searchDidEnd(false)
             }
           } catch {

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -29,17 +29,28 @@
   <section class="section has-text-centered" style="height: calc(100vh - 300px)">
 
     <p class="h-is-secondary-text" style="font-weight: 300">
-      No result
+      <template v-if="errorCount >= 1">
+        Search error
+      </template>
+      <template v-else>
+        No result
+      </template>
     </p>
     <br/>
 
     <div class="block">
       <p class="h-is-tertiary-text" style="font-weight: 300">
-        <span >No account, transaction, contract, token or topic matches "</span>
-        <span style="font-weight: 400">{{ this.searchedId }}</span>
-        <span >".</span>
-        <br/>
-        Make sure you enter either an entity ID (0.0.x) or a transaction ID (0.0.x@seconds.nanoseconds).
+        <template v-if="errorCount >= 1">
+          Server reported errors during the search execution.<br/>
+          This might be transient. Try to search again in a few moments.
+        </template>
+        <template v-else>
+          <span >No account, transaction, contract, token or topic matches "</span>
+          <span style="font-weight: 400">{{ this.searchedId }}</span>
+          <span >".</span>
+          <br/>
+          Make sure you enter either an entity ID (0.0.x) or a transaction ID (0.0.x@seconds.nanoseconds).
+        </template>
       </p>
     </div>
 
@@ -58,6 +69,7 @@ export default defineComponent({
   name: 'SearchResult',
   props: {
     "searchedId": String,
+    "errorCount": Number,
     "network": String
   }
 })

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -133,7 +133,11 @@ const routes: Array<RouteRecordRaw> = [
     path: '/:network/search-result/:searchedId',
     name: 'NoSearchResult',
     component: NoSearchResult,
-    props: true
+    props:  route => ({
+      network: route.params.network as string|undefined,
+      searchedId: route.params.searchedId as string|undefined,
+      errorCount: Number(route.query.errorCount) as number|undefined
+    })
   },
   {
     path: '/:network/mobile-menu',

--- a/src/utils/AxiosMonitor.ts
+++ b/src/utils/AxiosMonitor.ts
@@ -28,6 +28,7 @@ export class AxiosMonitor {
     private requestInterceptor: number | null = null
     private responseInterceptor: number | null = null
     private activeRequestCount = 0
+    private successfulRequestCount = 0
     private errorResponses = new Map<string, unknown>()
     private stateChangeCB: (() => void) | null = null
 
@@ -62,6 +63,10 @@ export class AxiosMonitor {
         return this.activeRequestCount
     }
 
+    public getSuccessfulRequestCount(): number {
+        return this.successfulRequestCount
+    }
+
     public getErrorResponses(): Map<string, unknown> {
         return this.errorResponses
     }
@@ -77,6 +82,7 @@ export class AxiosMonitor {
         if (this.errorResponses.size >= 1) {
             console.log("Clearing " + this.errorResponses.size + " error responses")
             this.errorResponses.clear()
+            this.successfulRequestCount = 0
             this.stateDidChange()
         }
     }
@@ -95,6 +101,7 @@ export class AxiosMonitor {
         let result: Promise<AxiosResponse>
         if (this.targetAxios !== null) {
             this.activeRequestCount -= 1
+            this.successfulRequestCount += 1
             this.errorResponses.delete(this.targetAxios.getUri(response.config))
             this.stateDidChange()
             result = Promise.resolve(response)

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -42,6 +42,7 @@ export class SearchRequest {
 
     private promise = new DeferredPromise<void>()
     private countdown = 0
+    private errorCount = 0
 
     constructor(searchedId: string) {
         this.searchedId = searchedId
@@ -50,6 +51,7 @@ export class SearchRequest {
     run(): Promise<void> {
 
         this.countdown = 5
+        this.errorCount = 0
 
         const isEntityId = EntityID.parse(this.searchedId) != null
         const isTransactionId = TransactionID.parse(this.searchedId) != null
@@ -61,8 +63,9 @@ export class SearchRequest {
                 .then(response => {
                     this.account = response.data
                 })
-                .catch(() => { // To avoid console pollution
-                    return null
+                .catch((reason: unknown) => {
+                    this.updateErrorCount(reason)
+                    return null // To avoid console pollution
                 })
                 .finally(() => {
                     this.updatePromise()
@@ -79,8 +82,9 @@ export class SearchRequest {
                 .then(response => {
                     this.transactions = response.data.transactions
                 })
-                .catch(() => { // To avoid console pollution
-                    return null
+                .catch((reason: unknown) => {
+                    this.updateErrorCount(reason)
+                    return null // To avoid console pollution
                 })
                 .finally(() => {
                     this.updatePromise()
@@ -97,8 +101,9 @@ export class SearchRequest {
                 .then(response => {
                     this.tokenInfo = response.data
                 })
-                .catch(() => { // To avoid console pollution
-                    return null
+                .catch((reason: unknown) => {
+                    this.updateErrorCount(reason)
+                    return null // To avoid console pollution
                 })
                 .finally(() => {
                     this.updatePromise()
@@ -119,8 +124,9 @@ export class SearchRequest {
                 .then(response => {
                     this.topicMessages = response.data.messages
                 })
-                .catch(() => { // To avoid console pollution
-                    return null
+                .catch((reason: unknown) => {
+                    this.updateErrorCount(reason)
+                    return null // To avoid console pollution
                 })
                 .finally(() => {
                     this.updatePromise()
@@ -137,8 +143,9 @@ export class SearchRequest {
                 .then(response => {
                     this.contract = response.data
                 })
-                .catch(() => { // To avoid console pollution
-                    return null
+                .catch((reason: unknown) => {
+                    this.updateErrorCount(reason)
+                    return null // To avoid console pollution
                 })
                 .finally(() => {
                     this.updatePromise()
@@ -151,6 +158,10 @@ export class SearchRequest {
         return this.promise
     }
 
+    getErrorCount(): number {
+        return this.errorCount
+    }
+
 
     //
     // Private
@@ -160,6 +171,13 @@ export class SearchRequest {
         this.countdown -= 1
         if (this.countdown <= 0) {
             this.promise.resolveNow()
+        }
+    }
+
+    private updateErrorCount(reason: unknown): void {
+        const notFound = axios.isAxiosError(reason) && reason.request?.status == 404
+        if (!notFound) {
+            this.errorCount += 1
         }
     }
 }


### PR DESCRIPTION
**Description**:

The changes below improve diagnostic message displayed by Explorer when server returns error.
In particular, it better detects if server is overloaded (busy) or if internet connection is faulty.

Search bar also makes some error analysis et may now reports « search error » when:
1) no match has been found
2) some calls to server did fail

**Related issue(s)**:

Fixes #00027


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
