### PR TITLE
TokenAmount component now takes TokenInfo.decimals into account.

### DIFF
--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -57,7 +57,8 @@
       <div v-else-if="props.row.balance?.tokens?.length === 1">
         <TokenAmount
             v-bind:amount="props.row.balance?.tokens[0].balance"
-            v-bind:token-id="props.row.balance?.tokens[0].token_id"/>
+            v-bind:token-id="props.row.balance?.tokens[0].token_id"
+            v-bind:show-extra="true"/>
       </div>
       <div v-else class="has-text-grey">
         None

--- a/src/components/account/BalanceTable.vue
+++ b/src/components/account/BalanceTable.vue
@@ -48,7 +48,8 @@
     </o-table-column>
 
     <o-table-column v-slot="props" field="balance" label="Balance" position="right">
-      <TokenAmount v-bind:amount="props.row.balance ?? 0"/>
+      <TokenAmount v-bind:amount="props.row.balance ?? 0"
+                   v-bind:token-id="props.row.token_id"/>
     </o-table-column>
 
   </o-table>

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -48,7 +48,7 @@
     </o-table-column>
 
     <o-table-column v-slot="props" field="balance" label="Balance" position="right">
-      <TokenAmount v-bind:amount="props.row.balance ?? 0"/>
+      <TokenAmount v-bind:amount="props.row.balance ?? 0" v-bind:token-id="tokenId"/>
     </o-table-column>
 
   </o-table>

--- a/src/components/transfer_graphs/TokenTransferGraphC.vue
+++ b/src/components/transfer_graphs/TokenTransferGraphC.vue
@@ -53,7 +53,8 @@
           <!-- #2 : token amount -->
           <div class="justify-end">
             <TokenAmount v-if="i === 1"
-                         v-bind:amount="tokenTransferLayout[s-1].netAmount"/>
+                         v-bind:amount="tokenTransferLayout[s-1].netAmount"
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"/>
           </div>
 
           <!-- #3 : arrow -->

--- a/src/components/transfer_graphs/TokenTransferGraphF.vue
+++ b/src/components/transfer_graphs/TokenTransferGraphF.vue
@@ -63,7 +63,8 @@
           <!-- #1 : token amount -->
           <div class="justify-end">
             <TokenAmount v-if="i <= tokenTransferLayout[s-1].sources.length"
-                         v-bind:amount="tokenTransferLayout[s-1].sources[i-1].amount"/>
+                         v-bind:amount="tokenTransferLayout[s-1].sources[i-1].amount"
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"/>
           </div>
 
           <!-- #2 : token symbol -->
@@ -95,7 +96,8 @@
           <!-- #5 : token amount -->
           <div>
             <TokenAmount v-if="i <= tokenTransferLayout[s-1].destinations.length"
-                         v-bind:amount="tokenTransferLayout[s-1].destinations[i-1].amount"/>
+                         v-bind:amount="tokenTransferLayout[s-1].destinations[i-1].amount"
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"/>
           </div>
 
           <template v-if="symbolVisible">

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -63,7 +63,7 @@
 
                   <div v-else>
                     <div v-for="b in tokenBalances ?? []" :key="b.token_id">
-                      <TokenAmount v-bind:amount="b.balance" v-bind:token-id="b.token_id"/>
+                      <TokenAmount v-bind:amount="b.balance" v-bind:token-id="b.token_id" v-bind:show-extra="true"/>
                     </div>
                   </div>
 

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -107,19 +107,25 @@
             <div class="columns">
               <div class="column is-one-third has-text-weight-light">Total Supply</div>
               <div class="column" id="totalSupply">
-                {{ tokenInfo?.total_supply }}
+                <TokenAmount v-bind:amount="parseIntString(tokenInfo?.total_supply)"
+                             v-bind:token-id="tokenId"
+                             v-bind:show-extra="false"/>
               </div>
             </div>
             <div class="columns">
               <div class="column is-one-third has-text-weight-light">Initial Supply</div>
               <div class="column" id="initialSupply">
-                {{ tokenInfo?.initial_supply }}
+                <TokenAmount v-bind:amount="parseIntString(tokenInfo?.initial_supply)"
+                             v-bind:token-id="tokenId"
+                             v-bind:show-extra="false"/>
               </div>
             </div>
             <div class="columns">
               <div class="column is-one-third has-text-weight-light">Max Supply</div>
               <div class="column" id="maxSupply">
-                {{ tokenInfo?.max_supply }}
+                <TokenAmount v-bind:amount="parseIntString(tokenInfo?.max_supply)"
+                             v-bind:token-id="tokenId"
+                             v-bind:show-extra="false"/>
               </div>
             </div>
 
@@ -165,6 +171,7 @@ import TokenBalanceTable from "@/components/token/TokenBalanceTable.vue";
 import {formatSeconds} from "@/utils/Duration";
 import DashboardCard from "@/components/DashboardCard.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
+import TokenAmount from "@/components/values/TokenAmount.vue";
 
 export default defineComponent({
 
@@ -176,6 +183,7 @@ export default defineComponent({
     TimestampValue,
     TokenBalanceTable,
     TokenNftTable,
+    TokenAmount,
     KeyValue
   },
 
@@ -211,12 +219,16 @@ export default defineComponent({
     return {
       tokenInfo,
       showTokenDetails,
-
-      formatSeconds
+      formatSeconds,
+      parseIntString
     }
   },
 });
 
+function parseIntString(s: string|undefined): number|undefined {
+  const result = Number(s)
+  return isNaN(result) ? undefined : result
+}
 
 
 </script>

--- a/tests/unit/token/TokenBalanceTable.spec.ts
+++ b/tests/unit/token/TokenBalanceTable.spec.ts
@@ -59,6 +59,10 @@ describe("TokenBalanceTable.vue", () => {
         const mock = new MockAdapter(axios);
 
         const testTokenId = SAMPLE_TOKEN.token_id
+
+        const matcher2 = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
+        mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
+
         const matcher = "/api/v1/tokens/" + testTokenId + "/balances"
         mock.onGet(matcher).reply(200, SAMPLE_BALANCES);
 

--- a/tests/unit/values/TokenAmount.spec.ts
+++ b/tests/unit/values/TokenAmount.spec.ts
@@ -38,7 +38,7 @@ mock.onGet(matcher).reply(200, SAMPLE_TOKEN);
 
 describe("TokenAmount.vue", () => {
 
-    it("no amount; topicId", async () => {
+    it("no amount; tokenId", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -49,9 +49,17 @@ describe("TokenAmount.vue", () => {
                 plugins: [router]
             },
             props: {
-                tokenId: SAMPLE_TOKEN.token_id
+                tokenId: SAMPLE_TOKEN.token_id,
             },
         });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(expectedAmount.toString())
+
+        await wrapper.setProps({
+                tokenId: SAMPLE_TOKEN.token_id,
+                showExtra: true
+            })
         await flushPromises()
 
         expect(wrapper.get('span').text()).toBe(expectedAmount.toString())
@@ -59,27 +67,7 @@ describe("TokenAmount.vue", () => {
         expect(wrapper.get('.h-is-extra-text').text()).toBe(SAMPLE_TOKEN.name)
     });
 
-    it("amount; no topicId", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
-
-        const testAmount = 42
-
-        const wrapper = mount(TokenAmount, {
-            global: {
-                plugins: [router]
-            },
-            props: {
-                amount: testAmount
-            },
-        });
-        await flushPromises()
-
-        expect(wrapper.get('span').text()).toBe(testAmount.toString())
-        expect(() => wrapper.get('a')).toThrowError()
-    });
-
-    it("amount; topicId", async () => {
+    it("amount; no tokenId", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -91,9 +79,37 @@ describe("TokenAmount.vue", () => {
             },
             props: {
                 amount: testAmount,
-                tokenId: SAMPLE_TOKEN.token_id
             },
         });
+        await flushPromises()
+
+        expect(wrapper.get('span').text()).toBe("")
+        expect(() => wrapper.get('a')).toThrowError()
+    });
+
+    it("amount; tokenId", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const testAmount = 42
+
+        const wrapper = mount(TokenAmount, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                amount: testAmount,
+                tokenId: SAMPLE_TOKEN.token_id,
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(testAmount.toString())
+
+        await wrapper.setProps({
+            tokenId: SAMPLE_TOKEN.token_id,
+            showExtra: true
+        })
         await flushPromises()
 
         expect(wrapper.get('span').text()).toBe(testAmount.toString())


### PR DESCRIPTION
Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

With the changes below, Explorer now computes  amount of tokens using the row amount number and the number of decimals specified in TokenInfo.decimals.

For token 00.731861, detail page now displays:
- Total supply: 20,000,002
- Max supply: 1,000,000

This new behavior applies across all places when token amounts are displayed.

**Related issue(s)**:
Fixes #37

**Notes for reviewer**:
See instructions in issue #37 to experiment those changes.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
