### PR TITLE
00035 improve mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,49 +19,17 @@
   -->
 
 <template>
+
   <section class="section is-top-section">
     <TopNavBar/>
   </section>
-
-<!--  <div v-if="sizeFallBack">-->
-<!--    <hr class="h-top-banner" style="margin: 0; height: 4px"/>-->
-
-<!--    <section class="section has-text-centered" style="height: calc(100vh - 300px)">-->
-
-<!--      <div class="block h-is-tertiary-text">-->
-<!--        <p style="font-weight: 300">Mobile support coming soon...</p>-->
-<!--        <p style="font-weight: 200">If on a desktop, please enlarge your browser window</p>-->
-<!--      </div>-->
-
-<!--    </section>-->
-<!--  </div>-->
 
   <div :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
     <router-view/>
   </div>
 
   <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
-
-    <hr class="h-top-banner mb-4 mt-0" style="height: 1px"/>
-
-    <div class="is-flex is-align-items-center">
-
-      <a href="https://hedera.com" style="line-height: 1">
-        <img alt="Built On Hedera" src="@/assets/built-on-hedera-white.svg" style="min-width: 104px;">
-      </a>
-
-      <span v-if="!isTouchDevice && isSmallScreen" class="h-is-property-text ml-5 pb-1" style="font-weight:300; color: #DBDBDB">
-        Hedera Mirror Node Explorer is a ledger explorer for the Hedera network.
-      </span>
-
-      <span class="is-flex-grow-1"/>
-
-      <a href="#" class="ml-4" style="line-height: 1">
-        <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
-      </a>
-
-    </div>
-
+    <Footer/>
   </section>
 
 </template>
@@ -70,6 +38,7 @@
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, provide, ref} from 'vue';
 import TopNavBar from "@/components/TopNavBar.vue";
+import Footer from "@/components/Footer.vue";
 
 export const XLARGE_BREAKPOINT = 1240
 export const LARGE_BREAKPOINT = 1120
@@ -84,7 +53,7 @@ export const ORUGA_MOBILE_BREAKPOINT = "1023px"
 
 export default defineComponent({
   name: 'App',
-  components: {TopNavBar},
+  components: {Footer, TopNavBar},
 
   setup() {
     const isTouchDevice = ('ontouchstart' in window)

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,11 +24,7 @@
     <TopNavBar/>
   </section>
 
-  <div :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
-    <router-view/>
-  </div>
-
-  <Footer/>
+  <router-view/>
 
 </template>
 
@@ -36,7 +32,6 @@
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, provide, ref} from 'vue';
 import TopNavBar from "@/components/TopNavBar.vue";
-import Footer from "@/components/Footer.vue";
 
 export const XLARGE_BREAKPOINT = 1240
 export const LARGE_BREAKPOINT = 1120
@@ -51,7 +46,7 @@ export const ORUGA_MOBILE_BREAKPOINT = "1023px"
 
 export default defineComponent({
   name: 'App',
-  components: {Footer, TopNavBar},
+  components: {TopNavBar},
 
   setup() {
     const isTouchDevice = ('ontouchstart' in window)

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,7 +57,7 @@
       <span class="is-flex-grow-1"/>
 
       <a href="#" class="ml-4" style="line-height: 1">
-        <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 124px;">
+        <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
       </a>
 
     </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,9 +28,7 @@
     <router-view/>
   </div>
 
-  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
-    <Footer/>
-  </section>
+  <Footer/>
 
 </template>
 

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -206,11 +206,6 @@ body {
         background-position: calc(100% - 13px) calc(100% - 16px);
     }
 }
-@media (max-width: 767px) {
-    #drop-down-menu .o-sel {
-        background-color: $h-mobile-page-background-color;
-    }
-}
 a.button {
     padding-top: 28px;
     padding-bottom: 16px;

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -23,6 +23,8 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
+  <section class="section pt-0"
+           :class="{'h-mobile-background': !keepBackground && (isTouchDevice || !isSmallScreen)}">
 
     <hr class="h-top-banner mb-4 mt-0" style="height: 1px"/>
 
@@ -46,6 +48,7 @@
 
     </div>
 
+  </section>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -58,6 +61,13 @@ import {defineComponent, inject} from "vue";
 
 export default defineComponent({
   name: "Footer",
+
+  props: {
+    keepBackground: {
+      type: Boolean,
+      default: false
+    }
+  },
 
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,0 +1,80 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+    <hr class="h-top-banner mb-4 mt-0" style="height: 1px"/>
+
+    <div class="is-flex is-align-items-center">
+
+      <a href="https://hedera.com" style="line-height: 1">
+        <img alt="Built On Hedera" src="@/assets/built-on-hedera-white.svg" style="min-width: 104px;">
+      </a>
+
+      <span v-if="!isTouchDevice && isSmallScreen"
+            class="h-is-property-text ml-5 pb-1"
+            style="font-weight:300; color: #DBDBDB">
+        Hedera Mirror Node Explorer is a ledger explorer for the Hedera network.
+      </span>
+
+      <span class="is-flex-grow-1"/>
+
+      <a class="ml-4" href="#" style="line-height: 1">
+        <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
+      </a>
+
+    </div>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, inject} from "vue";
+
+export default defineComponent({
+  name: "Footer",
+
+  setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+
+    return {
+      isSmallScreen,
+      isTouchDevice
+    }
+  },
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style>
+</style>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -24,7 +24,7 @@
 
 <template>
 
-  <div v-if="isTouchDevice || !isMediumScreen">
+  <div v-if="!isMediumScreen">
     <form data-cy="searchBar" class="control" action="" v-on:submit.prevent="performSearch">
       <input
           class="input has-background-white has-text-black"

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -24,15 +24,6 @@
 
 <template>
 
-<!--  <div v-if="hideNavBar">-->
-<!--    <span class="is-inline-flex is-align-items-center is-flex-grow-0 is-flex-shrink-0">-->
-<!--      <a @click="$router.push({name: 'MainDashboard'})" class="mr-3">-->
-<!--        <img alt="Product Logo" class="image" src="@/assets/branding/brand-product-logo.png" style="max-width: 270px;">-->
-<!--      </a>-->
-<!--      <AxiosStatus/>-->
-<!--    </span>-->
-<!--  </div>-->
-
   <div v-if="!isMediumScreen"
        class="is-flex is-align-items-center is-justify-content-space-between pt-3 pb-4">
 

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -33,7 +33,7 @@
 <!--    </span>-->
 <!--  </div>-->
 
-  <div v-if="isTouchDevice || !isMediumScreen"
+  <div v-if="!isMediumScreen"
        class="is-flex is-align-items-center is-justify-content-space-between pt-3 pb-4">
 
     <span class="is-inline-flex is-align-items-center is-flex-grow-0 is-flex-shrink-0">

--- a/src/pages/AccountBalances.vue
+++ b/src/pages/AccountBalances.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -40,6 +40,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -48,15 +50,17 @@
 
 <script lang="ts">
 
-import {defineComponent} from 'vue';
+import {defineComponent, inject} from 'vue';
 import BalanceTable from "@/components/account/BalanceTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
 
   name: 'AccountBalances',
 
   components: {
+    Footer,
     DashboardCard,
     BalanceTable
   },
@@ -64,8 +68,16 @@ export default defineComponent({
   props: {
     accountId: String,
     network: String
-  }
+  },
 
+  setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+    return {
+      isSmallScreen,
+      isTouchDevice
+    }
+  }
 });
 
 </script>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -162,6 +162,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -184,6 +186,7 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import {BalanceCache} from "@/components/account/BalanceCache";
+import Footer from "@/components/Footer.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -192,6 +195,7 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
+    Footer,
     BlobValue,
     TokenAmount,
     HbarAmount,

--- a/src/pages/Accounts.vue
+++ b/src/pages/Accounts.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -39,6 +39,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -47,9 +49,10 @@
 
 <script lang="ts">
 
-import {defineComponent} from 'vue';
+import {defineComponent, inject} from 'vue';
 import AccountTable from "@/components/account/AccountTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'Accounts',
@@ -59,9 +62,19 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     AccountTable
   },
+
+  setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+    return {
+      isSmallScreen,
+      isTouchDevice
+    }
+  }
 });
 
 </script>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -190,6 +190,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -198,7 +200,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, onBeforeMount, ref, watch} from 'vue';
+import {computed, defineComponent, inject, onBeforeMount, ref, watch} from 'vue';
 import axios from "axios";
 import {AccountBalanceTransactions, ContractResponse, TokenInfo} from "@/schemas/HederaSchemas";
 import KeyValue from "@/components/values/KeyValue.vue";
@@ -212,6 +214,7 @@ import DashboardCard from "@/components/DashboardCard.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
+import Footer from "@/components/Footer.vue";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -225,6 +228,7 @@ export default defineComponent({
   name: 'ContractDetails',
 
   components: {
+    Footer,
     BlobValue,
     HbarAmount,
     TokenAmount,
@@ -243,6 +247,8 @@ export default defineComponent({
   },
 
   setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
     let contract = ref(null as ContractResponse | null)
     let account = ref(null as AccountBalanceTransactions | null)
     let balances = ref([] as Array<TokenSymbolBalance>)
@@ -322,6 +328,8 @@ export default defineComponent({
     })
 
     return {
+      isSmallScreen,
+      isTouchDevice,
       contract,
       account,
       balances,

--- a/src/pages/Contracts.vue
+++ b/src/pages/Contracts.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -39,6 +39,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -47,9 +49,10 @@
 
 <script lang="ts">
 
-import {defineComponent} from 'vue';
+import {defineComponent, inject} from 'vue';
 import ContractTable from "@/components/contract/ContractTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'Contracts',
@@ -59,10 +62,20 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     ContractTable
   },
-});
+
+  setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+    return {
+      isSmallScreen,
+      isTouchDevice
+    }
+  }
+  });
 
 </script>
 

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -26,7 +26,7 @@
 
   <HbarMarketDashboard/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <div class="columns">
 
@@ -92,6 +92,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -109,11 +111,13 @@ import CryptoTransactionTable from "@/components/dashboard/CryptoTransactionTabl
 import MessageTransactionTable from "@/components/dashboard/MessageTransactionTable.vue";
 import ContractCallTransactionTable from "@/components/dashboard/ContractCallTransactionTable.vue";
 import {TransactionType} from "@/schemas/HederaSchemas";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'MainDashboard',
 
   components: {
+    Footer,
     PlayPauseButton,
     DashboardCard,
     CryptoTransactionTable,
@@ -127,6 +131,8 @@ export default defineComponent({
   },
 
   setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
     const displaySideBySide = inject('isLargeScreen', true)
 
     const CryptoTransactionCacheState = ref<PlayPauseState>(PlayPauseState.Play)
@@ -138,6 +144,8 @@ export default defineComponent({
     })
 
     return {
+      isSmallScreen,
+      isTouchDevice,
       displaySideBySide,
       CryptoTransactionCacheState,
       MessageTransactionCacheState,

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -66,6 +66,9 @@
     </div>
 
   </section>
+
+  <Footer :keep-background="true"/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -74,19 +77,23 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, onBeforeUnmount, onMounted, ref, watch} from 'vue';
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
 import {HederaNetwork} from "@/components/TopNavBar.vue";
 import {useRoute} from "vue-router";
 import router from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/App.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'MobileMenu',
+  components: {Footer},
   props: {
     "searchedId": String,
     "network": String
   },
   setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
     const route = useRoute()
     const network = computed(() => { return route.params.network })
     const name = computed(() => { return route.query.from })
@@ -130,6 +137,8 @@ export default defineComponent({
     })
 
     return {
+      isSmallScreen,
+      isTouchDevice,
       selectedNetwork,
       HederaNetwork,
       isDashboardRoute,

--- a/src/pages/MobileSearch.vue
+++ b/src/pages/MobileSearch.vue
@@ -37,6 +37,8 @@
 
   </section>
 
+  <Footer :keep-background="true"/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -45,21 +47,24 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, onBeforeUnmount, onMounted, ref, watch} from 'vue';
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
 import {HederaNetwork} from "@/components/TopNavBar.vue";
 import {useRoute} from "vue-router";
 import router from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/App.vue";
 import SearchBar from "@/components/SearchBar.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'MobileSearch',
-  components: {SearchBar},
+  components: {Footer, SearchBar},
   props: {
     "searchedId": String,
     "network": String
   },
   setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
     const route = useRoute()
     const network = computed(() => {
       return route.params.network
@@ -107,6 +112,8 @@ export default defineComponent({
     })
 
     return {
+      isSmallScreen,
+      isTouchDevice,
       selectedNetwork,
       HederaNetwork,
       isDashboardRoute,

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -55,6 +55,9 @@
     </div>
 
   </section>
+
+  <Footer :keep-background="true"/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -64,9 +67,11 @@
 <script lang="ts">
 
 import {defineComponent} from 'vue';
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'SearchResult',
+  components: {Footer},
   props: {
     "searchedId": String,
     "errorCount": Number,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -152,6 +152,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -160,7 +162,7 @@
 
 <script lang="ts">
 
-import {defineComponent, onBeforeMount, ref, watch} from 'vue';
+import {defineComponent, inject, onBeforeMount, ref, watch} from 'vue';
 import router from "@/router";
 import axios from "axios";
 import KeyValue from "@/components/values/KeyValue.vue";
@@ -172,12 +174,14 @@ import {formatSeconds} from "@/utils/Duration";
 import DashboardCard from "@/components/DashboardCard.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TokenAmount from "@/components/values/TokenAmount.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
 
   name: 'TokenDetails',
 
   components: {
+    Footer,
     BlobValue,
     DashboardCard,
     TimestampValue,
@@ -193,8 +197,9 @@ export default defineComponent({
   },
 
   setup(props) {
-
-    let tokenInfo = ref<TokenInfo | null> (null)
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+    let tokenInfo = ref<TokenInfo | null>(null)
 
     onBeforeMount(() => {
       fetchTokenInfo();
@@ -217,6 +222,8 @@ export default defineComponent({
     }
 
     return {
+      isSmallScreen,
+      isTouchDevice,
       tokenInfo,
       showTokenDetails,
       formatSeconds,

--- a/src/pages/Tokens.vue
+++ b/src/pages/Tokens.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <div class="columns is-multiline">
 
@@ -60,6 +60,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -71,6 +73,7 @@
 import {defineComponent, inject} from 'vue';
 import TokenTable from "@/components/token/TokenTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'Tokens',
@@ -81,17 +84,22 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     TokenTable
   },
 
   setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
     const displaySideBySide = inject('isLargeScreen', true)
 
     const FUNGIBLE = "FUNGIBLE_COMMON"
     const NONFUNGIBLE = "NON_FUNGIBLE_UNIQUE"
 
     return {
+      isSmallScreen,
+      isTouchDevice,
       displaySideBySide,
       FUNGIBLE,
       NONFUNGIBLE

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -43,6 +43,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -51,10 +53,11 @@
 
 <script lang="ts">
 
-import {defineComponent, ref} from 'vue';
+import {defineComponent, inject, ref} from 'vue';
 import PlayPauseButton, {PlayPauseState} from "@/components/PlayPauseButton.vue";
 import TopicMessageTable from "@/components/topic/TopicMessageTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
 
@@ -69,14 +72,19 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     TopicMessageTable,
     PlayPauseButton
   },
 
   setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
     const cacheState = ref<PlayPauseState>(PlayPauseState.Play)
     return {
+      isSmallScreen,
+      isTouchDevice,
       cacheState
     }
   }

--- a/src/pages/Topics.vue
+++ b/src/pages/Topics.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -39,6 +39,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -47,9 +49,10 @@
 
 <script lang="ts">
 
-import {defineComponent} from 'vue';
+import {defineComponent, inject} from 'vue';
 import TopicTable from "@/components/topic/TopicTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'Topics',
@@ -59,9 +62,20 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     TopicTable
   },
+
+  setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+
+    return {
+      isSmallScreen,
+      isTouchDevice,
+    }
+  }
 });
 
 </script>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -180,6 +180,8 @@
 
   </section>
 
+  <Footer/>
+
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -203,12 +205,14 @@ import DashboardCard from "@/components/DashboardCard.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TransferGraphSection from "@/components/transfer_graphs/TransferGraphSection.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
 
   name: 'TransactionDetails',
 
   components: {
+    Footer,
     HbarAmount, BlobValue,
     DashboardCard, EntityLink, AccountLink,
     HexaValue, TimestampValue, TransferGraphSection,

--- a/src/pages/Transactions.vue
+++ b/src/pages/Transactions.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -46,8 +46,9 @@
       </template>
     </DashboardCard>
 
-
   </section>
+
+  <Footer/>
 
 </template>
 
@@ -57,7 +58,7 @@
 
 <script lang="ts">
 
-import {defineComponent, ref, watch} from 'vue';
+import {defineComponent, inject, ref, watch} from 'vue';
 
 import TransactionTable from "@/components/transaction/TransactionTable.vue";
 import PlayPauseButton, {PlayPauseState} from "@/components/PlayPauseButton.vue";
@@ -65,6 +66,7 @@ import TransactionTypeSelect, {TransactionOption} from "@/components/transaction
 import {useRoute, useRouter} from "vue-router";
 import {TransactionType} from "@/schemas/HederaSchemas";
 import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'Transactions',
@@ -74,6 +76,7 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     TransactionTypeSelect,
     PlayPauseButton,
@@ -81,6 +84,8 @@ export default defineComponent({
   },
 
   setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
 
     const router = useRouter()
     const route = useRoute()
@@ -105,7 +110,7 @@ export default defineComponent({
 
     const cacheState = ref<PlayPauseState>(PlayPauseState.Play)
 
-    return {selectedTransactionType, cacheState}
+    return {isSmallScreen, isTouchDevice, selectedTransactionType, cacheState}
   }
 });
 

--- a/src/pages/TransactionsById.vue
+++ b/src/pages/TransactionsById.vue
@@ -26,7 +26,7 @@
 
   <hr class="h-has-blue-background" style="margin: 0; height: 4px"/>
 
-  <section class="section">
+  <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
     <DashboardCard>
       <template v-slot:title>
@@ -46,8 +46,9 @@
       </template>
     </DashboardCard>
 
-
   </section>
+
+  <Footer/>
 
 </template>
 
@@ -57,11 +58,12 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, ref} from 'vue';
+import {computed, defineComponent, inject, ref} from 'vue';
 import PlayPauseButton, {PlayPauseState} from "@/components/PlayPauseButton.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
 import TransactionByIdTable from "@/components/transaction/TransactionByIdTable.vue";
 import {normalizeTransactionId} from "@/utils/TransactionID";
+import Footer from "@/components/Footer.vue";
 
 export default defineComponent({
   name: 'TransactionsById',
@@ -72,12 +74,15 @@ export default defineComponent({
   },
 
   components: {
+    Footer,
     DashboardCard,
     PlayPauseButton,
     TransactionByIdTable,
   },
 
   setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
 
     const cacheState = ref<PlayPauseState>(PlayPauseState.Play)
 
@@ -85,7 +90,7 @@ export default defineComponent({
       return props.transactionId ? normalizeTransactionId(props.transactionId, true) : "?";
     })
 
-    return {cacheState, normalizedTransactionId}
+    return {isSmallScreen, isTouchDevice, cacheState, normalizedTransactionId}
   }
 });
 


### PR DESCRIPTION
**Description**:

This PR:

- makes a Footer component and inserts it into each page (instead of into App)
- makes each page control the background color of its content and footer (instead of App)
- fixes the layout of the network selector on iPad
- slightly reduces the size of the sponsor logo

**Related issue(s)**:

Related to #35

**Notes for reviewer**:

Reducing the size of the (NoSearchResult, MobileMenu, MobileSearch) pages on the desktop should not change their background color, and the network selector should match.
Menu and Search on mobile/tablet should not display background color mismatch.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
