### PR TITLE
Fix for #00047 : token amounts are now displayed with the number of d…

### DIFF
--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -97,11 +97,13 @@ export default defineComponent({
   }
 });
 
-const amountFormatter = new Intl.NumberFormat('en-US')
-
 function formatTokenAmount(rawAmount: number, decimals: string|undefined): string {
   const decimalCount = computeDecimalCount(decimals) ?? 0
   const amount = rawAmount / Math.pow(10, decimalCount)
+  const amountFormatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimalCount,
+    maximumFractionDigits: decimalCount
+  })
   return amountFormatter.format(amount)
 }
 


### PR DESCRIPTION
…ecimals specified in TokenInfo.decimals.

Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Token amounts are currently displayed with a variable number of decimals and a maximum of three.
With the changes below, they will be displayed with a fixed number of decimals matching the value of TokenInfo.decimals field.

**Related issue(s)**:

Fixes #47

**Notes for reviewer**:

Issue can be observed here:
https://hashscan.io/#/mainnet/token/0.0.127877

For token 0.0.127877, decimal number is 8 as reported by:
https://mainnet-public.mirrornode.hedera.com/api/v1/tokens/0.0.127877

Various amounts on the page are displayed with 0, 1,  2 or 3 max decimals.
With the changes below, they will all have 8 decimals.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
