### PR TITLE
Add support for PREVIEWNET

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,8 +33,8 @@
 import {computed, defineComponent, onBeforeUnmount, onMounted, provide, ref} from 'vue';
 import TopNavBar from "@/components/TopNavBar.vue";
 
-export const XLARGE_BREAKPOINT = 1240
-export const LARGE_BREAKPOINT = 1120
+// export const XLARGE_BREAKPOINT = 1240
+export const LARGE_BREAKPOINT = 1160
 export const MEDIUM_BREAKPOINT = 1024
 export const SMALL_BREAKPOINT = 768
 // this will eventually be the window min width
@@ -69,10 +69,10 @@ export default defineComponent({
     })
     provide('isLargeScreen', isLargeScreen)
 
-    const isXLargeScreen = computed(() => {
-      return windowWidth.value >= XLARGE_BREAKPOINT
-    })
-    provide('isXLargeScreen', isXLargeScreen)
+    // const isXLargeScreen = computed(() => {
+    //   return windowWidth.value >= XLARGE_BREAKPOINT
+    // })
+    // provide('isXLargeScreen', isXLargeScreen)
 
     const sizeFallBack = computed(() => {
       return windowWidth.value < FINAL_BREAKPOINT

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -241,6 +241,7 @@ a.button.is-ghost.is-rimmed {
     text-decoration-thickness: 1px;
     text-underline-offset: 9px;
     font-weight: bold;
+    letter-spacing: normal;
 }
 a.button.is-outlined {
     padding-left: 0.6em;

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -61,16 +61,7 @@
     <div class="is-flex-grow-0 is-flex-shrink-0 is-flex is-flex-direction-column ml-4">
       <div class="is-flex mb-3 is-align-items-baseline">
 
-        <template v-if="useFlatMenu">
-          <a v-for="network in networkRegistry.getEntries()" :key="network.name"
-             :class="{ 'is-active': selectedNetwork !== network.name, 'is-highlighted': selectedNetwork === network.name }"
-             class="button is-outlined h-is-navbar-item mr-2"
-             @click="selectedNetwork = network.name">
-            {{ network.displayName }}
-          </a>
-        </template>
-
-        <div v-else id="drop-down-menu">
+        <div id="drop-down-menu">
           <o-field>
             <o-select v-model="selectedNetwork" class="h-is-navbar-item">
               <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">
@@ -139,8 +130,6 @@ export default defineComponent({
     const name = computed( () => { return route.name })
 
     const hideNavBar = inject('sizeFallBack', false)
-    // const useFlatMenu = inject('isXLargeScreen', true)
-    const useFlatMenu = false
     const showTopRightLogo = inject('isLargeScreen', true)
 
     const isMobileMenuOpen = ref(false)
@@ -195,7 +184,6 @@ export default defineComponent({
       isTouchDevice,
       name,
       hideNavBar,
-      useFlatMenu,
       showTopRightLogo,
       isMobileMenuOpen,
       networkRegistry,

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -58,49 +58,48 @@
       </a>
       <AxiosStatus/>
     </span>
-    <div class="is-flex-grow-0 is-flex-shrink-0 is-flex is-flex-direction-column mx-5">
+    <div class="is-flex-grow-0 is-flex-shrink-0 is-flex is-flex-direction-column ml-4">
       <div class="is-flex mb-3 is-align-items-baseline">
 
         <template v-if="useFlatMenu">
-          <a class="button is-outlined h-is-navbar-item"
-             :class="{ 'is-active': isTestnetSelected, 'is-highlighted': isMainnetSelected}"
-             @click="selectedNetwork = HederaNetwork.MAINNET">MAINNET</a>
-          <a class="button is-outlined h-is-navbar-item ml-2"
-             :class="{ 'is-active': isMainnetSelected, 'is-highlighted': isTestnetSelected}"
-             @click="selectedNetwork = HederaNetwork.TESTNET">TESTNET</a>
+          <a v-for="network in networkRegistry.getEntries()" :key="network.name"
+             :class="{ 'is-active': selectedNetwork !== network.name, 'is-highlighted': selectedNetwork === network.name }"
+             class="button is-outlined h-is-navbar-item mr-2"
+             @click="selectedNetwork = network.name">
+            {{ network.displayName }}
+          </a>
         </template>
 
         <div v-else id="drop-down-menu">
           <o-field>
-            <o-select
-                v-model="selectedNetwork"
-                class="h-is-navbar-item"
-            >
-              <option v-bind:key="HederaNetwork.MAINNET" v-bind:value="HederaNetwork.MAINNET">MAINNET</option>
-              <option v-bind:key="HederaNetwork.TESTNET" v-bind:value="HederaNetwork.TESTNET">TESTNET</option>
+            <o-select v-model="selectedNetwork" class="h-is-navbar-item">
+              <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">
+                {{ network.displayName }}
+              </option>
+
             </o-select>
           </o-field>
         </div>
 
         <div class="is-flex-grow-1 px-2"/>
         <a id="dashboard-menu-item"
-            class="button is-ghost is-first h-is-navbar-item"
-           :class="{'is-rimmed': isDashboardRoute, 'h-is-dense': !isDashboardRoute}"
+            class="button is-ghost is-first h-is-navbar-item h-is-dense"
+           :class="{'is-rimmed': isDashboardRoute}"
            @click="$router.push({name: 'MainDashboard'})">Dashboard</a>
-        <a class="button is-ghost h-is-navbar-item"
-           :class="{ 'is-rimmed': isTransactionRoute, 'h-is-dense': !isTransactionRoute }"
+        <a class="button is-ghost h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isTransactionRoute}"
            @click="$router.push({name: 'Transactions'})">Transactions</a>
-        <a class="button is-ghost h-is-navbar-item"
-           :class="{ 'is-rimmed': isTokenRoute, 'h-is-dense': !isTokenRoute }"
+        <a class="button is-ghost h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isTokenRoute}"
            @click="$router.push({name: 'Tokens'})">Tokens</a>
-        <a class="button is-ghost h-is-navbar-item"
-           :class="{ 'is-rimmed': isTopicRoute, 'h-is-dense': !isTopicRoute }"
+        <a class="button is-ghost h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isTopicRoute}"
            @click="$router.push({name: 'Topics'})">Topics</a>
-        <a class="button is-ghost h-is-navbar-item"
-           :class="{ 'is-rimmed': isContractRoute, 'h-is-dense': !isContractRoute }"
+        <a class="button is-ghost h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isContractRoute}"
            @click="$router.push({name: 'Contracts'})">Contracts</a>
-        <a class="button is-ghost is-last h-is-navbar-item"
-           :class="{ 'is-rimmed': isAccountRoute, 'h-is-dense': !isAccountRoute }"
+        <a class="button is-ghost is-last h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isAccountRoute}"
            @click="$router.push({name: 'Accounts'})">Accounts</a>
       </div>
       <SearchBar style="margin-top: 4px"/>
@@ -124,11 +123,7 @@ import {useRoute} from "vue-router";
 import router from "@/router";
 import SearchBar from "@/components/SearchBar.vue";
 import AxiosStatus from "@/components/AxiosStatus.vue";
-
-export enum HederaNetwork {
-  TESTNET = "testnet",
-  MAINNET = "mainnet"
-}
+import {networkRegistry} from "@/schemas/NetworkRegistry";
 
 export default defineComponent({
   name: "TopNavBar",
@@ -144,19 +139,14 @@ export default defineComponent({
     const name = computed( () => { return route.name })
 
     const hideNavBar = inject('sizeFallBack', false)
-    const useFlatMenu = inject('isXLargeScreen', true)
+    // const useFlatMenu = inject('isXLargeScreen', true)
+    const useFlatMenu = false
     const showTopRightLogo = inject('isLargeScreen', true)
 
     const isMobileMenuOpen = ref(false)
 
     watch(network, (value) => {
       updateSelectedNetworkSilently(value)
-    })
-    const isMainnetSelected = computed(() => {
-      return selectedNetwork.value == HederaNetwork.MAINNET
-    })
-    const isTestnetSelected = computed(() => {
-      return selectedNetwork.value == HederaNetwork.TESTNET
     })
 
     const selectedNetwork = ref(network.value)
@@ -166,7 +156,7 @@ export default defineComponent({
       if (selectedNetworkWatchHandle) {
         selectedNetworkWatchHandle()
       }
-      selectedNetwork.value = newValue
+      selectedNetwork.value = newValue as string
       selectedNetworkWatchHandle = watch(selectedNetwork, (selection) => {
         router.push({
           name: name.value as string,
@@ -208,8 +198,7 @@ export default defineComponent({
       useFlatMenu,
       showTopRightLogo,
       isMobileMenuOpen,
-      isMainnetSelected,
-      isTestnetSelected,
+      networkRegistry,
       selectedNetwork,
       isDashboardRoute,
       isTransactionRoute,
@@ -217,7 +206,6 @@ export default defineComponent({
       isTopicRoute,
       isContractRoute,
       isAccountRoute,
-      HederaNetwork
     }
   },
 })

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -37,29 +37,34 @@
                 v-model="selectedNetwork"
                 class="h-is-navbar-item"
             >
-              <option v-bind:key="HederaNetwork.MAINNET" v-bind:value="HederaNetwork.MAINNET">MAINNET</option>
-              <option v-bind:key="HederaNetwork.TESTNET" v-bind:value="HederaNetwork.TESTNET">TESTNET</option>
+              <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">
+                {{ network.displayName }}
+              </option>
+
+<!--              <option v-bind:key="HederaNetwork.MAINNET" v-bind:value="HederaNetwork.MAINNET">MAINNET</option>-->
+<!--              <option v-bind:key="HederaNetwork.TESTNET" v-bind:value="HederaNetwork.TESTNET">TESTNET</option>-->
+<!--              <option v-bind:key="HederaNetwork.PREVIEWNET" v-bind:value="HederaNetwork.PREVIEWNET">PREVIEWNET</option>-->
             </o-select>
           </o-field>
         </div>
         <a id="dashboard-menu-item"
-           :class="{'is-rimmed': isDashboardRoute, 'h-is-dense': !isDashboardRoute}"
-           class="button is-ghost h-is-mobile-navbar-item"
+           :class="{'is-rimmed': isDashboardRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'MainDashboard'})">Dashboard</a>
-        <a :class="{ 'is-rimmed': isTransactionRoute, 'h-is-dense': !isTransactionRoute }"
-           class="button is-ghost h-is-mobile-navbar-item"
+        <a :class="{ 'is-rimmed': isTransactionRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'Transactions'})">Transactions</a>
-        <a :class="{ 'is-rimmed': isTokenRoute, 'h-is-dense': !isTokenRoute }"
-           class="button is-ghost h-is-mobile-navbar-item"
+        <a :class="{ 'is-rimmed': isTokenRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'Tokens'})">Tokens</a>
-        <a :class="{ 'is-rimmed': isTopicRoute, 'h-is-dense': !isTopicRoute }"
-           class="button is-ghost h-is-mobile-navbar-item"
+        <a :class="{ 'is-rimmed': isTopicRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'Topics'})">Topics</a>
-        <a :class="{ 'is-rimmed': isContractRoute, 'h-is-dense': !isContractRoute }"
-           class="button is-ghost h-is-mobile-navbar-item"
+        <a :class="{ 'is-rimmed': isContractRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'Contracts'})">Contracts</a>
-        <a :class="{ 'is-rimmed': isAccountRoute, 'h-is-dense': !isAccountRoute }"
-           class="button is-ghost h-is-mobile-navbar-item"
+        <a :class="{ 'is-rimmed': isAccountRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'Accounts'})">Accounts</a>
       </div>
 
@@ -78,11 +83,11 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
-import {HederaNetwork} from "@/components/TopNavBar.vue";
 import {useRoute} from "vue-router";
 import router from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/App.vue";
 import Footer from "@/components/Footer.vue";
+import {networkRegistry} from "@/schemas/NetworkRegistry";
 
 export default defineComponent({
   name: 'MobileMenu',
@@ -140,13 +145,13 @@ export default defineComponent({
       isSmallScreen,
       isTouchDevice,
       selectedNetwork,
-      HederaNetwork,
       isDashboardRoute,
       isTransactionRoute,
       isTokenRoute,
       isTopicRoute,
       isContractRoute,
-      isAccountRoute
+      isAccountRoute,
+      networkRegistry
     }
   }
 })

--- a/src/pages/MobileSearch.vue
+++ b/src/pages/MobileSearch.vue
@@ -48,7 +48,6 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
-import {HederaNetwork} from "@/components/TopNavBar.vue";
 import {useRoute} from "vue-router";
 import router from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/App.vue";
@@ -115,7 +114,6 @@ export default defineComponent({
       isSmallScreen,
       isTouchDevice,
       selectedNetwork,
-      HederaNetwork,
       isDashboardRoute,
       isTransactionRoute,
       isTokenRoute,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,21 +32,16 @@ import Topics from "@/pages/Topics.vue";
 import TopicDetails from "@/pages/TopicDetails.vue";
 import NoSearchResult from "@/pages/NoSearchResult.vue";
 import AccountBalances from "@/pages/AccountBalances.vue";
-import axios from "axios";
 import {AxiosMonitor} from "@/utils/AxiosMonitor";
 import TransactionsById from "@/pages/TransactionsById.vue";
 import MobileMenu from "@/pages/MobileMenu.vue";
 import MobileSearch from "@/pages/MobileSearch.vue";
-
-const TESTNET_URL = "https://testnet.mirrornode.hedera.com/";
-const MAINNET_URL = "https://mainnet-public.mirrornode.hedera.com/";
-
-const LAST_USED_NETWORK_KEY = 'network'
+import {networkRegistry} from "@/schemas/NetworkRegistry";
 
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
-    redirect: '/' + (localStorage.getItem(LAST_USED_NETWORK_KEY) ?? 'testnet') + '/dashboard'
+    redirect: '/' + networkRegistry.getLastUsedNetwork() + '/dashboard'
   },
   {
     path: '/:network/dashboard',
@@ -164,14 +159,14 @@ const router = createRouter({
 })
 
 router.beforeEach((to, from) => {
-  const fromNetwork = localStorage.getItem(LAST_USED_NETWORK_KEY)
-  const toNetwork = to.params.network
+  const fromNetwork = networkRegistry.getLastUsedNetwork()
+  const toNetwork = to.params.network as string
 
   let result
 
-  if (toNetwork == 'testnet' || toNetwork == 'mainnet') {
-    localStorage.setItem(LAST_USED_NETWORK_KEY, toNetwork);
-    axios.defaults.baseURL = (toNetwork == 'testnet') ? TESTNET_URL : MAINNET_URL
+  if(networkRegistry.lookup(toNetwork)) {
+
+    networkRegistry.useNetwork(toNetwork)
 
     if (fromNetwork && (fromNetwork != toNetwork) && (from.name == to.name)) {
       result = {

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -35,11 +35,11 @@ export class NetworkEntry {
 
 export class NetworkRegistry {
 
-    public static LAST_USED_NETWORK_KEY = 'network'
-    public static DEFAULT_NETWORK = 'testnet'
-    private readonly defaultUrl
+    private static readonly LAST_USED_NETWORK_KEY = 'network'
+    private static readonly DEFAULT_NETWORK = 'testnet'
+    private readonly defaultEntry: NetworkEntry
 
-    private readonly entries = [
+    private readonly entries: NetworkEntry[] = [
         {
             name: 'mainnet',
             displayName: 'MAINNET',
@@ -58,7 +58,7 @@ export class NetworkRegistry {
     ]
 
     constructor() {
-        this.defaultUrl = this.lookup(NetworkRegistry.DEFAULT_NETWORK)?.url
+        this.defaultEntry = this.lookup(NetworkRegistry.DEFAULT_NETWORK) ?? this.entries[0]
     }
 
     public getEntries(): Array<NetworkEntry> {
@@ -66,20 +66,17 @@ export class NetworkRegistry {
     }
 
     public lookup(name: string): NetworkEntry | null {
-        return this.entries.find(element => element.name === name) as NetworkEntry | null
+        return this.entries.find(element => element.name === name) ?? null
     }
 
     public getLastUsedNetwork(): string {
-        return localStorage.getItem(NetworkRegistry.LAST_USED_NETWORK_KEY) ?? NetworkRegistry.DEFAULT_NETWORK
+        return localStorage.getItem(NetworkRegistry.LAST_USED_NETWORK_KEY) ?? this.defaultEntry.name
     }
 
     public useNetwork(network: string): void {
-        localStorage.setItem(NetworkRegistry.LAST_USED_NETWORK_KEY, network);
-        axios.defaults.baseURL = this.lookup(network)?.url ?? this.defaultUrl
-    }
-
-    private addEntry(name: string, displayName: string, url: string): void {
-        this.entries.push(new NetworkEntry(name, displayName, url))
+        const newEntry = this.lookup(network) ?? this.defaultEntry
+        localStorage.setItem(NetworkRegistry.LAST_USED_NETWORK_KEY, newEntry.name);
+        axios.defaults.baseURL = newEntry.url
     }
 }
 

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -1,0 +1,86 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import axios from "axios";
+
+export class NetworkEntry {
+
+    public readonly name: string
+    public readonly displayName: string
+    public readonly url: string
+
+    constructor(name: string, displayName: string, url: string) {
+        this.name = name
+        this.displayName = displayName
+        this.url = url
+    }
+}
+
+export class NetworkRegistry {
+
+    public static LAST_USED_NETWORK_KEY = 'network'
+    public static DEFAULT_NETWORK = 'testnet'
+    private readonly defaultUrl
+
+    private readonly entries = [
+        {
+            name: 'mainnet',
+            displayName: 'MAINNET',
+            url: "https://mainnet-public.mirrornode.hedera.com/"
+        },
+        {
+            name: 'testnet',
+            displayName: 'TESTNET',
+            url: "https://testnet.mirrornode.hedera.com/"
+        },
+        {
+            name: 'previewnet',
+            displayName: 'PREVIEWNET',
+            url: "https://previewnet.mirrornode.hedera.com/"
+        }
+    ]
+
+    constructor() {
+        this.defaultUrl = this.lookup(NetworkRegistry.DEFAULT_NETWORK)?.url
+    }
+
+    public getEntries(): Array<NetworkEntry> {
+        return this.entries
+    }
+
+    public lookup(name: string): NetworkEntry | null {
+        return this.entries.find(element => element.name === name) as NetworkEntry | null
+    }
+
+    public getLastUsedNetwork(): string {
+        return localStorage.getItem(NetworkRegistry.LAST_USED_NETWORK_KEY) ?? NetworkRegistry.DEFAULT_NETWORK
+    }
+
+    public useNetwork(network: string): void {
+        localStorage.setItem(NetworkRegistry.LAST_USED_NETWORK_KEY, network);
+        axios.defaults.baseURL = this.lookup(network)?.url ?? this.defaultUrl
+    }
+
+    private addEntry(name: string, displayName: string, url: string): void {
+        this.entries.push(new NetworkEntry(name, displayName, url))
+    }
+}
+
+export const networkRegistry = new NetworkRegistry()

--- a/tests/e2e/specs/TopNavigationBar.spec.ts
+++ b/tests/e2e/specs/TopNavigationBar.spec.ts
@@ -32,12 +32,29 @@ describe('Top Navigation Bar', () => {
     cy.contains('Smart Contract Calls')
     cy.contains('HCS Messages')
 
-    cy.contains('MAINNET').click()
+    cy.get('select')
+        .select('MAINNET')
+        .should('have.value', 'mainnet')
+
+    cy.url().should('include', '/mainnet/dashboard')
     cy.contains('Crypto Transfers')
     cy.contains('Smart Contract Calls')
     cy.contains('HCS Messages')
 
-    cy.contains('TEST').click()
+    cy.get('select')
+        .select('TESTNET')
+        .should('have.value', 'testnet')
+
+    cy.url().should('include', '/testnet/dashboard')
+    cy.contains('Crypto Transfers')
+    cy.contains('Smart Contract Calls')
+    cy.contains('HCS Messages')
+
+    cy.get('select')
+        .select('PREVIEWNET')
+        .should('have.value', 'previewnet')
+
+    cy.url().should('include', '/previewnet/dashboard')
     cy.contains('Crypto Transfers')
     cy.contains('Smart Contract Calls')
     cy.contains('HCS Messages')

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -87,7 +87,7 @@ describe("App.vue", () => {
 
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
-        expect(navBar.text()).toBe("MAINNETTESTNETDashboardTransactionsTokensTopicsContractsAccounts")
+        expect(navBar.text()).toBe("MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
 
         expect(wrapper.findComponent(HbarMarketDashboard).exists()).toBe(true)
 

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -50,7 +50,7 @@ HMSF.forceUTC = true
 
 describe("TopNavBar.vue", () => {
 
-    it("Should display the regular (side-by-side) Network selection menu", async () => {
+    it("Should display logos, page links and search bar", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
         Object.defineProperty(window, 'innerWidth', {writable: true, configurable: true, value: 1920})
@@ -65,16 +65,16 @@ describe("TopNavBar.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
+        expect(wrapper.text()).toBe("MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
+
         const links = wrapper.findAll("a")
-        expect(links.length).toBe(10)
-        expect(links[1].text()).toBe("MAINNET")
-        expect(links[2].text()).toBe("TESTNET")
-        expect(links[3].text()).toBe("Dashboard")
-        expect(links[4].text()).toBe("Transactions")
-        expect(links[5].text()).toBe("Tokens")
-        expect(links[6].text()).toBe("Topics")
-        expect(links[7].text()).toBe("Contracts")
-        expect(links[8].text()).toBe("Accounts")
+        expect(links.length).toBe(8)
+        expect(links[1].text()).toBe("Dashboard")
+        expect(links[2].text()).toBe("Transactions")
+        expect(links[3].text()).toBe("Tokens")
+        expect(links[4].text()).toBe("Topics")
+        expect(links[5].text()).toBe("Contracts")
+        expect(links[6].text()).toBe("Accounts")
 
         expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
 
@@ -105,16 +105,11 @@ describe("TopNavBar.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        const links = wrapper.findAll("a")
-        expect(links.length).toBe(8)
-        expect(links[1].text()).toBe("Dashboard")
-        expect(links[2].text()).toBe("Transactions")
-        expect(links[3].text()).toBe("Tokens")
-        expect(links[4].text()).toBe("Topics")
-        expect(links[5].text()).toBe("Contracts")
-        expect(links[6].text()).toBe("Accounts")
-
-        expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
+        const options = wrapper.findAll("option")
+        expect(options.length).toBe(3)
+        expect(options[0].text()).toBe("MAINNET")
+        expect(options[1].text()).toBe("TESTNET")
+        expect(options[2].text()).toBe("PREVIEWNET")
 
         wrapper.unmount()
     });


### PR DESCRIPTION
**Description**:

This PR adds the support for PREVIEWNET network. It also:
- Changes the network selector to always use the dropdown version (this is yet to be vetted).
  (note the code for the original 'flat' version of the selector is still there).
- Moves network-related logic to NetworkRegistry.ts

**Related issue(s)**:

Fixes #11

**Notes for reviewer**:

This is still a draft PR, not ready for merge.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
