### PR TITLE
Fix for #49 : token details now displays Max Supply: Infinite when re…

### DIFF
--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -99,12 +99,6 @@
               </div>
             </div>
             <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Supply Type</div>
-              <div class="column" id="supplyType">
-                {{ tokenInfo?.supply_type }}
-              </div>
-            </div>
-            <div class="columns">
               <div class="column is-one-third has-text-weight-light">Total Supply</div>
               <div class="column" id="totalSupply">
                 <TokenAmount v-bind:amount="parseIntString(tokenInfo?.total_supply)"
@@ -123,9 +117,14 @@
             <div class="columns">
               <div class="column is-one-third has-text-weight-light">Max Supply</div>
               <div class="column" id="maxSupply">
-                <TokenAmount v-bind:amount="parseIntString(tokenInfo?.max_supply)"
-                             v-bind:token-id="tokenId"
-                             v-bind:show-extra="false"/>
+                <template v-if="tokenInfo?.supply_type == 'INFINITE'">
+                  <div class="has-text-grey">Infinite</div>
+                </template>
+                <template v-else>
+                  <TokenAmount v-bind:amount="parseIntString(tokenInfo?.max_supply)"
+                               v-bind:token-id="tokenId"
+                               v-bind:show-extra="false"/>
+                </template>
               </div>
             </div>
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -88,10 +88,9 @@ describe("TokenDetails.vue", () => {
 
         expect(wrapper.get("#createdAt").text()).toBe("10:02:30.2333 AMFeb 12, 2022")
         expect(wrapper.get("#modifiedAt").text()).toBe("10:02:30.2333 AMFeb 12, 2022")
-        expect(wrapper.get("#supplyType").text()).toBe("INFINITE")
         expect(wrapper.get("#totalSupply").text()).toBe("1")
         expect(wrapper.get("#initialSupply").text()).toBe("1")
-        expect(wrapper.get("#maxSupply").text()).toBe("0")
+        expect(wrapper.get("#maxSupply").text()).toBe("Infinite")
 
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)
@@ -134,7 +133,6 @@ describe("TokenDetails.vue", () => {
 
         expect(wrapper.get("#createdAt").text()).toBe("3:29:27.7128 PMMar 6, 2022")
         expect(wrapper.get("#modifiedAt").text()).toBe("8:56:33.5203 PMMar 6, 2022")
-        expect(wrapper.get("#supplyType").text()).toBe("FINITE")
         expect(wrapper.get("#totalSupply").text()).toBe("2")
         expect(wrapper.get("#initialSupply").text()).toBe("0")
         expect(wrapper.get("#maxSupply").text()).toBe("150")


### PR DESCRIPTION
…quired and hides Supply Type field.

Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

When the changes below, Token Details page:
- displays Max Supply: Infinite when TokenInfo.supply_type == "INFINITE"
- hides (now superfluous) Supply Type field

**Related issue(s)**:

Fixes #49 

**Notes for reviewer**:
You can check the changes using the following tokens:
- 0.0.786931    // FINITE
- 0.0.127877    // INFINITE

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
