### PR TITLE
00052 display ethereum address

### DIFF
--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -127,12 +127,12 @@
                 </template>
               </div>
             </div>
-            <div class="columns" id="ethereumAddress">
+            <div class="columns">
               <div class="column is-one-third has-text-weight-light">Ethereum Address</div>
-              <div class="column" v-if="ethereumAddress">
-                <HexaValue v-bind:byte-string="ethereumAddress"/>
+              <div class="column"  id="ethereumAddress">
+                <HexaValue v-if="ethereumAddress" v-bind:byte-string="ethereumAddress"/>
+                <div v-else class="has-text-grey">None</div>
               </div>
-              <div v-else class="column has-text-grey">None</div>
             </div>
 
           </div>

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -127,6 +127,13 @@
                 </template>
               </div>
             </div>
+            <div class="columns" id="ethereumAddress">
+              <div class="column is-one-third has-text-weight-light">Ethereum Address</div>
+              <div class="column" v-if="ethereumAddress">
+                <HexaValue v-bind:byte-string="ethereumAddress"/>
+              </div>
+              <div v-else class="column has-text-grey">None</div>
+            </div>
 
           </div>
 
@@ -161,7 +168,7 @@
 
 <script lang="ts">
 
-import {defineComponent, inject, onBeforeMount, ref, watch} from 'vue';
+import {computed, defineComponent, inject, onBeforeMount, ref, watch} from 'vue';
 import router from "@/router";
 import axios from "axios";
 import KeyValue from "@/components/values/KeyValue.vue";
@@ -174,12 +181,15 @@ import DashboardCard from "@/components/DashboardCard.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import Footer from "@/components/Footer.vue";
+import HexaValue from "@/components/values/HexaValue.vue";
+import {EntityID} from "@/utils/EntityID";
 
 export default defineComponent({
 
   name: 'TokenDetails',
 
   components: {
+    HexaValue,
     Footer,
     BlobValue,
     DashboardCard,
@@ -220,13 +230,25 @@ export default defineComponent({
       router.push({name: 'TokenDetails', params: {tokenId: tokenId}})
     }
 
+    const ethereumAddress = computed(() => {
+      let result: string|undefined
+      if (props.tokenId) {
+        const entityID = EntityID.parse(props.tokenId)
+        result = entityID?.toAddress()
+      } else {
+        result = undefined
+      }
+      return result
+    })
+
     return {
       isSmallScreen,
       isTouchDevice,
       tokenInfo,
       showTokenDetails,
       formatSeconds,
-      parseIntString
+      parseIntString,
+      ethereumAddress
     }
   },
 });

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -18,6 +18,8 @@
  *
  */
 
+import {byteToHex} from "@/utils/B64Utils";
+
 export class EntityID {
 
     public readonly shard: number
@@ -62,6 +64,17 @@ export class EntityID {
 
     public toString(): string {
         return this.shard + "." + this.realm + "." + this.num
+    }
+
+    public toAddress(): string {
+        const buffer = new Uint8Array(20);
+        const view = new DataView(buffer.buffer, 0, 20);
+
+        view.setInt32(0, this.shard);
+        view.setBigInt64(4, BigInt(this.realm));
+        view.setBigInt64(12, BigInt(this.num));
+
+        return "0x" + byteToHex(buffer)
     }
 
     /*

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -74,7 +74,7 @@ export class EntityID {
         view.setBigInt64(4, BigInt(this.realm));
         view.setBigInt64(12, BigInt(this.num));
 
-        return "0x" + byteToHex(buffer)
+        return byteToHex(buffer)
     }
 
     /*

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {byteToHex} from "@/utils/B64Utils";
+import {byteToHex} from "./B64Utils";
 
 export class EntityID {
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -91,6 +91,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#totalSupply").text()).toBe("1")
         expect(wrapper.get("#initialSupply").text()).toBe("1")
         expect(wrapper.get("#maxSupply").text()).toBe("Infinite")
+        expect(wrapper.get("#ethereumAddress").text()).toBe("0000 0000 0000 0000 0000 00000000 0000 01c4 9eecCopy to Clipboard")
 
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)


### PR DESCRIPTION
**Description**:

With the changes below, Explorer now displays new field named Ethereum Address in token details page.

**Related issue(s)**:

Fixes #52

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
