### PR TITLE
Add support for local network

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+### When set, these variables will cause the insertion of a custom menu item
+### in the network selector pull-down menu of the TopNavBar
+
+# VUE_APP_LOCAL_MIRROR_NODE_NAME=<network menu item for mirror node>
+# VUE_APP_LOCAL_MIRROR_NODE_URL=<URL of mirror node>

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ npm run test:e2e
 # Or run the tests in headless browser mode
 npm run test:e2e:headless
 ```
+### Run the Explorer with a local mirror node
+The Explorer can be used with a local mirror by means of a .env file located at the root 
+of the repository and containing the definition of the following variables to add a custom menu
+item in the network selector pull-down menu:
+
+- VUE_APP_LOCAL_MIRROR_NODE_URL=\<URL of the local mirror node\>
+- VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME=\<label of the custom menu item\>
+
+The latter may be omitted and will default to 'LOCALNET'
 
 ### Run the Explorer locally in Docker
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     image: "hedera-explorer:latest"
     restart: "unless-stopped"
     ports:
-      - 9090:80
+      - "9090:80"

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -59,6 +59,14 @@ export class NetworkRegistry {
 
     constructor() {
         this.defaultEntry = this.lookup(NetworkRegistry.DEFAULT_NETWORK) ?? this.entries[0]
+
+        if (process.env.VUE_APP_LOCAL_MIRROR_NODE_URL) {
+            this.entries.push(new NetworkEntry(
+                'localnet',
+                process.env.VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME ?? "LOCALNET",
+                process.env.VUE_APP_LOCAL_MIRROR_NODE_URL
+            ))
+        }
     }
 
     public getEntries(): Array<NetworkEntry> {


### PR DESCRIPTION
**Description**:

This PR modifies the NetworkRegistry such that a custom NetworkEntry is added when 2 environment variables are set in the .env file located at the root of the repository. These variables define the url and displayName of the additional NetworkEntry. This will result in a custom menu item added to the network selector pull-down menu.

**Related issue(s)**:

Fixes #10

**Notes for reviewer**:

Note the variables in the .env file are taken into account by Webpack at build time, and available to the code in all
environments:
 - in development (ex: 'npm run serve'
 - in a production build (ex: 'npm build && npm serve')
 - or in a Docker container (ex: 'docker-compose up -d')
 
This PR can be squashed.

**Checklist**

- [x] Documented (added mention in README)
- [x] Tested (unit, e2e)
