### PR TITLE
Added grace period notif

### DIFF
--- a/src/components/NotificationBanner.vue
+++ b/src/components/NotificationBanner.vue
@@ -1,0 +1,61 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <div class="hero is-small is-danger mb-5 has-text-centered">
+    <div class="hero-body h-is-tertiary-text">
+      <span>{{ message }}</span>
+    </div>
+  </div>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent} from "vue";
+
+export default defineComponent({
+  name: "NotificationBanner",
+
+  props: {
+    message: {
+      type: String,
+      required: true
+    }
+  },
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style>
+</style>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -39,6 +39,9 @@
         </span>
       </template>
       <template v-slot:table>
+
+        <NotificationBanner v-if="notification" :message="notification"/>
+
         <div class="columns h-is-property-text">
 
           <div class="column">
@@ -215,6 +218,7 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import Footer from "@/components/Footer.vue";
+import NotificationBanner from "@/components/NotificationBanner.vue";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -228,6 +232,7 @@ export default defineComponent({
   name: 'ContractDetails',
 
   components: {
+    NotificationBanner,
     Footer,
     BlobValue,
     HbarAmount,
@@ -254,6 +259,21 @@ export default defineComponent({
     let balances = ref([] as Array<TokenSymbolBalance>)
     let displayAllTokenLinks = ref(false)
     const cacheState = ref<PlayPauseState>(PlayPauseState.Play)
+
+    const notification = computed(() => {
+      let result
+      if (contract.value?.deleted === true) {
+        result = "Contract is deleted"
+      } else {
+        const expiration = contract.value?.expiration_timestamp
+        if (expiration && Number.parseFloat(expiration) <= new Date().getTime() / 1000) {
+          result = "Contract has expired and is in grace period"
+        } else {
+          result = null
+        }
+      }
+      return result
+    })
 
     onBeforeMount(() => {
       fetchContract()
@@ -335,6 +355,7 @@ export default defineComponent({
       balances,
       displayAllTokenLinks,
       cacheState,
+      notification,
       obtainerId,
       proxyAccountId,
       formattedSolidity,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -40,11 +40,7 @@
      </template>
       <template v-slot:table>
 
-        <div v-if="transaction && transaction?.result !== TRANSACTION_SUCCESS" class="hero is-small is-danger mb-5 has-text-centered">
-          <div class="hero-body h-is-tertiary-text">
-            <span>Transaction has failed: {{ transaction?.result }}</span>
-          </div>
-        </div>
+        <NotificationBanner v-if="notify" :message="notification"/>
 
         <div class="columns h-is-property-text">
 
@@ -206,12 +202,14 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TransferGraphSection from "@/components/transfer_graphs/TransferGraphSection.vue";
 import Footer from "@/components/Footer.vue";
+import NotificationBanner from "@/components/NotificationBanner.vue";
 
 export default defineComponent({
 
   name: 'TransactionDetails',
 
   components: {
+    NotificationBanner,
     Footer,
     HbarAmount, BlobValue,
     DashboardCard, EntityLink, AccountLink,
@@ -232,7 +230,10 @@ export default defineComponent({
     const response = ref<AxiosResponse<TransactionByIdResponse>|null>(null)
     const transaction = ref<Transaction|null>(null)
     let netAmount = ref(0)
-    let entity = ref<EntityDescriptor|null>(null)
+    let entity = ref<EntityDescriptor | null>(null)
+
+    const notify = computed(() => transaction.value && transaction.value.result !== TRANSACTION_SUCCESS)
+    const notification = computed(() => "Transaction has failed: " + transaction.value?.result)
 
     onBeforeMount(() => {
       fetchTransaction()
@@ -290,6 +291,8 @@ export default defineComponent({
       transaction,
       netAmount,
       entity,
+      notify,
+      notification,
       routeName,
       TRANSACTION_SUCCESS,
       convertTransactionId,

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -319,9 +319,51 @@ export const SAMPLE_TRANSACTION = {
     "valid_start_timestamp": "1646025139.152901498",
 }
 
+export const SAMPLE_FAILED_TRANSACTION = {
+    "bytes": null,
+    "charged_tx_fee": 120694790,
+    "consensus_timestamp": "1652256326.071602560",
+    "entity_id": "0.0.34739492",
+    "max_fee": "1000000000",
+    "memo_base64": "",
+    "name": "CONTRACTCALL",
+    "node": "0.0.3",
+    "nonce": 0,
+    "parent_consensus_timestamp": null,
+    "result": "CONTRACT_REVERT_EXECUTED",
+    "scheduled": false,
+    "transaction_hash": "kLnhFcr1zLlhcuH4Doz6VF20IB4dEaxomChYqSie0+xkDNwaWrd2UFWl0ZxWYStj",
+    "transaction_id": "0.0.34376678-1652256313-310050890",
+    "transfers": [
+        {
+            "account": "0.0.3",
+            "amount": 1719386,
+            "is_approval": false
+        },
+        {
+            "account": "0.0.98",
+            "amount": 118975404,
+            "is_approval": false
+        },
+        {
+            "account": "0.0.34376678",
+            "amount": -120694790,
+            "is_approval": false
+        }
+    ],
+    "valid_duration_seconds": "120",
+    "valid_start_timestamp": "1652256313.310050890"
+}
+
 export const SAMPLE_TRANSACTIONS = {
     "transactions": [
         SAMPLE_TRANSACTION
+    ]
+}
+
+export const SAMPLE_FAILED_TRANSACTIONS = {
+    "transactions": [
+        SAMPLE_FAILED_TRANSACTION
     ]
 }
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -747,7 +747,23 @@ export const SAMPLE_CONTRACT_DUDE = {
     "created_timestamp": "1648377044.798291252",
     "deleted": false,
     "evm_address": "0x00000000000000000000000000000000000c41df",
-    "expiration_timestamp": null,
+    "expiration_timestamp": "1649648001.410978000",
+    "file_id": "0.0.803267",
+    "memo": "",
+    "obtainer_id": null,
+    "proxy_account_id": null,
+    "timestamp": {"from": "1648377044.798291252", "to": null},
+    "bytecode": "0x30783630383036303430353236303030" // deliberately kept only the first 16 bytes of the bytecode
+}
+
+export const SAMPLE_CONTRACT_DELETED = {
+    "admin_key": null,
+    "auto_renew_period": 7776000,
+    "contract_id": "0.0.803295",
+    "created_timestamp": "1648377044.798291252",
+    "deleted": true,
+    "evm_address": "0x00000000000000000000000000000000000c41df",
+    "expiration_timestamp": "1649648001.410978000",
     "file_id": "0.0.803267",
     "memo": "",
     "obtainer_id": null,


### PR DESCRIPTION
**Description**:

This PR:

- extracts the notification banner from the TransactionDetails template to make a very simple NotificationBanner component which is destined to be used potentially by every details page.
- uses NotificationBanner in ContractDetails to notify the user:
   - when the contract is in grace period (expiration_timestamp ≤ now and deleted == false )
   - when the contract is deleted

There is no notion of grace period duration yet (we could notify the user of the grace time remaining) because the design for that has not been finalized in the infrastructure.

**Related issue(s)**:

Fixes #26

**Notes for reviewer**:

There is currently no "live" contract in grace period to exercise this. It has been unit tested only.
This can be squashed.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
