### PR TITLE
Modify layout of property key-values on mobile.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -55,7 +55,7 @@ export default defineComponent({
     const windowWidth = ref(window.screen.width)
 
     const isSmallScreen = computed(() => {
-      return windowWidth.value >= SMALL_BREAKPOINT
+      return windowWidth.value > SMALL_BREAKPOINT
     })
     provide('isSmallScreen', isSmallScreen)
 

--- a/src/components/Property.vue
+++ b/src/components/Property.vue
@@ -1,0 +1,85 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <div v-if="!isSmallScreen" class="columns" :id="id">
+    <div class="column is-flex is-justify-content-space-between">
+      <div class="has-text-weight-light" :id="nameId">
+        <slot name="name"/>
+      </div>
+      <div :id="valueId" class="ml-4">
+        <slot name="value"/>
+      </div>
+    </div>
+  </div>
+
+  <div v-else class="columns" :id="id">
+    <div class="column is-one-third has-text-weight-light" :id="nameId">
+      <slot name="name"/>
+    </div>
+    <div class="column" :id="valueId">
+      <slot name="value"/>
+    </div>
+  </div>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, inject} from "vue";
+
+export default defineComponent({
+  name: "Property",
+  props: {
+    id: String,
+  },
+  setup(props){
+    const nameId = props.id + 'Name'
+    const valueId = props.id + 'Value'
+
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+
+    return {
+      nameId,
+      valueId,
+      isSmallScreen,
+      isTouchDevice
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style>
+</style>

--- a/src/components/Property.vue
+++ b/src/components/Property.vue
@@ -29,7 +29,7 @@
       <div class="has-text-weight-light" :id="nameId">
         <slot name="name"/>
       </div>
-      <div :id="valueId" class="ml-4">
+      <div :id="valueId" class="ml-4 has-text-right">
         <slot name="value"/>
       </div>
     </div>

--- a/src/components/values/HexaValue.vue
+++ b/src/components/values/HexaValue.vue
@@ -23,16 +23,9 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div v-if="byteString" style="display: inline-block; position: relative" class="shy-scope">
-    <template v-if="!isSmallScreen" >
-      <div v-for="l in split()" :key="l">
-        <div class="is-family-monospace has-text-grey">{{ l }}</div>
-      </div>
-    </template>
-    <template v-else>
-      <div class="is-family-monospace has-text-grey">{{ flow() }}</div>
-    </template>
-    <div  v-if="isCopyEnabled" id="shyCopyButton" class="shy" style="position: absolute; left: 0; top: 0; width: 100%; height: 100%">
+  <div v-if="byteString" class="shy-scope" style="display: inline-block; position: relative">
+    <div class="is-family-monospace has-text-grey">{{ flow() }}</div>
+    <div v-if="isCopyEnabled" id="shyCopyButton" class="shy" style="position: absolute; left: 0; top: 0; width: 100%; height: 100%">
       <div style="position: absolute; left: 0; top: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.50)"></div>
       <div style="position: absolute; display: inline-block; left: 50%; top: 50%; transform: translate(-50%, -50%);">
         <button class="button is-dark h-is-text-size-3" v-on:click="copyToClipboard">Copy to Clipboard</button>

--- a/src/components/values/HexaValue.vue
+++ b/src/components/values/HexaValue.vue
@@ -24,9 +24,14 @@
 
 <template>
   <div v-if="byteString" style="display: inline-block; position: relative" class="shy-scope">
-    <div v-for="l in split()" :key="l">
-      <div class="is-family-monospace has-text-grey">{{ l }}</div>
-    </div>
+    <template v-if="!isSmallScreen" >
+      <div v-for="l in split()" :key="l">
+        <div class="is-family-monospace has-text-grey">{{ l }}</div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="is-family-monospace has-text-grey">{{ flow() }}</div>
+    </template>
     <div  v-if="isCopyEnabled" id="shyCopyButton" class="shy" style="position: absolute; left: 0; top: 0; width: 100%; height: 100%">
       <div style="position: absolute; left: 0; top: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.50)"></div>
       <div style="position: absolute; display: inline-block; left: 50%; top: 50%; transform: translate(-50%, -50%);">
@@ -44,9 +49,9 @@
 
 <script lang="ts">
 
-import {computed, defineComponent} from "vue";
+import {computed, defineComponent, inject} from "vue";
 
-const BYTES_PER_LINE = 12
+const BYTES_PER_LINE = 10
 
 export default defineComponent({
   name: "HexaValue",
@@ -59,8 +64,9 @@ export default defineComponent({
   },
 
   setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
 
-    // 1)
+    // 1.a)
     const split = (): string[] => {
       const result = Array<string>()
       if (props.byteString) {
@@ -71,6 +77,11 @@ export default defineComponent({
         }
       }
       return result
+    }
+
+    // 1.b)
+    const flow = (): string => {
+      return props.byteString ? makeByteLine(props.byteString) : ""
     }
 
     // 2)
@@ -86,6 +97,8 @@ export default defineComponent({
     })
 
     return {
+      isSmallScreen,
+      flow,
       split,
       copyToClipboard,
       isCopyEnabled

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -25,10 +25,9 @@
 <template>
   <span class="is-numeric">{{ formattedAmount }}</span>
   <template v-if="showExtra && tokenId != null">
-    <router-link :to="{name: 'TokenDetails', params: {tokenId: tokenId}}">
-      <span class="ml-2 h-is-smaller h-is-extra-text should-wrap">{{ extra }}</span>
-      <span v-if="errorFlag" class="icon h-is-smaller"><i class="fas fa-exclamation-triangle"/></span>
-    </router-link>
+    <span class="ml-2">
+      <TokenExtra v-bind:token-id="tokenId" v-bind:use-anchor="useAnchor"/>
+    </span>
   </template>
 </template>
 
@@ -42,10 +41,12 @@ import {computed, defineComponent, ref} from "vue";
 import {AxiosResponse} from "axios";
 import {TokenInfo} from "@/schemas/HederaSchemas";
 import {TokenInfoCollector} from "@/utils/TokenInfoCollector";
+import TokenExtra from "@/components/values/TokenExtra.vue";
 
 export default defineComponent({
   name: "TokenAmount",
 
+  components: {TokenExtra},
   props: {
     amount: {
       type: Number,
@@ -55,6 +56,10 @@ export default defineComponent({
     showExtra: {
       type: Boolean,
       default: false
+    },
+    useAnchor: {
+      type: Boolean,
+      default: true
     }
   },
 

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -48,7 +48,6 @@
               <template v-slot:name>{{ tokenBalances?.length ? 'Balances' : 'Balance' }}</template>
               <template v-slot:value>
                 <div class="h-is-tertiary-text"><HbarAmount v-bind:amount="balance" v-bind:show-extra="true"/></div>
-                <div v-if="elapsed && !isSmallScreen" class="has-text-grey has-text-right"> {{ elapsed }} ago</div>
                 <div v-if="displayAllTokenLinks">
                   <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
                     See all token balances
@@ -59,6 +58,7 @@
                     <TokenAmount v-bind:amount="b.balance" v-bind:token-id="b.token_id" v-bind:show-extra="true"/>
                   </div>
                 </div>
+                <div v-if="elapsed && !isSmallScreen" class="has-text-grey has-text-right"> {{ elapsed }} ago</div>
               </template>
             </Property>
           </div>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -39,43 +39,31 @@
         </span>
         <p class="h-is-tertiary-text" v-if="accountInfo != null"> {{ accountInfo }} </p>
       </template>
+
       <template v-slot:table>
 
         <div class="columns h-is-property-text">
           <div class="column">
-
-            <div class="columns">
-              <div v-if="tokenBalances?.length" class="column is-one-third has-text-weight-light">
-                Balances
-              </div>
-              <div v-else class="column is-one-third has-text-weight-light">
-                Balance
-              </div>
-              <div class="column" id="balance">
-                <div class="has-flex-direction-column h-is-tertiary-text">
-                  <HbarAmount v-bind:amount="balance" v-bind:show-extra="true"/>
-
-                  <div v-if="displayAllTokenLinks">
-                    <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
-                      See all token balances
-                    </router-link>
-                  </div>
-
-                  <div v-else>
-                    <div v-for="b in tokenBalances ?? []" :key="b.token_id">
-                      <TokenAmount v-bind:amount="b.balance" v-bind:token-id="b.token_id" v-bind:show-extra="true"/>
-                    </div>
-                  </div>
-
+            <Property :id="'balance'">
+              <template v-slot:name>{{ tokenBalances?.length ? 'Balances' : 'Balance' }}</template>
+              <template v-slot:value>
+                <div class="h-is-tertiary-text"><HbarAmount v-bind:amount="balance" v-bind:show-extra="true"/></div>
+                <div v-if="elapsed && !isSmallScreen" class="has-text-grey has-text-right"> {{ elapsed }} ago</div>
+                <div v-if="displayAllTokenLinks">
+                  <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
+                    See all token balances
+                  </router-link>
                 </div>
-              </div>
-            </div>
-
+                <div v-else>
+                  <div v-for="b in tokenBalances ?? []" :key="b.token_id" class="h-is-tertiary-text">
+                    <TokenAmount v-bind:amount="b.balance" v-bind:token-id="b.token_id" v-bind:show-extra="true"/>
+                  </div>
+                </div>
+              </template>
+            </Property>
           </div>
-          <div v-if="!isTouchDevice && isSmallScreen" class="column">
-            <div class="has-text-right  has-text-grey">
-              <span v-if="elapsed">Balance from {{ elapsed }} ago</span>
-            </div>
+          <div v-if="isSmallScreen && elapsed" class="column has-text-right  has-text-grey mt-1">
+              {{ elapsed }} ago
           </div>
         </div>
         <br/>
@@ -83,64 +71,45 @@
         <div class="columns h-is-property-text">
 
           <div class="column">
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Key
-              </div>
-              <div v-if="account?.key != null" class="column" id="key">
-                <KeyValue v-bind:key-bytes="account?.key?.key" v-bind:key-type="account?.key?._type"/>
-              </div>
-              <div v-else class="column has-text-grey">
-                None
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Memo
-              </div>
-              <div class="column should-wrap" id="memo">
-                <BlobValue v-bind:blob-value="account?.memo" v-bind:show-none="true" v-bind:base64="true"/>
-              </div>
-            </div>
-
+            <Property :id="'key'">
+              <template v-slot:name>Key</template>
+              <template v-slot:value>
+                <KeyValue :key-bytes="account?.key?.key" :key-type="account?.key?._type" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'memo'">
+              <template v-slot:name>Memo</template>
+              <template v-slot:value>
+                <BlobValue v-bind:blob-value="account?.memo" v-bind:show-none="true" v-bind:base64="true" class="should-wrap"/>
+              </template>
+            </Property>
+            <Property :id="'expiresAt'">
+              <template v-slot:name>Expires at</template>
+              <template v-slot:value>
+                <TimestampValue v-bind:timestamp="account?.expiry_timestamp" v-bind:show-none="true" />
+              </template>
+            </Property>
           </div>
 
-          <div class="column has-text-left">
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Expires at
-              </div>
-              <div class="column" id="expiresAt">
-                <TimestampValue v-bind:timestamp="account?.expiry_timestamp" v-bind:show-none="true" />
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Auto Renew Period
-              </div>
-              <div class="column" id="autoRenewPeriod">
+          <div class="column">
+            <Property :id="'autoRenewPeriod'">
+              <template v-slot:name>Auto Renew Period</template>
+              <template v-slot:value>
                 {{ formatSeconds(account?.auto_renew_period) }}
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Max. Auto. Association
-              </div>
-              <div class="column" id="maxAutoAssociation">
+              </template>
+            </Property>
+            <Property :id="'maxAutoAssociation'">
+              <template v-slot:name>Max. Auto. Association</template>
+              <template v-slot:value>
                 {{ account?.max_automatic_token_associations ?? "" }}
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Receiver Sig. Required
-              </div>
-              <div class="column" id="receiverSigRequired">
+              </template>
+            </Property>
+            <Property :id="'receiverSigRequired'">
+              <template v-slot:name>Receiver Sig. Required</template>
+              <template v-slot:value>
                 {{ account?.receiver_sig_required ?? ""}}
-              </div>
-            </div>
-
+              </template>
+            </Property>
           </div>
 
         </div>
@@ -194,6 +163,7 @@ import Footer from "@/components/Footer.vue";
 import TransactionTypeSelect, {TransactionOption} from "@/components/transaction/TransactionTypeSelect.vue";
 import {useRoute, useRouter} from "vue-router";
 import {EntityID} from "@/utils/EntityID";
+import Property from "@/components/Property.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -202,6 +172,7 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
+    Property,
     TransactionTypeSelect,
     Footer,
     BlobValue,

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -45,134 +45,96 @@
         <div class="columns h-is-property-text">
 
           <div class="column">
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Balance
-              </div>
-              <div class="column" id="balance">
+            <Property :id="'balance'">
+              <template v-slot:name>{{ tokens?.length ? 'Balances' : 'Balance' }}</template>
+              <template v-slot:value>
                 <div class="has-flex-direction-column">
                   <HbarAmount :amount="balance" :show-extra="true"/>
-
                   <div v-if="displayAllTokenLinks">
                     <router-link :to="{name: 'AccountBalances', params: {accountId: contractId}}">
                       See all token balances
                     </router-link>
                   </div>
-
                   <div v-else>
                     <div v-for="t in tokens" :key="t.token_id">
                       <TokenAmount :amount="t.balance" :token-id="t.token_id" :show-extra="true"/>
                     </div>
                   </div>
-
                 </div>
-              </div>
-            </div>
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Key
-              </div>
-              <div class="column" id="key">
-                <KeyValue
-                    v-bind:key-bytes="contract?.admin_key?.key"
-                    v-bind:key-type="contract?.admin_key?._type"
-                    v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Memo
-              </div>
-              <div class="column should-wrap" id="memo">
-                <BlobValue v-bind:blob-value="contract?.memo" v-bind:show-none="true" v-bind:base64="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Expires at
-              </div>
-              <div class="column" id="expiresAt">
+              </template>
+            </Property>
+            <Property :id="'key'">
+              <template v-slot:name>Key</template>
+              <template v-slot:value>
+                <KeyValue :key-bytes="contract?.admin_key?.key" :key-type="contract?.admin_key?._type" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'memo'">
+              <template v-slot:name>Memo</template>
+              <template v-slot:value>
+                <BlobValue :blob-value="contract?.memo" :show-none="true" :base64="true" class="should-wrap"/>
+              </template>
+            </Property>
+            <Property :id="'expiresAt'">
+              <template v-slot:name>Expires at</template>
+              <template v-slot:value>
                 <TimestampValue v-bind:timestamp="contract?.expiration_timestamp" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Auto Renew Period
-              </div>
-              <div class="column" id="autoRenewPeriod">
+              </template>
+            </Property>
+            <Property :id="'autoRenewPeriod'">
+              <template v-slot:name>Auto Renew Period</template>
+              <template v-slot:value>
                 {{ formatSeconds(contract?.auto_renew_period) }}
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Code
-              </div>
-              <div  id="code">
-                <div v-if="contract?.bytecode != null" class="column">
-                <textarea v-model="contract.bytecode" readonly rows="4"
+              </template>
+            </Property>
+            <Property :id="'code'">
+              <template v-slot:name>Code</template>
+              <template v-slot:value>
+                <textarea v-if="contract?.bytecode" v-model="contract.bytecode" readonly rows="4"
                           style="width:100%; font-family: novamonoregular,monospace"></textarea>
-                </div>
-                <div v-else class="column has-text-grey">
-                  None
-                </div>
-              </div>
-            </div>
-
+                <div v-else class="column has-text-grey">None</div>
+              </template>
+            </Property>
           </div>
 
           <div class="column">
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Obtainer
-              </div>
-              <div class="column" id="obtainer">
-                <AccountLink v-bind:account-id="obtainerId" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Proxy Account
-              </div>
-              <div class="column" id="proxyAccount">
-                <AccountLink v-bind:account-id="proxyAccountId" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Valid from
-              </div>
-              <div class="column" id="validFrom">
-                <TimestampValue v-bind:timestamp="contract?.timestamp?.from" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Valid until
-              </div>
-              <div class="column" id="validUntil">
-                <TimestampValue v-bind:timestamp="contract?.timestamp?.to" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                File
-              </div>
-              <div class="column" id="file">
-                {{ contract?.file_id ?? "None" }}
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">
-                Solidity
-              </div>
-              <div class="column" id="solidity">
-                <HexaValue v-bind:byteString="formattedSolidity" v-bind:show-none="true"/>
-              </div>
-            </div>
-
+            <Property :id="'obtainer'">
+              <template v-slot:name>Obtainer</template>
+              <template v-slot:value>
+                <AccountLink :account-id="obtainerId" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'proxyAccount'">
+              <template v-slot:name>Proxy Account</template>
+              <template v-slot:value>
+                <AccountLink :account-id="proxyAccountId" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'validFrom'">
+              <template v-slot:name>Valid from</template>
+              <template v-slot:value>
+                <TimestampValue :timestamp="contract?.timestamp?.from" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'validUntil'">
+              <template v-slot:name>Valid until</template>
+              <template v-slot:value>
+                <TimestampValue :timestamp="contract?.timestamp?.to" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'file'">
+              <template v-slot:name>File</template>
+              <template v-slot:value>
+                <div v-if="contract?.file_id">{{ contract?.file_id }}</div>
+                <div v-else class="has-text-grey">None</div>
+              </template>
+            </Property>
+            <Property :id="'solidity'">
+              <template v-slot:name>Solidity</template>
+              <template v-slot:value>
+                <HexaValue :byteString="formattedSolidity" :show-none="true"/>
+              </template>
+            </Property>
           </div>
 
         </div>
@@ -220,6 +182,7 @@ import BlobValue from "@/components/values/BlobValue.vue";
 import Footer from "@/components/Footer.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import {EntityID} from "@/utils/EntityID";
+import Property from "@/components/Property.vue";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -228,6 +191,7 @@ export default defineComponent({
   name: 'ContractDetails',
 
   components: {
+    Property,
     NotificationBanner,
     Footer,
     BlobValue,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -30,11 +30,10 @@
 
     <DashboardCard>
       <template v-slot:title>
-        <span class="h-is-primary-title">Token </span>
-        <span class="h-is-secondary-text mr-2">{{ normalizedTokenId }}</span>
-        <span v-if="tokenInfo?.type === 'NON_FUNGIBLE_UNIQUE'"
-              class="h-is-tertiary-text has-text-grey">Non Fungible</span>
+        <span v-if="tokenInfo?.type === 'NON_FUNGIBLE_UNIQUE'" class="h-is-tertiary-text has-text-grey">Non Fungible</span>
         <span v-else class="h-is-tertiary-text has-text-grey">Fungible</span>
+        <span class="h-is-primary-title"> Token </span>
+        <span class="h-is-secondary-text mr-2">{{ normalizedTokenId }}</span>
       </template>
       <template v-slot:table>
         <div class="columns h-is-property-text">

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -40,101 +40,82 @@
         <div class="columns h-is-property-text">
 
           <div class="column">
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Name</div>
-              <div class="column should-wrap" id="name">
-                <BlobValue v-bind:blob-value="tokenInfo?.name" v-bind:show-none="true"/>
-              </div>
-            </div>
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Symbol</div>
-              <div class="column should-wrap" id="symbol">
-                <BlobValue v-bind:blob-value="tokenInfo?.symbol" v-bind:show-none="true"/>
-              </div>
-            </div>
-
-            <div class="columns" id="adminKey">
-              <div class="column is-one-third has-text-weight-light">Admin Key</div>
-              <div v-if="tokenInfo?.admin_key != null" class="column">
-                <KeyValue
-                    v-bind:key-bytes="tokenInfo?.admin_key?.key"
-                    v-bind:key-type="tokenInfo?.admin_key?._type"
-                />
-              </div>
-              <div v-else class="column has-text-grey">None</div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Memo</div>
-              <div class="column should-wrap" id="memo">
-                <BlobValue v-bind:blob-value="tokenInfo?.memo" v-bind:show-none="true" v-bind:base64="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Expires at</div>
-              <div class="column" id="expiresAt">
-                <TimestampValue v-bind:timestamp="tokenInfo?.expiry_timestamp" v-bind:nano="true" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Auto Renew Period</div>
-              <div class="column" id="autoRenewPeriod">{{ formatSeconds(tokenInfo?.auto_renew_period) }}</div>
-            </div>
-
+            <Property :id="'name'">
+              <template v-slot:name>Name</template>
+              <template v-slot:value>
+                <BlobValue v-bind:blob-value="tokenInfo?.name" v-bind:show-none="true" class="should-wrap"/>
+              </template>
+            </Property>
+            <Property :id="'symbol'">
+              <template v-slot:name>Symbol</template>
+              <template v-slot:value>
+                <BlobValue v-bind:blob-value="tokenInfo?.symbol" v-bind:show-none="true" class="should-wrap"/>
+              </template>
+            </Property>
+            <Property :id="'adminKey'">
+              <template v-slot:name>Admin Key</template>
+              <template v-slot:value>
+                <KeyValue :key-bytes="tokenInfo?.admin_key?.key" :key-type="tokenInfo?.admin_key?._type" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'memo'">
+              <template v-slot:name>Memo</template>
+              <template v-slot:value>
+                <BlobValue :blob-value="tokenInfo?.memo" :show-none="true" :base64="true" class="should-wrap"/>
+              </template>
+            </Property>
+            <Property :id="'expiresAt'">
+              <template v-slot:name>Expires at</template>
+              <template v-slot:value>
+                <TimestampValue :timestamp="tokenInfo?.expiry_timestamp" :nano="true" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'autoRenewPeriod'">
+              <template v-slot:name>Auto Renew Period</template>
+              <template v-slot:value>
+                {{ formatSeconds(tokenInfo?.auto_renew_period) }}
+              </template>
+            </Property>
           </div>
 
-          <div class="column has-text-left">
-
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Created at</div>
-              <div class="column" id="createdAt">
-                <TimestampValue v-bind:timestamp="tokenInfo?.created_timestamp" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Modified at</div>
-              <div class="column" id="modifiedAt">
-                <TimestampValue v-bind:timestamp="tokenInfo?.modified_timestamp" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Total Supply</div>
-              <div class="column" id="totalSupply">
-                <TokenAmount v-bind:amount="parseIntString(tokenInfo?.total_supply)"
-                             v-bind:token-id="tokenId"
-                             v-bind:show-extra="false"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Initial Supply</div>
-              <div class="column" id="initialSupply">
-                <TokenAmount v-bind:amount="parseIntString(tokenInfo?.initial_supply)"
-                             v-bind:token-id="tokenId"
-                             v-bind:show-extra="false"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Max Supply</div>
-              <div class="column" id="maxSupply">
-                <template v-if="tokenInfo?.supply_type == 'INFINITE'">
-                  <div class="has-text-grey">Infinite</div>
-                </template>
-                <template v-else>
-                  <TokenAmount v-bind:amount="parseIntString(tokenInfo?.max_supply)"
-                               v-bind:token-id="tokenId"
-                               v-bind:show-extra="false"/>
-                </template>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third has-text-weight-light">Ethereum Compat. Address</div>
-              <div class="column"  id="ethereumAddress">
-                <HexaValue v-if="ethereumAddress" v-bind:byte-string="ethereumAddress"/>
-                <div v-else class="has-text-grey">None</div>
-              </div>
-            </div>
-
+          <div class="column">
+            <Property :id="'createdAt'">
+              <template v-slot:name>Created at</template>
+              <template v-slot:value>
+                <TimestampValue :timestamp="tokenInfo?.created_timestamp" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'modifiedAt'">
+              <template v-slot:name>Modified at</template>
+              <template v-slot:value>
+                <TimestampValue :timestamp="tokenInfo?.modified_timestamp" :show-none="true"/>
+              </template>
+            </Property>
+            <Property :id="'totalSupply'">
+              <template v-slot:name>Total Supply</template>
+              <template v-slot:value>
+                <TokenAmount :amount="parseIntString(tokenInfo?.total_supply)" :token-id="tokenId" :show-extra="false"/>
+              </template>
+            </Property>
+            <Property :id="'initialSupply'">
+              <template v-slot:name>Initial Supply</template>
+              <template v-slot:value>
+                <TokenAmount :amount="parseIntString(tokenInfo?.initial_supply)" :token-id="tokenId" :show-extra="false"/>
+              </template>
+            </Property>
+            <Property :id="'maxSupply'">
+              <template v-slot:name>Max Supply</template>
+              <template v-slot:value>
+                <div v-if="tokenInfo?.supply_type === 'INFINITE'" class="has-text-grey">Infinite</div>
+                <TokenAmount v-else :amount="parseIntString(tokenInfo?.max_supply)" :show-extra="false" :token-id="tokenId"/>
+              </template>
+            </Property>
+            <Property :id="'ethereumAddress'">
+              <template v-slot:name>Ethereum Compat. Address</template>
+              <template v-slot:value>
+                <HexaValue v-if="ethereumAddress" :byte-string="ethereumAddress" :show-none="true"/>
+              </template>
+            </Property>
           </div>
 
         </div>
@@ -183,12 +164,14 @@ import TokenAmount from "@/components/values/TokenAmount.vue";
 import Footer from "@/components/Footer.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import {EntityID} from "@/utils/EntityID";
+import Property from "@/components/Property.vue";
 
 export default defineComponent({
 
   name: 'TokenDetails',
 
   components: {
+    Property,
     HexaValue,
     Footer,
     BlobValue,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -38,6 +38,7 @@
           </router-link>
         </span>
      </template>
+
       <template v-slot:table>
 
         <NotificationBanner v-if="notify" :message="notification"/>
@@ -45,71 +46,48 @@
         <div class="columns h-is-property-text">
 
           <div class="column">
-
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Type
-              </div>
-              <div class="column" id="transactionType">
+            <Property :id="'transactionType'">
+              <template v-slot:name>Type</template>
+              <template v-slot:value>
                 {{ transaction ? makeTypeLabel(transaction.name) : "" }}
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Consensus at
-              </div>
-              <div class="column" id="consensusAt">
+              </template>
+            </Property>
+            <Property :id="'consensusAt'">
+              <template v-slot:name>Consensus at</template>
+              <template v-slot:value>
                 <TimestampValue v-bind:timestamp="transaction?.consensus_timestamp" v-bind:show-none="true" />
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Transaction Hash
-              </div>
-              <div class="column" id="transactionHash">
+              </template>
+            </Property>
+            <Property :id="'transactionHash'">
+              <template v-slot:name>Transaction Hash</template>
+              <template v-slot:value>
                 <HexaValue v-bind:byteString="transaction ? formatHash(transaction?.transaction_hash): undefined" v-bind:show-none="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Net Amount
-              </div>
-              <div class="column" id="netAmount">
-                <template v-if="transaction">
-                  <HbarAmount v-bind:amount="computeNetAmount(transaction)" v-bind:show-extra="true"/>
-                </template>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Charged Fee
-              </div>
-              <div class="column" id="chargedFee">
-                <template v-if="transaction">
-                  <HbarAmount v-bind:amount="transaction.charged_tx_fee" v-bind:show-extra="true"/>
-                </template>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Max fee
-              </div>
-              <div class="column" id="maxFee">
-                <template v-if="transaction">
-                  <HbarAmount v-bind:amount="computeMaxFee(transaction)" v-bind:show-extra="true"/>
-                </template>
-              </div>
-            </div>
-
+              </template>
+            </Property>
+            <Property :id="'netAmount'">
+              <template v-slot:name>Net Amount</template>
+              <template v-slot:value>
+                <HbarAmount v-if="transaction" v-bind:amount="computeNetAmount(transaction)" v-bind:show-extra="true"/>
+              </template>
+            </Property>
+            <Property :id="'chargedFee'">
+              <template v-slot:name>Charged Fee</template>
+              <template v-slot:value>
+                <HbarAmount v-if="transaction" v-bind:amount="transaction.charged_tx_fee" v-bind:show-extra="true"/>
+              </template>
+            </Property>
+            <Property :id="'maxFee'">
+              <template v-slot:name>Max fee</template>
+              <template v-slot:value>
+                <HbarAmount v-if="transaction" v-bind:amount="computeMaxFee(transaction)" v-bind:show-extra="true"/>
+              </template>
+            </Property>
           </div>
 
           <div class="column">
-
-            <div v-if="transaction?.entity_id" id="entityKV" class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                {{ entity?.label }}
-              </div>
-              <div id="entityId" class="column">
+            <Property v-if="transaction?.entity_id" :id="'entityId'">
+              <template v-slot:name>{{ entity?.label }}</template>
+              <template v-slot:value>
                 <template v-if="entity?.routeName">
                   <EntityLink
                       v-bind:entity-id="transaction?.entity_id"
@@ -120,49 +98,38 @@
                 <template v-else>
                   {{ transaction?.entity_id }}
                 </template>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Memo
-              </div>
-              <div class="column should-wrap" id="memo">
-                <BlobValue v-bind:blob-value="transaction?.memo_base64" v-bind:show-none="true" v-bind:base64="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Operator Account
-              </div>
-              <div v-if="transaction" class="column" id="operatorAccount">
-                <AccountLink v-bind:accountId="makeOperatorAccountLabel(transaction)" v-bind:show-extra="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Node Account
-              </div>
-              <div v-if="transaction" class="column" id="nodeAccount">
-                <AccountLink v-bind:accountId="transaction?.node" v-bind:show-extra="true"/>
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Duration
-              </div>
-              <div class="column" id="duration">
+              </template>
+            </Property>
+            <Property :id="'memo'">
+              <template v-slot:name>Memo</template>
+              <template v-slot:value>
+                <BlobValue :blob-value="transaction?.memo_base64" :show-none="true" :base64="true" class="should-wrap"/>
+              </template>
+            </Property>
+            <Property :id="'operatorAccount'">
+              <template v-slot:name>Operator Account</template>
+              <template v-slot:value>
+                <AccountLink v-if="transaction" v-bind:accountId="makeOperatorAccountLabel(transaction)" v-bind:show-extra="true"/>
+              </template>
+            </Property>
+            <Property :id="'nodeAccount'">
+              <template v-slot:name>Node Account</template>
+              <template v-slot:value>
+                <AccountLink v-if="transaction" v-bind:accountId="transaction?.node" v-bind:show-extra="true"/>
+              </template>
+            </Property>
+            <Property :id="'duration'">
+              <template v-slot:name>Duration</template>
+              <template v-slot:value>
                 {{ transaction ? transaction.valid_duration_seconds : "" }} seconds
-              </div>
-            </div>
-            <div class="columns">
-              <div class="column is-one-third  has-text-weight-light">
-                Scheduled
-              </div>
-              <div class="column" id="scheduled">
+              </template>
+            </Property>
+            <Property :id="'scheduled'">
+              <template v-slot:name>Scheduled</template>
+              <template v-slot:value>
                 {{ transaction ? transaction.scheduled : "" }}
-              </div>
-            </div>
-
+              </template>
+            </Property>
           </div>
 
         </div>
@@ -203,12 +170,14 @@ import BlobValue from "@/components/values/BlobValue.vue";
 import TransferGraphSection from "@/components/transfer_graphs/TransferGraphSection.vue";
 import Footer from "@/components/Footer.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
+import Property from "@/components/Property.vue";
 
 export default defineComponent({
 
   name: 'TransactionDetails',
 
   components: {
+    Property,
     NotificationBanner,
     Footer,
     HbarAmount, BlobValue,

--- a/tests/e2e/specs/CopyHexaToClipboard.spec.ts
+++ b/tests/e2e/specs/CopyHexaToClipboard.spec.ts
@@ -58,7 +58,7 @@ describe('Copy HexaValue to Clipboard', () => {
             .invoke('readText').should('not.be.empty')
             .then(($txt) => {
                 // cy.log($txt)
-                cy.get('#transactionHash').should(($hash) => {
+                cy.get('#transactionHashValue').should(($hash) => {
                     expect($txt.substr(0, $txt.length)).equal(
                         $hash.text()
                             .replace(/\s/g, "")

--- a/tests/e2e/specs/DashboardNavigation.spec.ts
+++ b/tests/e2e/specs/DashboardNavigation.spec.ts
@@ -31,21 +31,21 @@ describe('Main Dashboard Navigation', () => {
         cy.get('[data-cy=cryptoTransfers]').find('table').contains('td', '@').click()
         cy.url().should('include', '/testnet/transaction/')
         cy.contains('Transaction ')
-        cy.get('#transactionType').should('have.text', 'CRYPTO TRANSFER')
+        cy.get('#transactionTypeValue').should('have.text', 'CRYPTO TRANSFER')
     })
 
     it('should navigate to Smart Contract Call transaction details', () => {
         cy.get('[data-cy=smartContractCalls]').find('table').contains('td', '@').click()
         cy.url().should('include', '/testnet/transaction/')
         cy.contains('Transaction ')
-        cy.get('#transactionType').should('have.text', 'CONTRACT CALL')
+        cy.get('#transactionTypeValue').should('have.text', 'CONTRACT CALL')
     })
 
     it('should navigate to HCS Message transaction details', () => {
         cy.get('[data-cy=hcsMessages]').find('table').contains('td', '0.0.').click()
         cy.url().should('include', '/testnet/transaction/')
         cy.contains('Transaction ')
-        cy.get('#transactionType').should('have.text', 'HCS SUBMIT MESSAGE')
+        cy.get('#transactionTypeValue').should('have.text', 'HCS SUBMIT MESSAGE')
     })
 
 })

--- a/tests/e2e/specs/TokenNavigation.spec.ts
+++ b/tests/e2e/specs/TokenNavigation.spec.ts
@@ -39,7 +39,7 @@ describe('Token Navigation', () => {
             .then(($id) => {
                 // cy.log('Selected transaction Id: ' + $id.text())
                 cy.url().should('include', '/testnet/token/' + $id.text())
-                cy.contains('Token ' + $id.text() + 'Non Fungible')
+                cy.contains('Non Fungible Token ' + $id.text())
             })
 
         cy.go('back')
@@ -57,7 +57,7 @@ describe('Token Navigation', () => {
             .then(($id) => {
                 // cy.log('Selected transaction Id: ' + $id.text())
                 cy.url().should('include', '/testnet/token/' + $id.text())
-                cy.contains('Token ' + $id.text() + 'Fungible')
+                cy.contains('Fungible Token ' + $id.text())
             })
     })
 
@@ -65,7 +65,7 @@ describe('Token Navigation', () => {
     it('should follow links from NFT details', () => {
         cy.visit('#/testnet/token/' + nftId)
         cy.url().should('include', '/testnet/token/' + nftId)
-        cy.contains('Token ' + nftId + 'Non Fungible')
+        cy.contains('Non Fungible Token ' + nftId)
 
         cy.get('table')
             .find('tbody tr')
@@ -86,7 +86,7 @@ describe('Token Navigation', () => {
     it('should follow links from token details', () => {
         cy.visit('#/testnet/token/' + tokenId)
         cy.url().should('include', '/testnet/token/' + tokenId)
-        cy.contains('Token ' + tokenId + 'Fungible')
+        cy.contains('Fungible Token ' + tokenId)
 
         cy.get('table')
             .find('tbody tr')

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -101,7 +101,7 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Account " + SAMPLE_ACCOUNT.account))
         expect(wrapper.get("#balance").text()).toBe("23.42647909$5.7637998234231ĦFRENSKINGDOM")
         expect(wrapper.get("#key").text()).toBe(
-            "aa2f 7b3e 759f 4531 ec2e 7941afa4 49e6 a6e6 10ef b52a dae89e9c d8e9 d40d dcbf" +
+            "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
             "Copy to Clipboard" +
             "ED25519")
         expect(wrapper.get("#memo").text()).toBe("None")
@@ -155,7 +155,7 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Account " + SAMPLE_ACCOUNT.account))
         expect(wrapper.get("#key").text()).toBe(
-            "aa2f 7b3e 759f 4531 ec2e 7941afa4 49e6 a6e6 10ef b52a dae89e9c d8e9 d40d dcbf" +
+            "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
             "Copy to Clipboard" +
             "ED25519")
 
@@ -176,7 +176,7 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Account " + SAMPLE_ACCOUNT_DUDE.account))
         expect(wrapper.get("#key").text()).toBe(
-            "38f1 ea46 0e95 d97e ea13 aefac760 eaf9 9015 4b80 a360 8ab01d4a 2649 44d6 8746" +
+            "38f1 ea46 0e95 d97e ea13 aefa c760 eaf9 9015 4b80 a360 8ab0 1d4a 2649 44d6 8746" +
             "Copy to Clipboard" +
             "ED25519")
         expect(wrapper.get("#memo").text()).toBe("Account Dude Memo in clear")

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -99,16 +99,16 @@ describe("AccountDetails.vue", () => {
         // console.log(wrapper.html())
 
         expect(wrapper.text()).toMatch(RegExp("^Account " + SAMPLE_ACCOUNT.account))
-        expect(wrapper.get("#balance").text()).toBe("23.42647909$5.7637998234231ĦFRENSKINGDOM")
-        expect(wrapper.get("#key").text()).toBe(
+        expect(wrapper.get("#balanceValue").text()).toBe("23.42647909$5.7637998234231ĦFRENSKINGDOM")
+        expect(wrapper.get("#keyValue").text()).toBe(
             "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
             "Copy to Clipboard" +
             "ED25519")
-        expect(wrapper.get("#memo").text()).toBe("None")
-        expect(wrapper.get("#expiresAt").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriod").text()).toBe("90 days")
-        expect(wrapper.get("#maxAutoAssociation").text()).toBe("0")
-        expect(wrapper.get("#receiverSigRequired").text()).toBe("false")
+        expect(wrapper.get("#memoValue").text()).toBe("None")
+        expect(wrapper.get("#expiresAtValue").text()).toBe("None")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
+        expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("false")
 
         expect(wrapper.find("#recentTransactions").exists()).toBe(true)
         expect(wrapper.findComponent(TransactionTable).exists()).toBe(true)
@@ -154,7 +154,7 @@ describe("AccountDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Account " + SAMPLE_ACCOUNT.account))
-        expect(wrapper.get("#key").text()).toBe(
+        expect(wrapper.get("#keyValue").text()).toBe(
             "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
             "Copy to Clipboard" +
             "ED25519")
@@ -175,15 +175,15 @@ describe("AccountDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Account " + SAMPLE_ACCOUNT_DUDE.account))
-        expect(wrapper.get("#key").text()).toBe(
+        expect(wrapper.get("#keyValue").text()).toBe(
             "38f1 ea46 0e95 d97e ea13 aefa c760 eaf9 9015 4b80 a360 8ab0 1d4a 2649 44d6 8746" +
             "Copy to Clipboard" +
             "ED25519")
-        expect(wrapper.get("#memo").text()).toBe("Account Dude Memo in clear")
-        expect(wrapper.get("#expiresAt").text()).toBe("3:33:21.4109 AMApr 11, 2022")
-        expect(wrapper.get("#autoRenewPeriod").text()).toBe("77 days 3 hours 40 minutes")
-        expect(wrapper.get("#maxAutoAssociation").text()).toBe("10")
-        expect(wrapper.get("#receiverSigRequired").text()).toBe("true")
+        expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
+        expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77 days 3 hours 40 minutes")
+        expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
+        expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
     });
 
 });

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -81,17 +81,17 @@ describe("ContractDetails.vue", () => {
         // console.log(wrapper.html())
 
         expect(wrapper.text()).toMatch(RegExp("^Contract " + SAMPLE_CONTRACT.contract_id))
-        expect(wrapper.get("#balance").text()).toBe("2.00000000$0.4921")
-        expect(wrapper.get("#key").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
-        expect(wrapper.get("#memo").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
-        expect(wrapper.get("#expiresAt").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriod").text()).toBe("90 days")
-        expect(wrapper.get("#obtainer").text()).toBe("None")
-        expect(wrapper.get("#proxyAccount").text()).toBe("None")
-        expect(wrapper.get("#validFrom").text()).toBe("3:09:15.9474 PMMar 7, 2022")
-        expect(wrapper.get("#validUntil").text()).toBe("None")
-        expect(wrapper.get("#file").text()).toBe("0.0.749773")
-        expect(wrapper.get("#solidity").text()).toBe("None")
+        expect(wrapper.get("#balanceValue").text()).toBe("2.00000000$0.4921")
+        expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
+        expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
+        expect(wrapper.get("#expiresAtValue").text()).toBe("None")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#obtainerValue").text()).toBe("None")
+        expect(wrapper.get("#proxyAccountValue").text()).toBe("None")
+        expect(wrapper.get("#validFromValue").text()).toBe("3:09:15.9474 PMMar 7, 2022")
+        expect(wrapper.get("#validUntilValue").text()).toBe("None")
+        expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
+        expect(wrapper.get("#solidityValue").text()).toBe("None")
 
     });
 
@@ -127,9 +127,9 @@ describe("ContractDetails.vue", () => {
 
         expect(wrapper.findComponent(NotificationBanner).exists()).toBe(false)
 
-        expect(wrapper.get("#key").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
-        expect(wrapper.get("#memo").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
-        expect(wrapper.get("#file").text()).toBe("0.0.749773")
+        expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
+        expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
+        expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
 
         const contract2 = SAMPLE_CONTRACT_DUDE
         matcher1 = "/api/v1/contracts/" + contract2.contract_id
@@ -145,9 +145,9 @@ describe("ContractDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Contract " + SAMPLE_CONTRACT_DUDE.contract_id))
-        expect(wrapper.get("#key").text()).toBe("None")
-        expect(wrapper.get("#memo").text()).toBe("None")
-        expect(wrapper.get("#file").text()).toBe("0.0.803267")
+        expect(wrapper.get("#keyValue").text()).toBe("None")
+        expect(wrapper.get("#memoValue").text()).toBe("None")
+        expect(wrapper.get("#fileValue").text()).toBe("0.0.803267")
 
     });
 

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -82,7 +82,7 @@ describe("ContractDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Contract " + SAMPLE_CONTRACT.contract_id))
         expect(wrapper.get("#balance").text()).toBe("2.00000000$0.4921")
-        expect(wrapper.get("#key").text()).toBe("4210 5082 0e14 85ac dd59 726088e0 e4a2 130e bbbb 7000 9f640ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
+        expect(wrapper.get("#key").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memo").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
         expect(wrapper.get("#expiresAt").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriod").text()).toBe("90 days")
@@ -127,7 +127,7 @@ describe("ContractDetails.vue", () => {
 
         expect(wrapper.findComponent(NotificationBanner).exists()).toBe(false)
 
-        expect(wrapper.get("#key").text()).toBe("4210 5082 0e14 85ac dd59 726088e0 e4a2 130e bbbb 7000 9f640ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
+        expect(wrapper.get("#key").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memo").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
         expect(wrapper.get("#file").text()).toBe("0.0.749773")
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -91,7 +91,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#totalSupply").text()).toBe("1")
         expect(wrapper.get("#initialSupply").text()).toBe("1")
         expect(wrapper.get("#maxSupply").text()).toBe("Infinite")
-        expect(wrapper.get("#ethereumAddress").text()).toBe("0000 0000 0000 0000 0000 00000000 0000 01c4 9eecCopy to Clipboard")
+        expect(wrapper.get("#ethereumAddress").text()).toBe("0000 0000 0000 0000 0000 0000 0000 0000 01c4 9eecCopy to Clipboard")
 
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)
@@ -126,7 +126,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#name").text()).toBe("Ħ Frens Kingdom Dude")
         expect(wrapper.get("#symbol").text()).toBe("ĦFRENSKINGDOM")
         expect(wrapper.find("#adminKey").text()).toBe(
-            "Admin Keyc1a8 c8c5 b446 ce05 3b6e ff4fe4f0 192f 7653 5ea9 ed6b 2b919811 77ba 237f 4b5dCopy to ClipboardED25519"
+            "Admin Keyc1a8 c8c5 b446 ce05 3b6e ff4f e4f0 192f 7653 5ea9 ed6b 2b91 9811 77ba 237f 4b5dCopy to ClipboardED25519"
         )
         expect(wrapper.get("#memo").text()).toBe("None")
         expect(wrapper.get("#expiresAt").text()).toBe("None")

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -79,19 +79,19 @@ describe("TokenDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Fungible"))
 
-        expect(wrapper.get("#name").text()).toBe("23423")
-        expect(wrapper.get("#symbol").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
+        expect(wrapper.get("#nameValue").text()).toBe("23423")
+        expect(wrapper.get("#symbolValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
         expect(wrapper.find("#adminKey").text()).toBe("Admin KeyNone")
-        expect(wrapper.get("#memo").text()).toBe("234234")
-        expect(wrapper.get("#expiresAt").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriod").text()).toBe("90 days")
+        expect(wrapper.get("#memoValue").text()).toBe("234234")
+        expect(wrapper.get("#expiresAtValue").text()).toBe("None")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
 
-        expect(wrapper.get("#createdAt").text()).toBe("10:02:30.2333 AMFeb 12, 2022")
-        expect(wrapper.get("#modifiedAt").text()).toBe("10:02:30.2333 AMFeb 12, 2022")
-        expect(wrapper.get("#totalSupply").text()).toBe("1")
-        expect(wrapper.get("#initialSupply").text()).toBe("1")
-        expect(wrapper.get("#maxSupply").text()).toBe("Infinite")
-        expect(wrapper.get("#ethereumAddress").text()).toBe("0000 0000 0000 0000 0000 0000 0000 0000 01c4 9eecCopy to Clipboard")
+        expect(wrapper.get("#createdAtValue").text()).toBe("10:02:30.2333 AMFeb 12, 2022")
+        expect(wrapper.get("#modifiedAtValue").text()).toBe("10:02:30.2333 AMFeb 12, 2022")
+        expect(wrapper.get("#totalSupplyValue").text()).toBe("1")
+        expect(wrapper.get("#initialSupplyValue").text()).toBe("1")
+        expect(wrapper.get("#maxSupplyValue").text()).toBe("Infinite")
+        expect(wrapper.get("#ethereumAddressValue").text()).toBe("0000 0000 0000 0000 0000 0000 0000 0000 01c4 9eecCopy to Clipboard")
 
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)
@@ -123,20 +123,20 @@ describe("TokenDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Non Fungible"))
 
-        expect(wrapper.get("#name").text()).toBe("Ħ Frens Kingdom Dude")
-        expect(wrapper.get("#symbol").text()).toBe("ĦFRENSKINGDOM")
+        expect(wrapper.get("#nameValue").text()).toBe("Ħ Frens Kingdom Dude")
+        expect(wrapper.get("#symbolValue").text()).toBe("ĦFRENSKINGDOM")
         expect(wrapper.find("#adminKey").text()).toBe(
             "Admin Keyc1a8 c8c5 b446 ce05 3b6e ff4f e4f0 192f 7653 5ea9 ed6b 2b91 9811 77ba 237f 4b5dCopy to ClipboardED25519"
         )
-        expect(wrapper.get("#memo").text()).toBe("None")
-        expect(wrapper.get("#expiresAt").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriod").text()).toBe("90 days")
+        expect(wrapper.get("#memoValue").text()).toBe("None")
+        expect(wrapper.get("#expiresAtValue").text()).toBe("None")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
 
-        expect(wrapper.get("#createdAt").text()).toBe("3:29:27.7128 PMMar 6, 2022")
-        expect(wrapper.get("#modifiedAt").text()).toBe("8:56:33.5203 PMMar 6, 2022")
-        expect(wrapper.get("#totalSupply").text()).toBe("2")
-        expect(wrapper.get("#initialSupply").text()).toBe("0")
-        expect(wrapper.get("#maxSupply").text()).toBe("150")
+        expect(wrapper.get("#createdAtValue").text()).toBe("3:29:27.7128 PMMar 6, 2022")
+        expect(wrapper.get("#modifiedAtValue").text()).toBe("8:56:33.5203 PMMar 6, 2022")
+        expect(wrapper.get("#totalSupplyValue").text()).toBe("2")
+        expect(wrapper.get("#initialSupplyValue").text()).toBe("0")
+        expect(wrapper.get("#maxSupplyValue").text()).toBe("150")
 
         expect(wrapper.text()).toMatch("NFT Holders")
         expect(wrapper.findComponent(TokenNftTable).exists()).toBe(true)
@@ -167,8 +167,8 @@ describe("TokenDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Non Fungible"))
-        expect(wrapper.get("#name").text()).toBe("Ħ Frens Kingdom Dude")
-        expect(wrapper.get("#symbol").text()).toBe("ĦFRENSKINGDOM")
+        expect(wrapper.get("#nameValue").text()).toBe("Ħ Frens Kingdom Dude")
+        expect(wrapper.get("#symbolValue").text()).toBe("ĦFRENSKINGDOM")
         expect(wrapper.text()).toMatch("NFT Holders")
         expect(wrapper.findComponent(TokenNftTable).exists()).toBe(true)
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(false)
@@ -188,8 +188,8 @@ describe("TokenDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Fungible"))
-        expect(wrapper.get("#name").text()).toBe("23423")
-        expect(wrapper.get("#symbol").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
+        expect(wrapper.get("#nameValue").text()).toBe("23423")
+        expect(wrapper.get("#symbolValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenNftTable).exists()).toBe(false)
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -77,7 +77,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Fungible"))
+        expect(wrapper.text()).toMatch(RegExp("^Fungible Token " + testTokenId))
 
         expect(wrapper.get("#nameValue").text()).toBe("23423")
         expect(wrapper.get("#symbolValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
@@ -121,7 +121,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Non Fungible"))
+        expect(wrapper.text()).toMatch(RegExp("^Non Fungible Token " + testTokenId))
 
         expect(wrapper.get("#nameValue").text()).toBe("Ħ Frens Kingdom Dude")
         expect(wrapper.get("#symbolValue").text()).toBe("ĦFRENSKINGDOM")
@@ -166,7 +166,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Non Fungible"))
+        expect(wrapper.text()).toMatch(RegExp("^Non Fungible Token " + testTokenId))
         expect(wrapper.get("#nameValue").text()).toBe("Ħ Frens Kingdom Dude")
         expect(wrapper.get("#symbolValue").text()).toBe("ĦFRENSKINGDOM")
         expect(wrapper.text()).toMatch("NFT Holders")
@@ -187,7 +187,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch(RegExp("^Token " + testTokenId + "Fungible"))
+        expect(wrapper.text()).toMatch(RegExp("^Fungible Token " + testTokenId))
         expect(wrapper.get("#nameValue").text()).toBe("23423")
         expect(wrapper.get("#symbolValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
         expect(wrapper.text()).toMatch("Balances")

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -71,19 +71,19 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(SAMPLE_TRANSACTION.transaction_id, true)))
 
-        expect(wrapper.get("#transactionType").text()).toBe("CRYPTO TRANSFER")
-        expect(wrapper.get("#consensusAt").text()).toBe("5:12:31.6676 AMFeb 28, 2022") // UTC because of HMSF.forceUTC
-        expect(wrapper.get("#transactionHash").text()).toBe("a012 9612 32ed 7d28 4283 6e95f7e9 c435 6fdf e2de 0819 9091701a 969c 1d1f d936 71d3 078ee83b 28fb 460a 88b4 cbd8 ecd2Copy to Clipboard")
-        expect(wrapper.get("#netAmount").text()).toBe("0.00000000$0.0000")
-        expect(wrapper.get("#chargedFee").text()).toBe("0.00470065$0.0012")
-        expect(wrapper.get("#maxFee").text()).toBe("1.00000000$0.2460")
+        expect(wrapper.get("#transactionTypeValue").text()).toBe("CRYPTO TRANSFER")
+        expect(wrapper.get("#consensusAtValue").text()).toBe("5:12:31.6676 AMFeb 28, 2022") // UTC because of HMSF.forceUTC
+        expect(wrapper.get("#transactionHashValue").text()).toBe("a012 9612 32ed 7d28 4283 6e95 f7e9 c435 6fdf e2de 0819 9091 701a 969c 1d1f d936 71d3 078e e83b 28fb 460a 88b4 cbd8 ecd2Copy to Clipboard")
+        expect(wrapper.get("#netAmountValue").text()).toBe("0.00000000$0.0000")
+        expect(wrapper.get("#chargedFeeValue").text()).toBe("0.00470065$0.0012")
+        expect(wrapper.get("#maxFeeValue").text()).toBe("1.00000000$0.2460")
 
-        expect(wrapper.get("#memo").text()).toBe("None")
-        expect(wrapper.get("#operatorAccount").text()).toBe("0.0.29624024")
-        expect(wrapper.get("#nodeAccount").text()).toBe("0.0.7Node 4 - Nomura - Tokyo, Japan")
-        expect(wrapper.get("#duration").text()).toBe("120 seconds")
-        expect(wrapper.get("#entityKV").text()).toBe("Account ID0.0.29662956")
-        expect(wrapper.get("#scheduled").text()).toBe("false")
+        expect(wrapper.get("#memoValue").text()).toBe("None")
+        expect(wrapper.get("#operatorAccountValue").text()).toBe("0.0.29624024")
+        expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.7Node 4 - Nomura - Tokyo, Japan")
+        expect(wrapper.get("#durationValue").text()).toBe("120 seconds")
+        expect(wrapper.get("#entityId").text()).toBe("Account ID0.0.29662956")
+        expect(wrapper.get("#scheduledValue").text()).toBe("false")
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
@@ -130,8 +130,8 @@ describe("TransactionDetails.vue", () => {
         await flushPromises()
 
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(SAMPLE_TRANSACTION.transaction_id, true)))
-        expect(wrapper.get("#transactionType").text()).toBe("CRYPTO TRANSFER")
-        expect(wrapper.get("#memo").text()).toBe("None")
+        expect(wrapper.get("#transactionTypeValue").text()).toBe("CRYPTO TRANSFER")
+        expect(wrapper.get("#memoValue").text()).toBe("None")
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
@@ -148,8 +148,8 @@ describe("TransactionDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(transaction.transaction_id, true)))
-        expect(wrapper.get("#transactionType").text()).toBe("CONTRACT CALL")
-        expect(wrapper.get("#memo").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:26.066680977Z Execute contract")
+        expect(wrapper.get("#transactionTypeValue").text()).toBe("CONTRACT CALL")
+        expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:26.066680977Z Execute contract")
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("")

--- a/tests/unit/values/HexaValue.spec.ts
+++ b/tests/unit/values/HexaValue.spec.ts
@@ -64,7 +64,7 @@ describe("HexaValue.vue", () => {
 
         // console.log(wrapper.html())
 
-        expect(wrapper.text()).toBe("0102 0304 0506 0708 090A 0B0C0D0E 0FCopy to Clipboard")
+        expect(wrapper.text()).toBe("0102 0304 0506 0708 090A 0B0C 0D0E 0FCopy to Clipboard")
 
         // Lines below ...
         //

--- a/tests/unit/values/KeyValue.spec.ts
+++ b/tests/unit/values/KeyValue.spec.ts
@@ -38,7 +38,7 @@ describe("KeyValue.vue", () => {
             },
         });
 
-        expect(wrapper.text()).toBe("0001 0203 0405 0607 0809 0A0B0C0D 0E0FCopy to Clipboard")
+        expect(wrapper.text()).toBe("0001 0203 0405 0607 0809 0A0B 0C0D 0E0FCopy to Clipboard")
     });
 
     it("props.keyBytes unset, showNone=false", async () => {


### PR DESCRIPTION
**Description**:

This PR essentially introduces a small component ('Property') and its use by entity details pages which need to display (key, value) for each of the entity properties.

The Property component currently offers 2 different layouts:
 - column based (like previously) above the SMALL_SCREEN breakpoint 
 - flexbox based below the SMALL_SCREEN breakpoint

**Related issue(s)**:

Fixes #35

**Notes for reviewer**:

Can be squashed (and branch deleted).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
