### PR TITLE
Interpret Entity ID as Account ID in TOKENASSOCIATE & TOKENDISSOCIATE

### DIFF
--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -52,6 +52,8 @@ export class EntityDescriptor {
             case TransactionType.CRYPTOUPDATEACCOUNT:
             case TransactionType.CRYPTODELETELIVEHASH:
             case TransactionType.CRYPTOTRANSFER:
+            case TransactionType.TOKENASSOCIATE:
+            case TransactionType.TOKENDISSOCIATE:
                 result = new EntityDescriptor("Account ID", "AccountDetails")
                 break;
 
@@ -73,8 +75,6 @@ export class EntityDescriptor {
             case TransactionType.TOKENCREATION:
             case TransactionType.TOKENDELETION:
             case TransactionType.TOKENUPDATE:
-            case TransactionType.TOKENASSOCIATE:
-            case TransactionType.TOKENDISSOCIATE:
             case TransactionType.TOKENFEESCHEDULEUPDATE:
             case TransactionType.TOKENFREEZE:
             case TransactionType.TOKENGRANTKYC:

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -40,14 +40,14 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.CRYPTOCREATEACCOUNT:
         case TransactionType.CRYPTODELETE:
         case TransactionType.CRYPTOUPDATEACCOUNT:
+        case TransactionType.TOKENASSOCIATE:
+        case TransactionType.TOKENDISSOCIATE:
             result = row.entity_id ? "Account ID: " + row.entity_id : ""
             break
         case TransactionType.TOKENBURN:
         case TransactionType.TOKENMINT:
         case TransactionType.TOKENCREATION:
         case TransactionType.TOKENDELETION:
-        case TransactionType.TOKENASSOCIATE:
-        case TransactionType.TOKENDISSOCIATE:
         case TransactionType.TOKENFEESCHEDULEUPDATE:
         case TransactionType.TOKENFREEZE:
         case TransactionType.TOKENUNFREEZE:


### PR DESCRIPTION
**Description**:

With this PR, the entity_id property in transactions of type TOKENASSOCIATE & TOKENDISSOCIATE is now interpreted as an Account ID instead of a TOKEN ID.

**Related issue(s)**:

Fixes #65

**Notes for reviewer**:

Can be squashed and branch deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
