### PR TITLE
Display build date

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,10 @@
+### The name of the product as shown in the footer tagline
+VUE_APP_PRODUCT_NAME="Hedera Mirror Node Explorer"
+
+### The URL to which a click on the bottom-right sponsor logo will navigate
+# VUE_APP_SPONSOR_URL="<URL of sponsor>"
+
 ### When set, these variables will cause the insertion of a custom menu item
 ### in the network selector pull-down menu of the TopNavBar
-
 # VUE_APP_LOCAL_MIRROR_NODE_NAME=<network menu item for mirror node>
 # VUE_APP_LOCAL_MIRROR_NODE_URL=<URL of mirror node>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
   -->
 
 <!DOCTYPE html>
-<html lang="">
+<html data-build-timestamp-utc="<%= new Date().toUTCString() %>" lang="">
 
 <head>
     <meta charset="utf-8">

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,9 @@ export default defineComponent({
   components: {TopNavBar},
 
   setup() {
+    const buildTime = document.documentElement.dataset.buildTimestampUtc ?? "not available"
+    provide('buildTime', buildTime)
+
     const isTouchDevice = ('ontouchstart' in window)
     provide('isTouchDevice', isTouchDevice)
 

--- a/src/assets/branding/install-branding.sh
+++ b/src/assets/branding/install-branding.sh
@@ -8,6 +8,7 @@ cp ./src/assets/styles/brand-theme.scss ./src/assets/branding/
 BRANDING_DIR="${BRANDING_LOCATION:-./branding}"
 cp ${BRANDING_DIR}/assets/* ./src/assets/branding/ 2>/dev/null | :
 cp ${BRANDING_DIR}/public/* ./public 2>/dev/null | :
+cp ${BRANDING_DIR}/.env ./ 2>/dev/null | :
 
 # When custom theme provided: pre-process SASS/SCSS files based on it
 npx sass ./src/assets/branding/brand-theme.scss ./src/assets/branding/brand-theme.css

--- a/src/assets/styles/brand-theme.scss
+++ b/src/assets/styles/brand-theme.scss
@@ -21,7 +21,7 @@
 // Set brand variables
 $h-highlight-color: lightgrey;
 $h-page-background-color: #171717;
-$h-top-banner-background-color: #2f2f2f;
+$h-top-banner-background-color: #575757;
 $h-box-background-color: $h-page-background-color;
 $h-table-background-color: $h-page-background-color;
 $h-mobile-page-background-color: $h-page-background-color;

--- a/src/components/AxiosStatus.vue
+++ b/src/components/AxiosStatus.vue
@@ -46,7 +46,7 @@
       <i class="fa fa-exclamation-triangle has-text-danger" @click="showErrorDialog = true"/>
     </template>
     <span style="display: inline-block">
-        <ModalDialog v-model:show-dialog="showErrorDialog">
+        <ModalDialog v-model:show-dialog="showErrorDialog" :iconClass="'fa fa-2x fa-exclamation-triangle has-text-danger'">
           <template v-slot:dialogMessage><slot name="message"/>{{ explanation }}</template>
           <template v-slot:dialogDetails>
             <div v-if="explanation" class="block">

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -37,14 +37,17 @@
       <span v-if="!isTouchDevice && isSmallScreen"
             class="h-is-property-text ml-5 pb-1"
             style="font-weight:300; color: #DBDBDB">
-        Hedera Mirror Node Explorer is a ledger explorer for the Hedera network.
+        {{ productName }} is a ledger explorer for the Hedera network.
       </span>
 
       <span class="is-flex-grow-1"/>
 
-      <a class="ml-4" href="#" style="line-height: 1">
+      <a v-if="sponsorURL" class="ml-4" :href="sponsorURL" style="line-height: 1">
         <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
       </a>
+      <div v-else class="ml-4" style="line-height: 1">
+        <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
+      </div>
 
     </div>
 
@@ -73,9 +76,14 @@ export default defineComponent({
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
+    const productName = process.env.VUE_APP_PRODUCT_NAME ?? "Hedera Mirror Node Explorer"
+    const sponsorURL = process.env.VUE_APP_SPONSOR_URL ?? ""
+
     return {
       isSmallScreen,
-      isTouchDevice
+      isTouchDevice,
+      productName,
+      sponsorURL
     }
   },
 })

--- a/src/components/ModalDialog.vue
+++ b/src/components/ModalDialog.vue
@@ -28,7 +28,7 @@
     <div class="modal-content">
       <div class="box">
         <div class="is-flex is-flex-direction-row is-align-items-start">
-          <span class="icon is-large mr-4"><i class="fa fa-exclamation-triangle fa-2x has-text-danger"/></span>
+          <span class="icon is-large mr-4"><i :class="iconClass"/></span>
           <div>
             <div class="block h-is-tertiary-text mt-2">
               <slot name="dialogMessage"/>
@@ -59,7 +59,8 @@ export default defineComponent({
     showDialog: {
       type: Boolean,
       default: false
-    }
+    },
+    iconClass: String
   },
 
   setup(props, context) {

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -24,11 +24,21 @@
 
 <template>
 
+  <ModalDialog v-model:show-dialog="showErrorDialog" :iconClass="'fa fa-2x fa-info has-text-info'">
+    <template v-slot:dialogMessage>
+      <div>Hedera Mirror Node Explorer is a ledger explorer</div>
+      <div>for the Hedera network</div>
+    </template>
+    <template v-slot:dialogDetails>
+      <div>Build date: {{ buildTime }}</div>
+    </template>
+  </ModalDialog>
+
   <div v-if="!isMediumScreen"
        class="is-flex is-align-items-center is-justify-content-space-between pt-3 pb-4">
 
     <span class="is-inline-flex is-align-items-center is-flex-grow-0 is-flex-shrink-0">
-      <a class="mr-3" @click="$router.push({name: 'MainDashboard'})">
+      <a class="mr-3" @click="showErrorDialog=true">
         <img alt="Product Logo" class="image" src="@/assets/branding/brand-product-logo.png" style="max-width: 165px;">
       </a>
       <AxiosStatus/>
@@ -53,7 +63,7 @@
 
   <div v-else class="is-flex is-justify-content-space-between is-align-items-flex-end">
     <span class="is-inline-flex is-align-items-center is-flex-grow-0 is-flex-shrink-0">
-      <a id="product-logo" @click="$router.push({name: 'MainDashboard'})" class="mr-3">
+      <a id="product-logo" @click="showErrorDialog = true" class="mr-3">
         <img alt="Product Logo" class="image" src="@/assets/branding/brand-product-logo.png">
       </a>
       <AxiosStatus/>
@@ -115,15 +125,19 @@ import router from "@/router";
 import SearchBar from "@/components/SearchBar.vue";
 import AxiosStatus from "@/components/AxiosStatus.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
+import ModalDialog from "@/components/ModalDialog.vue";
 
 export default defineComponent({
   name: "TopNavBar",
-  components: {AxiosStatus, SearchBar},
+  components: {ModalDialog, AxiosStatus, SearchBar},
 
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)
     const isMediumScreen = inject('isMediumScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
+    const buildTime = inject('buildTime', "not available")
+
+    const showErrorDialog = ref(false)
 
     const route = useRoute()
     const network = computed( () => { return route.params.network })
@@ -182,6 +196,8 @@ export default defineComponent({
       isSmallScreen,
       isMediumScreen,
       isTouchDevice,
+      buildTime,
+      showErrorDialog,
       name,
       hideNavBar,
       showTopRightLogo,

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -25,10 +25,7 @@
 <template>
 
   <ModalDialog v-model:show-dialog="showErrorDialog" :iconClass="'fa fa-2x fa-info has-text-info'">
-    <template v-slot:dialogMessage>
-      <div>Hedera Mirror Node Explorer is a ledger explorer</div>
-      <div>for the Hedera network</div>
-    </template>
+    <template v-slot:dialogMessage>{{ productName }} is a ledger explorer for the Hedera network</template>
     <template v-slot:dialogDetails>
       <div>Build date: {{ buildTime }}</div>
     </template>
@@ -137,6 +134,8 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const buildTime = inject('buildTime', "not available")
 
+    const productName = process.env.VUE_APP_PRODUCT_NAME ?? "Hedera Mirror Node Explorer"
+
     const showErrorDialog = ref(false)
 
     const route = useRoute()
@@ -197,6 +196,7 @@ export default defineComponent({
       isMediumScreen,
       isTouchDevice,
       buildTime,
+      productName,
       showErrorDialog,
       name,
       hideNavBar,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -30,9 +30,9 @@
 
     <DashboardCard>
       <template v-slot:title>
-        <span v-if="tokenInfo">
-          <span v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'" class="h-is-tertiary-text has-text-grey">Non Fungible</span>
-          <span v-else class="h-is-tertiary-text has-text-grey">Fungible</span>
+        <span v-if="tokenInfo" class="h-is-primary-title">
+          <span v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'">Non Fungible</span>
+          <span v-else>Fungible</span>
         </span>
         <span class="h-is-primary-title"> Token </span>
         <span class="h-is-secondary-text mr-2">{{ normalizedTokenId }}</span>

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -88,8 +88,7 @@ describe("App.vue", () => {
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
         expect(navBar.text()).toBe(
-            "Hedera Mirror Node Explorer is a ledger explorer" +
-            "for the Hedera network" +
+            "Hedera Mirror Node Explorer is a ledger explorer for the Hedera network" +
             "Build date: not available" +
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -87,7 +87,11 @@ describe("App.vue", () => {
 
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
-        expect(navBar.text()).toBe("MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
+        expect(navBar.text()).toBe(
+            "Hedera Mirror Node Explorer is a ledger explorer" +
+            "for the Hedera network" +
+            "Build date: not available" +
+            "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
 
         expect(wrapper.findComponent(HbarMarketDashboard).exists()).toBe(true)
 

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -66,8 +66,7 @@ describe("TopNavBar.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe(
-            "Hedera Mirror Node Explorer is a ledger explorer" +
-            "for the Hedera network" +
+            "Hedera Mirror Node Explorer is a ledger explorer for the Hedera network" +
             "Build date: not available" +
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
 

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -65,7 +65,11 @@ describe("TopNavBar.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toBe("MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
+        expect(wrapper.text()).toBe(
+            "Hedera Mirror Node Explorer is a ledger explorer" +
+            "for the Hedera network" +
+            "Build date: not available" +
+            "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccounts")
 
         const links = wrapper.findAll("a")
         expect(links.length).toBe(8)


### PR DESCRIPTION
**Description**:

This PR:
* adds an about dialog, displayed when clicking on the (top-left) product logo, which mentions the build date
* adds 2 environment variables, allowing to customize the product name and the URL visited when clicking on the (bottom-right) sponsor logo and includes the .env file in the branding
* slightly modifies ModalDialog to pass icon class as a prop.

**Related issue(s)**:

Fixes #55

**Notes for reviewer**:

- A couple of cosmetic changes have sneaked in...
- This can be squashed-merged and branch deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
