### PR TITLE
00054 node owners incorrect

### DIFF
--- a/src/components/transfer_graphs/HbarTransferGraphF.vue
+++ b/src/components/transfer_graphs/HbarTransferGraphF.vue
@@ -135,7 +135,7 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import HbarExtra from "@/components/values/HbarExtra.vue";
 import {HbarTransferLayout} from "@/components/transfer_graphs/layout/HbarTransferLayout";
 import {Transaction} from "@/schemas/HederaSchemas";
-import {operatorRegistry} from "@/schemas/OperatorRegistry";
+import {EntityID} from "@/utils/EntityID";
 
 export default defineComponent({
   name: "HbarTransferGraphF",
@@ -151,7 +151,7 @@ export default defineComponent({
     function hasLowContrast(i: number): boolean {
       const destinations = hbarTransferLayout.value.destinations
       const accountId = i < destinations.length ? destinations[i].transfer.account : null
-      return accountId != null && operatorRegistry.lookup(accountId) != null
+      return accountId != null && EntityID.isOperator(accountId)
     }
 
     watch(() => props.transaction, () => {

--- a/src/components/transfer_graphs/layout/HbarTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/HbarTransferLayout.ts
@@ -20,6 +20,7 @@
 
 import {compareTransferByAccount, Transaction, Transfer} from "@/schemas/HederaSchemas";
 import {computeNetAmount} from "@/utils/TransactionTools";
+import {EntityID} from "@/utils/EntityID";
 import {operatorRegistry} from "@/schemas/OperatorRegistry";
 
 export class HbarTransferLayout {
@@ -53,11 +54,11 @@ export class HbarTransferLayout {
             positiveTransfers.sort(compareTransferByAccount)
 
             for (const t of negativeTransfers) {
-                const payload = t.account === null || operatorRegistry.lookup(t.account) === null
+                const payload = t.account === null || !EntityID.isOperator(t.account)
                 this.sources.push(new HbarTransferRow(t, null, payload))
             }
             for (const t of positiveTransfers) {
-                const payload = t.account === null || operatorRegistry.lookup(t.account) === null
+                const payload = t.account === null || !EntityID.isOperator(t.account)
                 this.destinations.push(new HbarTransferRow(t, HbarTransferLayout.makeDescription(t), payload))
             }
         }
@@ -83,10 +84,7 @@ export class HbarTransferLayout {
     //
 
     private static makeDescription(t: Transfer): string {
-        const registryEntry = t.account != null ? operatorRegistry.lookup(t.account) : null
-        return registryEntry !== null ?
-            registryEntry.getDescription() :
-            "Transfer"
+        return (t.account !== null ? operatorRegistry.makeDescription(t.account) : null) ?? "Transfer"
     }
 
     private static removeFeeRows(rows: HbarTransferRow[]): number {

--- a/src/components/values/AccountLink.vue
+++ b/src/components/values/AccountLink.vue
@@ -80,8 +80,7 @@ export default defineComponent({
 
   setup(props) {
     const extra = computed(() => {
-      const entry = props.accountId ? operatorRegistry.lookup(props.accountId) : null
-      return entry ? entry.getDescription() : ""
+      return (props.accountId ? operatorRegistry.makeDescription(props.accountId) : null) ?? ""
     })
 
     return { extra }

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -224,8 +224,7 @@ export default defineComponent({
     })
 
     const accountInfo = computed(() => {
-      const entry = normalizedAccountId.value ? operatorRegistry.lookup(normalizedAccountId.value) : null
-      return entry != null ? entry.getDescription() : null
+      return normalizedAccountId.value ? operatorRegistry.makeDescription(normalizedAccountId.value) : null
     })
 
 

--- a/src/schemas/OperatorRegistry.ts
+++ b/src/schemas/OperatorRegistry.ts
@@ -48,14 +48,18 @@
 
  */
 
+import {networkRegistry} from "@/schemas/NetworkRegistry";
+
 export class OperatorEntry {
     public readonly accountId: string
+    public readonly network: string|null
     public readonly name: string
     public readonly location: string|null
     public readonly nodeId: number|null
 
-    constructor(accountId: string, name: string, location: string|null, nodeId: number|null) {
+    constructor(accountId: string, network: string|null, name: string, location: string|null, nodeId: number|null) {
         this.accountId = accountId
+        this.network = network
         this.name = name
         this.location = location
         this.nodeId = nodeId
@@ -105,15 +109,17 @@ export class OperatorRegistry {
         this.addEntry("0.0.27", "ServiceNow", "Ogden, Utah", 24)
         this.addEntry("0.0.28", "Ubisoft", "Singapore, Republic of Singapore", 25)
 
-        this.addEntry("0.0.98", "Hedera fee collection account", null, null)
+        this.addEntry("0.0.98", "Hedera fee collection account", null, null, null)
     }
 
     public lookup(accountId: string): OperatorEntry|null {
-        return this.entries.get(accountId) ?? null
+        const result = this.entries.get(accountId)
+        const network = networkRegistry.getLastUsedNetwork()
+        return result && (result.network == network || result.network == null) ? result : null
     }
 
-    private addEntry(accountId: string, name: string, location: string|null, nodeID: number|null) {
-        this.entries.set(accountId, new OperatorEntry(accountId, name, location, nodeID))
+    private addEntry(accountId: string, name: string, location: string|null, nodeID: number|null, network: string|null = "mainnet") {
+        this.entries.set(accountId, new OperatorEntry(accountId, network, name, location, nodeID))
     }
 }
 

--- a/src/schemas/OperatorRegistry.ts
+++ b/src/schemas/OperatorRegistry.ts
@@ -49,6 +49,7 @@
  */
 
 import {networkRegistry} from "@/schemas/NetworkRegistry";
+import {EntityID} from "@/utils/EntityID";
 
 export class OperatorEntry {
     public readonly accountId: string
@@ -116,6 +117,17 @@ export class OperatorRegistry {
         const result = this.entries.get(accountId)
         const network = networkRegistry.getLastUsedNetwork()
         return result && (result.network == network || result.network == null) ? result : null
+    }
+
+    public makeDescription(accountId: string): string | null {
+        let result: string|null
+        if (accountId && EntityID.isOperator(accountId)) {
+            const registryEntry = operatorRegistry.lookup(accountId)
+            result = registryEntry !== null ? registryEntry.getDescription() : "Node"
+        } else {
+            result = null
+        }
+        return result
     }
 
     private addEntry(accountId: string, name: string, location: string|null, nodeID: number|null, network: string|null = "mainnet") {

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -82,6 +82,15 @@ export class EntityID {
         return byteToHex(buffer)
     }
 
+    public isOperator(): boolean {
+        return this.shard == 0 && this.realm == 0 && this.num < 100
+    }
+
+    public static isOperator(entityID: string): boolean {
+        const eid = EntityID.parse(entityID)
+        return eid !== null && eid.isOperator()
+    }
+
     /*
      * Compare two account ID.
      * Accounts are sorted in ascending but account ids < 100 are put at the end.

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -81,7 +81,7 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#operatorAccountValue").text()).toBe("0.0.29624024")
-        expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.7Node 4 - Nomura - Tokyo, Japan")
+        expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.7Node")
         expect(wrapper.get("#durationValue").text()).toBe("120 seconds")
         expect(wrapper.get("#entityId").text()).toBe("Account ID0.0.29662956")
         expect(wrapper.get("#scheduledValue").text()).toBe("false")
@@ -92,7 +92,7 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe(
             "Fee TransfersAccountHbar AmountAccountHbar Amount0.0.29624024-0.00470065-$0.0012\n\n" +
-            "0.0.70.00022028$0.0001Node 4 - Nomura - Tokyo, Japan\n\n" +
+            "0.0.70.00022028$0.0001Node\n\n" +
             "0.0.980.00448037$0.0011Hedera fee collection account")
 
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe(

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -61,7 +61,7 @@ describe("HbarTransferLayout.vue", () => {
         const d0 = fullLayout.destinations[0]
         expect(d0.transfer.account).toBe("0.0.7")
         expect(d0.transfer.amount).toBe(+3)
-        expect(d0.description).toBe("Node 4 - Nomura - Tokyo, Japan")
+        expect(d0.description).toBe("Node")
         expect(d0.payload).toBe(false)
 
         const d1 = fullLayout.destinations[1]
@@ -123,7 +123,7 @@ describe("HbarTransferLayout.vue", () => {
         const fd1 = fullLayout.destinations[1]
         expect(fd1.transfer.account).toBe("0.0.7")
         expect(fd1.transfer.amount).toBe(+3)
-        expect(fd1.description).toBe("Node 4 - Nomura - Tokyo, Japan")
+        expect(fd1.description).toBe("Node")
         expect(fd1.payload).toBe(false)
 
         const fd2 = fullLayout.destinations[2]
@@ -203,7 +203,7 @@ describe("HbarTransferLayout.vue", () => {
         const d2 = fullLayout.destinations[2]
         expect(d2.transfer.account).toBe("0.0.7")
         expect(d2.transfer.amount).toBe(+3)
-        expect(d2.description).toBe("Node 4 - Nomura - Tokyo, Japan")
+        expect(d2.description).toBe("Node")
         expect(d2.payload).toBe(false)
 
         const d3 = fullLayout.destinations[3]
@@ -287,7 +287,7 @@ describe("HbarTransferLayout.vue", () => {
         const d0 = fullLayout.destinations[0]
         expect(d0.transfer.account).toBe("0.0.7")
         expect(d0.transfer.amount).toBe(+3)
-        expect(d0.description).toBe("Node 4 - Nomura - Tokyo, Japan")
+        expect(d0.description).toBe("Node")
         expect(d0.payload).toBe(false)
 
         const d1 = fullLayout.destinations[1]
@@ -357,7 +357,7 @@ describe("HbarTransferLayout.vue", () => {
         const d1 = fullLayout.destinations[1]
         expect(d1.transfer.account).toBe("0.0.7")
         expect(d1.transfer.amount).toBe(+3)
-        expect(d1.description).toBe("Node 4 - Nomura - Tokyo, Japan")
+        expect(d1.description).toBe("Node")
         expect(d1.payload).toBe(false)
 
         const d2 = fullLayout.destinations[2]
@@ -450,7 +450,7 @@ describe("HbarTransferLayout.vue", () => {
         const d2 = fullLayout.destinations[2]
         expect(d2.transfer.account).toBe("0.0.7")
         expect(d2.transfer.amount).toBe(+3)
-        expect(d2.description).toBe("Node 4 - Nomura - Tokyo, Japan")
+        expect(d2.description).toBe("Node")
         expect(d2.payload).toBe(false)
 
         const d3 = fullLayout.destinations[3]

--- a/tests/unit/values/AccountLink.spec.ts
+++ b/tests/unit/values/AccountLink.spec.ts
@@ -86,7 +86,7 @@ describe("AccountLink.vue", () => {
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const testAccountId = "0.0.21" // EDF - Paris, France
-        const testExtra = "Node 18 - EDF - Paris, France"
+        const testExtra = "Node"
         const wrapper = mount(AccountLink, {
             global: {
                 plugins: [router]


### PR DESCRIPTION
**Description**:

With the changes below, Explorer now displays node owners of mainnet only when mainnet is selected.
When testnet or previewnet are selected, node < 100 are simply labeled « Node ».

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/91124272/169507435-d0a434c2-8c99-43b0-8914-7693805fbb86.png">

**Related issue(s)**:

Fixes #54

**Notes for reviewer**:

Can be squashed and branch deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
