### PR TITLE
Handle transaction relationships

### DIFF
--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -59,6 +59,10 @@
       <TransactionSummary v-bind:transaction="props.row"/>
     </o-table-column>
 
+    <o-table-column v-slot="props" label="Relationship">
+      {{ makeRelationshipLabel(props.row) }}
+    </o-table-column>
+
   </o-table>
 
   <EmptyTable v-if="!transactions.length"/>
@@ -73,14 +77,14 @@
 
 import {computed, defineComponent, inject, onBeforeUnmount, PropType, ref, watch} from 'vue';
 import {Transaction} from '@/schemas/HederaSchemas';
-import {makeTypeLabel} from "@/utils/TransactionTools";
+import {makeRelationshipLabel, makeTypeLabel} from "@/utils/TransactionTools";
 import {EntityCacheState} from "@/utils/EntityCache";
 import {PlayPauseState} from "@/components/PlayPauseButton.vue";
 import router from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import {TransactionByIdCache} from "@/components/transaction/TransactionByIdCache";
-import { ORUGA_MOBILE_BREAKPOINT } from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 
 export default defineComponent({
@@ -180,6 +184,7 @@ export default defineComponent({
 
       // From TransactionTools
       makeTypeLabel,
+      makeRelationshipLabel
     }
   }
 });

--- a/src/components/values/AccountLink.vue
+++ b/src/components/values/AccountLink.vue
@@ -24,9 +24,7 @@
 
 <template>
 
-  <div v-if="accountId === null">{{ nullLabel }}</div>
-
-  <div v-else-if="accountId">
+  <div v-if="accountId">
     <template v-if="noAnchor">
       <span class="is-numeric">{{ accountId }}</span>
     </template>
@@ -41,6 +39,8 @@
   </div>
 
   <span v-else-if="showNone && !initialLoading" class="has-text-grey">None</span>
+
+  <div v-else-if="accountId === null">{{ nullLabel }}</div>
 
   <span v-else/>
 

--- a/src/components/values/AccountLink.vue
+++ b/src/components/values/AccountLink.vue
@@ -24,7 +24,9 @@
 
 <template>
 
-  <div v-if="accountId">
+  <div v-if="accountId === null">{{ nullLabel }}</div>
+
+  <div v-else-if="accountId">
     <template v-if="noAnchor">
       <span class="is-numeric">{{ accountId }}</span>
     </template>
@@ -39,8 +41,6 @@
   </div>
 
   <span v-else-if="showNone && !initialLoading" class="has-text-grey">None</span>
-
-  <div v-else-if="accountId === null">{{ nullLabel }}</div>
 
   <span v-else/>
 

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -34,7 +34,7 @@
         <span class="h-is-secondary-text mr-3">{{ account ? normalizedAccountId : "" }}</span>
         <span v-if="showContractVisible" class="is-inline-block" id="showContractLink">
           <router-link :to="{name: 'ContractDetails', params: {contractId: accountId}}">
-            <span class="h-is-property-text has-text-grey">Associated contract</span>
+            <span class="h-is-property-text">Show associated contract</span>
           </router-link>
         </span>
         <p class="h-is-tertiary-text" v-if="accountInfo != null"> {{ accountInfo }} </p>
@@ -52,7 +52,7 @@
                 <div v-if="account" class="h-is-tertiary-text"><HbarAmount v-bind:amount="balance" v-bind:show-extra="true"/></div>
                 <div v-if="displayAllTokenLinks">
                   <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
-                    See all token balances
+                    Show all token balances
                   </router-link>
                 </div>
                 <div v-else>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -34,7 +34,7 @@
         <span class="h-is-secondary-text is-numeric mr-3">{{ contract ? normalizedContractId : "" }}</span>
         <span v-if="contract" class="is-inline-block">
           <router-link :to="{name: 'AccountDetails', params: {accountId: normalizedContractId}}">
-            <span class="h-is-property-text has-text-grey">Associated account</span>
+            <span class="h-is-property-text">Show associated account</span>
           </router-link>
         </span>
       </template>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -122,7 +122,7 @@
               </template>
             </Property>
             <Property :id="'operatorAccount'">
-              <template v-slot:name>Operator Account</template>
+              <template v-slot:name>Payer Account</template>
               <template v-slot:value>
                 <AccountLink v-if="transaction" v-bind:accountId="makeOperatorAccountLabel(transaction)" v-bind:show-extra="true"/>
               </template>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -32,11 +32,6 @@
       <template v-slot:title>
         <span class="h-is-primary-title">Transaction </span>
         <span class="h-is-secondary-text mr-3">{{ transaction ? convertTransactionId(transactionId) : "" }}</span>
-        <span v-if="showAllTransactionVisible" class="is-inline-block" id="allTransactionsLink">
-          <router-link :to="{name: 'TransactionsById', params: {transactionId: transactionId}}">
-            <span class="h-is-property-text has-text-grey">See all transactions with the same ID</span>
-          </router-link>
-        </span>
      </template>
 
       <template v-slot:table>
@@ -352,11 +347,6 @@ export default defineComponent({
       return isNaN(result) ? -9999 : result
     }
 
-    const showAllTransactionVisible = computed(() => {
-      const transactionCount = response.value?.data.transactions?.length ?? 0
-      return transactionCount >= 2
-    })
-
     return {
       isSmallScreen,
       isTouchDevice,
@@ -373,7 +363,6 @@ export default defineComponent({
       makeTypeLabel,
       computeNetAmount,
       makeOperatorAccountLabel,
-      showAllTransactionVisible,
       displayAllChildrenLinks,
       scheduledTransaction,
       schedulingTransaction,

--- a/src/pages/TransactionsById.vue
+++ b/src/pages/TransactionsById.vue
@@ -24,7 +24,7 @@
 
 <template>
 
-  <hr class="h-has-blue-background" style="margin: 0; height: 4px"/>
+  <hr class="h-top-banner" style="margin: 0; height: 4px"/>
 
   <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -138,6 +138,20 @@ export function showPositiveNetAmount(row: Transaction): boolean {
     return result
 }
 
+export function makeRelationshipLabel(row: Transaction): string {
+    let result: string
+    if (row.name === TransactionType.SCHEDULECREATE) {
+        result = "Scheduling"
+    } else if (row.scheduled) {
+        result = "Scheduled"
+    } else if (row.nonce && row.nonce > 0) {
+        result = "Child"
+    } else {
+        result = "Parent"
+    }
+    return result
+}
+
 export function makeTypeLabel(type: TransactionType | undefined): string {
     let result: string
     switch (type) {

--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -67,7 +67,7 @@ describe('Account Navigation', () => {
         cy.url().should('include', '/testnet/account/')
 
         cy.get('#balance')
-            .contains('a', "See all token balances")
+            .contains('a', "Show all token balances")
             .click()
 
         cy.url().should('include', 'accountbalances/' + accountId1)

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -44,13 +44,54 @@ describe('Search Bar', () => {
         )
     })
 
-    it('should find all transactions with the same ID', () => {
+    it('should find and list the scheduling/scheduled transactions', () => {
         const searchTransaction = "0.0.11852473@1650382121.542685062"
         testBody(
             searchTransaction,
             '/testnet/transactionsById/' + normalizeTransactionId(searchTransaction),
             'Transactions with ID ' + searchTransaction
         )
+        cy.get('table')
+            .find('tbody tr')
+            .should('have.length', 2)
+            .eq(0)
+            .find('td')
+            .eq(3)
+            .should('contain', 'Scheduling')  // criteria to check
+        cy.get('table')
+            .find('tbody tr')
+            .eq(1)
+            .find('td')
+            .eq(3)
+            .should('contain', 'Scheduled')  // criteria to check
+    })
+
+    it('should find and list the parent/child transactions', () => {
+        const searchTransaction = "0.0.6036@1652787852.826165451"
+        testBody(
+            searchTransaction,
+            '/testnet/transactionsById/' + normalizeTransactionId(searchTransaction),
+            'Transactions with ID ' + searchTransaction
+        )
+        cy.get('table')
+            .find('tbody tr')
+            .should('have.length', 3)
+            .eq(0)
+            .find('td')
+            .eq(3)
+            .should('contain', 'Parent')  // criteria to check
+        cy.get('table')
+            .find('tbody tr')
+            .eq(1)
+            .find('td')
+            .eq(3)
+            .should('contain', 'Child')  // criteria to check
+        cy.get('table')
+            .find('tbody tr')
+            .eq(2)
+            .find('td')
+            .eq(3)
+            .should('contain', 'Child')  // criteria to check
     })
 
     it('should find the NFT ID', () => {

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -97,15 +97,69 @@ describe('Transaction Navigation', () => {
         cy.url().should('include', '/testnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
+    })
 
-        cy.get('#allTransactionsLink')
+    it('should follow schedule relationship links', () => {
+        const transactionId = "0.0.11495@1650446896.868427600"
+        const schedulingConsensusTimestamp = "1650446903.332120989"
+        const scheduledConsensusTimestamp = "1650446904.595635000"
+
+        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + schedulingConsensusTimestamp)
+        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', normalizeTransactionId(transactionId))
+        cy.url().should('include', schedulingConsensusTimestamp)
+
+        cy.get('#scheduledTransactionValue')
             .find('a')
             .click()
             .then(($id) => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transactionsById/')
-                cy.url().should('include', normalizeTransactionId(transactionId))
-                cy.contains('Transactions with ID ' + transactionId)
+                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', normalizeTransactionId(transactionId) + "?t=" + scheduledConsensusTimestamp)
+                cy.contains('Transaction ' + transactionId)
+            })
+
+        cy.get('#schedulingTransactionValue')
+            .find('a')
+            .click()
+            .then(($id) => {
+                // cy.log('Selected operator Id: ' + $id.text())
+                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', normalizeTransactionId(transactionId) + "?t=" + schedulingConsensusTimestamp)
+                cy.contains('Transaction ' + transactionId)
+            })
+    })
+
+    it('should follow parent/child relationship links', () => {
+        const transactionId = "0.0.6036@1652787852.826165451"
+        const parentConsensusTimestamp = "1652787861.365127000"
+        const childConsensusTimestamp = "1652787861.365127001"
+
+        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + parentConsensusTimestamp)
+        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', normalizeTransactionId(transactionId))
+        cy.url().should('include', parentConsensusTimestamp)
+
+        cy.get('#childrenValue')
+            .find('a')
+            .should('have.length', 2)
+            .eq(0)
+            .click()
+            .then(($id) => {
+                // cy.log('Selected operator Id: ' + $id.text())
+                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', normalizeTransactionId(transactionId) + "?t=" + childConsensusTimestamp)
+                cy.contains('Transaction ' + transactionId)
+            })
+
+        cy.get('#parentTransactionValue')
+            .find('a')
+            .click()
+            .then(($id) => {
+                // cy.log('Selected operator Id: ' + $id.text())
+                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', normalizeTransactionId(transactionId) + "?t=" + parentConsensusTimestamp)
+                cy.contains('Transaction ' + transactionId)
             })
     })
 

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -69,6 +69,7 @@ describe("TransactionDetails.vue", () => {
 
         await flushPromises()
         // console.log(wrapper.html())
+        // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(SAMPLE_TRANSACTION.transaction_id, true)))
 
@@ -84,7 +85,6 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.7Node")
         expect(wrapper.get("#durationValue").text()).toBe("2 minutes")
         expect(wrapper.get("#entityId").text()).toBe("Account ID0.0.29662956")
-        expect(wrapper.get("#scheduledValue").text()).toBe("false")
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)


### PR DESCRIPTION
**Description**:

This PR mostly touches TransactionDetails and TransactionByIdTable in order to:

 * handle relationships between transactions:
   * Parent transaction and child transactions
   * Scheduling transaction and scheduled transaction
 * display nature of relationship in the table listing transactions with same ID (result of search)

**Related issue(s)**:

Fixes #68
Related to #9

**Notes for reviewer**:

Search for the following transactions (on TESTNET) to visualize the changes, and then navigate between the details of individual transaction:
 * 0.0.6036@1652787852.826165451
 * 0.0.2812286@1653665235.098465576

I removed the link "Show all transactions..." and then changed my mind. I think we might still find useful to display the table showing all transactions involved in a relationship, so let's further use it and rediscuss the issue.

This can be squashed-merged and the branch can be deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
