### PR TITLE
00008 support account alias in search and account details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@oruga-ui/oruga-next": "^0.5.5",
         "axios": "^0.24.0",
         "base32-decode": "^1.0.0",
+        "base32-encode": "^1.2.0",
         "bulma": "^0.9.3",
         "core-js": "^3.6.5",
         "js-sha3": "^0.8.0",
@@ -7434,6 +7435,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base32-decode/-/base32-decode-1.0.0.tgz",
       "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g=="
+    },
+    "node_modules/base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "dependencies": {
+        "to-data-view": "^1.1.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -25472,6 +25481,11 @@
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
     },
+    "node_modules/to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -34420,6 +34434,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base32-decode/-/base32-decode-1.0.0.tgz",
       "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g=="
+    },
+    "base32-encode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
+      "requires": {
+        "to-data-view": "^1.1.0"
+      }
     },
     "base64-js": {
       "version": "1.5.1",
@@ -48854,6 +48876,11 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
+    },
+    "to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "vue-router": "^4.0.0-0",
     "@metamask/detect-provider": "^1.2.0",
     "base32-decode": "^1.0.0",
+    "base32-encode": "^1.2.0",
     "js-sha3": "^0.8.0"
   },
   "devDependencies": {

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -189,8 +189,7 @@ import {makeEthAddressForAccount} from "@/schemas/HederaUtils";
 import EthAddress from "@/components/values/EthAddress.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import StringValue from "@/components/values/StringValue.vue";
-import base32Decode from "base32-decode";
-import {byteToHex} from "@/utils/B64Utils";
+import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -382,7 +381,7 @@ export default defineComponent({
 
     const aliasByteString = computed(() => {
       const alias = account.value?.alias
-      return alias ? byteToHex(new Uint8Array(base32Decode(alias, 'RFC4648'))) : null
+      return alias ? byteToHex(new Uint8Array(base32ToAlias(alias))) : null
     })
 
     return {

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -199,8 +199,7 @@ import {EntityID} from "@/utils/EntityID";
 import Property from "@/components/Property.vue";
 import {makeEthAddressForAccount} from "@/schemas/HederaUtils";
 import EthAddress from "@/components/values/EthAddress.vue";
-import {byteToHex} from "@/utils/B64Utils";
-import base32Decode from "base32-decode";
+import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -330,7 +329,7 @@ export default defineComponent({
 
     const aliasByteString = computed(() => {
       const alias = account.value?.alias
-      return alias ? byteToHex(new Uint8Array(base32Decode(alias, 'RFC4648'))) : null
+      return alias ? byteToHex(new Uint8Array(base32ToAlias(alias))) : null
     })
 
     return {

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -48,8 +48,8 @@
           <span >No account, transaction, contract, token or topic matches "</span>
           <span style="font-weight: 400">{{ this.searchedId }}</span>
           <span >".</span>
-          <br/>
-          Make sure you enter either an entity ID (0.0.x) or a transaction ID (0.0.x@seconds.nanoseconds).
+          <br/><br/>
+          Make sure you enter either an entity ID (0.0.x), a transaction ID (0.0.x@seconds.nanoseconds)<br/>or an account alias using hexadecimal notation.
         </template>
       </p>
     </div>

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -20,8 +20,7 @@
 
 import {AccountInfo, KeyType, TokenInfo} from "@/schemas/HederaSchemas";
 import {EntityID} from "@/utils/EntityID";
-import {byteToHex, hexToByte} from "@/utils/B64Utils";
-import base32Decode from "base32-decode";
+import {base32ToAlias, byteToHex, hexToByte} from "@/utils/B64Utils";
 import {keccak256} from "js-sha3";
 
 export function makeEthAddressForAccount(account: AccountInfo): string|null {
@@ -29,7 +28,7 @@ export function makeEthAddressForAccount(account: AccountInfo): string|null {
 
     if (account.alias) {
         // Decodes BASE32 encoding of account.alias
-        const buffer = base32Decode(account.alias, 'RFC4648')
+        const buffer = base32ToAlias(account.alias)
         result = byteToHex(new Uint8Array(buffer))
     } else if (account.key?.key && account.key?._type == KeyType.ECDSA_SECP256K1) {
         // Generates Eth. address from key

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -81,9 +81,11 @@ const HEXSET = "0123456789ABCDEF"
 export function hexToByte(hex: string): Uint8Array|null {
     let result: Uint8Array|null
     if (hex.length % 2 == 0) {
+        const startIndex = hex.startsWith("0x") ? 2 : 0
+        const byteCount = (hex.length - startIndex) / 2
         const bytes = Array<number>()
         let ok = true
-        for (let i = 0, byteCount = hex.length / 2; i < byteCount && ok; i += 1) {
+        for (let i = startIndex; i < byteCount && ok; i += 1) {
             const b1 = hex[i].toUpperCase()
             const b0 = hex[i+1].toUpperCase()
             const okB1 = HEXSET.indexOf(b1) != -1

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -81,13 +81,12 @@ const HEXSET = "0123456789ABCDEF"
 export function hexToByte(hex: string): Uint8Array|null {
     let result: Uint8Array|null
     if (hex.length % 2 == 0) {
-        const startIndex = hex.startsWith("0x") ? 2 : 0
-        const byteCount = (hex.length - startIndex) / 2
+        const startIndex = hex.startsWith("0x") ? 1 : 0
         const bytes = Array<number>()
         let ok = true
-        for (let i = startIndex; i < byteCount && ok; i += 1) {
-            const b1 = hex[i].toUpperCase()
-            const b0 = hex[i+1].toUpperCase()
+        for (let i = startIndex, endIndex = hex.length / 2; i < endIndex && ok; i += 1) {
+            const b1 = hex[2*i].toUpperCase()
+            const b0 = hex[2*i+1].toUpperCase()
             const okB1 = HEXSET.indexOf(b1) != -1
             const okB0 = HEXSET.indexOf(b0) != -1
             if (okB0 && okB1) {

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -19,6 +19,9 @@
  */
 
 
+import base32Decode from "base32-decode";
+import base32Encode from "base32-encode";
+
 //
 // https://developer.mozilla.org/en-US/docs/Glossary/Base64
 //
@@ -101,4 +104,16 @@ export function hexToByte(hex: string): Uint8Array|null {
         result = null
     }
     return result
+}
+
+//
+// Alias conversion
+//
+
+export function aliasToBase32(bytes: Uint8Array): string {
+    return base32Encode(bytes, 'RFC4648', { padding: false })
+}
+
+export function base32ToAlias(aliasBase32: string): Uint8Array {
+    return new Uint8Array(base32Decode(aliasBase32, 'RFC4648'))
 }

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -116,9 +116,11 @@ export class EntityID {
 
     // Utility
 
+    private static readonly MAX_INT = Math.pow(2, 32) // Max supported by mirror node rest api on May 30, 2022
+
     public static parsePositiveInt(s: string): number|null {
         const n = Number(s)
-        return (isNaN(n) || Math.floor(n) != n || n < 0) ? null : n
+        return (isNaN(n) || Math.floor(n) != n || n < 0 || n >= EntityID.MAX_INT) ? null : n
     }
 
 

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -59,7 +59,7 @@ export class SearchRequest {
         const transactionID = TransactionID.parse(this.searchedId)
         const normTransactionID = transactionID != null ? transactionID.toString(false) : null
         const hexBytes = hexToByte(this.searchedId)
-        const hexByteString32 = hexBytes !== null ? aliasToBase32(hexBytes) : null
+        const hexByteString32 = (hexBytes !== null && hexBytes.length >= 15) ? aliasToBase32(hexBytes) : null
 
         // 1) Searches accounts
         if (normEntityID !== null || hexByteString32 !== null) {

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -53,13 +53,14 @@ export class SearchRequest {
         this.countdown = 5
         this.errorCount = 0
 
-        const isEntityId = EntityID.parse(this.searchedId, true) != null
+        const entityID = EntityID.parse(this.searchedId, true)
+        const normEntityID = entityID !== null ? entityID.toString() : null
         const isTransactionId = TransactionID.parse(this.searchedId) != null
 
         // 1) Searches accounts
-        if (isEntityId) {
+        if (normEntityID !== null) {
             axios
-                .get("api/v1/accounts/" + this.searchedId)
+                .get("api/v1/accounts/" + normEntityID)
                 .then(response => {
                     this.account = response.data
                 })
@@ -95,9 +96,9 @@ export class SearchRequest {
         }
 
         // 3) Searches tokens
-        if (isEntityId) {
+        if (normEntityID !== null) {
             axios
-                .get("api/v1/tokens/" + this.searchedId)
+                .get("api/v1/tokens/" + normEntityID)
                 .then(response => {
                     this.tokenInfo = response.data
                 })
@@ -114,13 +115,13 @@ export class SearchRequest {
         }
 
         // 4) Searches topics
-        if (isEntityId) {
+        if (normEntityID !== null) {
             const params = {
                 order: "desc",
                 limit: "1"
             }
             axios
-                .get("api/v1/topics/" + this.searchedId + "/messages", {params})
+                .get("api/v1/topics/" + normEntityID + "/messages", {params})
                 .then(response => {
                     this.topicMessages = response.data.messages
                 })
@@ -137,9 +138,9 @@ export class SearchRequest {
         }
 
         // 5) Searches contracts
-        if (isEntityId) {
+        if (normEntityID !== null) {
             axios
-                .get<ContractResponse>("api/v1/contracts/" + this.searchedId)
+                .get<ContractResponse>("api/v1/contracts/" + normEntityID)
                 .then(response => {
                     this.contract = response.data
                 })

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -29,6 +29,8 @@ import axios from "axios";
 import {TransactionID} from "@/utils/TransactionID";
 import {DeferredPromise} from "@/utils/DeferredPromise";
 import {EntityID} from "@/utils/EntityID";
+import {hexToByte} from "@/utils/B64Utils";
+import base32Encode from "base32-encode";
 
 
 export class SearchRequest {
@@ -57,11 +59,14 @@ export class SearchRequest {
         const normEntityID = entityID !== null ? entityID.toString() : null
         const transactionID = TransactionID.parse(this.searchedId)
         const normTransactionID = transactionID != null ? transactionID.toString(false) : null
+        const hexBytes = hexToByte(this.searchedId)
+        const hexByteString32 = hexBytes !== null ? base32Encode(hexBytes, 'RFC4648', { padding: false }) : null
 
         // 1) Searches accounts
-        if (normEntityID !== null) {
+        if (normEntityID !== null || hexByteString32 !== null) {
+            const entityOrAlias = hexByteString32 ? hexByteString32 : normEntityID
             axios
-                .get("api/v1/accounts/" + normEntityID)
+                .get("api/v1/accounts/" + entityOrAlias)
                 .then(response => {
                     this.account = response.data
                 })

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -29,8 +29,7 @@ import axios from "axios";
 import {TransactionID} from "@/utils/TransactionID";
 import {DeferredPromise} from "@/utils/DeferredPromise";
 import {EntityID} from "@/utils/EntityID";
-import {hexToByte} from "@/utils/B64Utils";
-import base32Encode from "base32-encode";
+import {aliasToBase32, hexToByte} from "@/utils/B64Utils";
 
 
 export class SearchRequest {
@@ -60,7 +59,7 @@ export class SearchRequest {
         const transactionID = TransactionID.parse(this.searchedId)
         const normTransactionID = transactionID != null ? transactionID.toString(false) : null
         const hexBytes = hexToByte(this.searchedId)
-        const hexByteString32 = hexBytes !== null ? base32Encode(hexBytes, 'RFC4648', { padding: false }) : null
+        const hexByteString32 = hexBytes !== null ? aliasToBase32(hexBytes) : null
 
         // 1) Searches accounts
         if (normEntityID !== null || hexByteString32 !== null) {

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -26,7 +26,7 @@ import {
     Transaction
 } from "@/schemas/HederaSchemas";
 import axios from "axios";
-import {TransactionID, normalizeTransactionId} from "@/utils/TransactionID";
+import {TransactionID} from "@/utils/TransactionID";
 import {DeferredPromise} from "@/utils/DeferredPromise";
 import {EntityID} from "@/utils/EntityID";
 
@@ -55,7 +55,8 @@ export class SearchRequest {
 
         const entityID = EntityID.parse(this.searchedId, true)
         const normEntityID = entityID !== null ? entityID.toString() : null
-        const isTransactionId = TransactionID.parse(this.searchedId) != null
+        const transactionID = TransactionID.parse(this.searchedId)
+        const normTransactionID = transactionID != null ? transactionID.toString(false) : null
 
         // 1) Searches accounts
         if (normEntityID !== null) {
@@ -77,9 +78,9 @@ export class SearchRequest {
         }
 
         // 2) Searches transactions
-        if (isTransactionId) {
+        if (normTransactionID !== null) {
             axios
-                .get("api/v1/transactions/" + normalizeTransactionId(this.searchedId))
+                .get("api/v1/transactions/" + normTransactionID)
                 .then(response => {
                     this.transactions = response.data.transactions
                 })

--- a/tests/unit/utils/B64Utils.spec.ts
+++ b/tests/unit/utils/B64Utils.spec.ts
@@ -18,9 +18,7 @@
  *
  */
 
-import {byteToHex, hexToByte} from "@/utils/B64Utils";
-import base32Decode from "base32-decode";
-import base32Encode from "base32-encode";
+import {aliasToBase32, base32ToAlias, byteToHex, hexToByte} from "@/utils/B64Utils";
 
 describe("B64Utils.ts", () => {
 
@@ -42,19 +40,19 @@ describe("B64Utils.ts", () => {
         expect(hexString2).toEqual(hexString)
     })
 
-    test("base32Encode", () => {
+    test("aliasToBase32()", () => {
 
         const decodedBytes = hexToByte(hexString)
         expect(decodedBytes).not.toBeNull()
 
-        const encodedString = base32Encode(decodedBytes!, 'RFC4648', { padding: false })
+        const encodedString = aliasToBase32(decodedBytes!)
         expect(encodedString).toEqual(base32String)
     })
 
 
-    test("base32Decode", () => {
+    test("base32ToAlias", () => {
 
-        const decodedBytes = base32Decode(base32String, 'RFC4648')
+        const decodedBytes = base32ToAlias(base32String)
         expect(decodedBytes).not.toBeNull()
 
         const decodedHex = byteToHex(new Uint8Array(decodedBytes))

--- a/tests/unit/utils/B64Utils.spec.ts
+++ b/tests/unit/utils/B64Utils.spec.ts
@@ -1,0 +1,65 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {byteToHex, hexToByte} from "@/utils/B64Utils";
+import base32Decode from "base32-decode";
+import base32Encode from "base32-encode";
+
+describe("B64Utils.ts", () => {
+
+    const hexString = "12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296"
+    const base32String = "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ"
+
+
+    test("hexToByte() <=> byteToHex()", ()=> {
+        const decodedBytes = hexToByte(hexString)
+        expect(decodedBytes).not.toBeNull()
+        const hexString2 = byteToHex(decodedBytes!)
+        expect(hexString2).toEqual(hexString)
+    })
+
+    test("hexToByte() <=> byteToHex()   with 0x prefix", ()=> {
+        const decodedBytes = hexToByte("0x" + hexString)
+        expect(decodedBytes).not.toBeNull()
+        const hexString2 = byteToHex(decodedBytes!)
+        expect(hexString2).toEqual(hexString)
+    })
+
+    test("base32Encode", () => {
+
+        const decodedBytes = hexToByte(hexString)
+        expect(decodedBytes).not.toBeNull()
+
+        const encodedString = base32Encode(decodedBytes!, 'RFC4648', { padding: false })
+        expect(encodedString).toEqual(base32String)
+    })
+
+
+    test("base32Decode", () => {
+
+        const decodedBytes = base32Decode(base32String, 'RFC4648')
+        expect(decodedBytes).not.toBeNull()
+
+        const decodedHex = byteToHex(new Uint8Array(decodedBytes))
+        expect(decodedHex).toEqual(hexString)
+    })
+
+})
+

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -53,6 +53,15 @@ describe("EntityID.ts", () => {
         expect(obj?.toString()).toBe(str)
     })
 
+    test("0.0.721838", () => {
+        const str = "0.0.721838"
+        const obj = EntityID.parse(str)
+        expect(obj?.shard).toBe(0)
+        expect(obj?.realm).toBe(0)
+        expect(obj?.num).toBe(721838)
+        expect(obj?.toString()).toBe(str)
+    })
+
     test("98", () => {
         const obj = EntityID.parse("98")
         expect(obj).toBeNull()
@@ -61,6 +70,17 @@ describe("EntityID.ts", () => {
         expect(obj2?.realm).toBe(0)
         expect(obj2?.num).toBe(98)
         expect(obj2?.toString()).toBe("0.0.98")
+    })
+
+    test("Very big number", () => {
+        const veryBigNum = Math.pow(2, 32) - 1
+        const obj = EntityID.parse(veryBigNum.toString())
+        expect(obj).toBeNull()
+        const obj2 = EntityID.parse(veryBigNum.toString(), true)
+        expect(obj2?.shard).toBe(0)
+        expect(obj2?.realm).toBe(0)
+        expect(obj2?.num).toBe(veryBigNum)
+        expect(obj2?.toString()).toBe("0.0." + veryBigNum.toString())
     })
 
     test("1.2.3.4", () => {
@@ -81,6 +101,14 @@ describe("EntityID.ts", () => {
     test("0.0.c", () => {
         const obj = EntityID.parse("0.0.c")
         expect(obj).toBeNull()
+    })
+
+    test("Too Big Number", () => {
+        const tooBigNum = Math.pow(2, 32)
+        const obj = EntityID.parse(tooBigNum.toString())
+        expect(obj).toBeNull()
+        const obj2 = EntityID.parse(tooBigNum.toString(), true)
+        expect(obj2).toBeNull()
     })
 
     //

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -29,11 +29,15 @@ import {
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import {SearchRequest} from "@/utils/SearchRequest";
+import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
 
 const mock = new MockAdapter(axios)
 
 const matcher_account = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
 mock.onGet(matcher_account).reply(200, SAMPLE_ACCOUNT)
+
+const matcher_account_with_alias = "/api/v1/accounts/" + SAMPLE_ACCOUNT.alias
+mock.onGet(matcher_account_with_alias).reply(200, SAMPLE_ACCOUNT)
 
 const matcher_transaction = "/api/v1/transactions/" + SAMPLE_TRANSACTION.transaction_id
 mock.onGet(matcher_transaction).reply(200, SAMPLE_TRANSACTIONS)
@@ -56,6 +60,20 @@ describe("SearchRequest.ts", () => {
         await r.run()
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT.account)
+        expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+
+    })
+
+    test("account (with alias)", async () => {
+        const aliasHex = byteToHex(new Uint8Array(base32ToAlias(SAMPLE_ACCOUNT.alias)))
+        const r = new SearchRequest(aliasHex)
+        await r.run()
+
+        expect(r.searchedId).toBe(aliasHex)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -80,6 +80,17 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
 
+        const aliasHex2 = "0x" + aliasHex
+        const r2 = new SearchRequest(aliasHex2)
+        await r2.run()
+
+        expect(r2.searchedId).toBe(aliasHex2)
+        expect(r2.account).toStrictEqual(SAMPLE_ACCOUNT)
+        expect(r2.transactions).toStrictEqual([])
+        expect(r2.tokenInfo).toBeNull()
+        expect(r2.topicMessages).toStrictEqual([])
+        expect(r2.contract).toBeNull()
+
     })
 
     test("transaction", async () => {


### PR DESCRIPTION
**Description**:

Changes below enable Explorer to search an account using its alias.
User may now enter an account alias in hexadecimal form (with or without 0x prefix).

**Related issue(s)**:

Fixes #8 

**Notes for reviewer**:

On mainnet, the following accounts have an alias:
- 0.0.721838 / 0x12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296
- 0.0.714669 / 0x1220fe7c4f2fbb892f9d494a168b0efcd5f4f06424c622474149d4f49308e6a84be6

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
