### PR TITLE
Support EVM address in Search and Contract Details (#30)

### DIFF
--- a/src/components/values/HexaValue.vue
+++ b/src/components/values/HexaValue.vue
@@ -23,7 +23,7 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div v-if="byteString" class="shy-scope" style="display: inline-block; position: relative">
+  <div v-if="normByteString" class="shy-scope" style="display: inline-block; position: relative">
     <div class="is-family-monospace has-text-grey">{{ flow() }}</div>
     <div v-if="isCopyEnabled" id="shyCopyButton" class="shy" style="position: absolute; left: 0; top: 0; width: 100%; height: 100%">
       <div style="position: absolute; left: 0; top: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.50)"></div>
@@ -58,27 +58,39 @@ export default defineComponent({
   setup(props) {
     const isSmallScreen = inject('isSmallScreen', true)
 
+    // 0)
+    const normByteString = computed((): string|undefined => {
+      let result: string|undefined
+      if (props.byteString) {
+        result = props.byteString.startsWith("0x") ? props.byteString.slice(2) : props.byteString
+      } else {
+        result = undefined
+      }
+      return result
+    })
+
     // 1)
     const flow = (): string => {
-      return props.byteString ? makeByteLine(props.byteString) : ""
+      return normByteString.value ? makeByteLine(normByteString.value) : ""
     }
 
     // 2)
     const copyToClipboard = (): void => {
       if (props.byteString) {
-        navigator.clipboard.writeText("0x" + props.byteString)
+        navigator.clipboard.writeText("0x" + normByteString.value)
       }
     }
 
     // 3)
     const isCopyEnabled = computed(() => {
-      return (props.byteString?.length ?? 0) >= 1
+      return (normByteString.value?.length ?? 0) >= 1
     })
 
     // 4)
     const initialLoading = inject(initialLoadingKey, ref(false))
 
     return {
+      normByteString,
       isSmallScreen,
       flow,
       copyToClipboard,

--- a/src/components/values/HexaValue.vue
+++ b/src/components/values/HexaValue.vue
@@ -45,8 +45,6 @@
 import {computed, defineComponent, inject, ref} from "vue";
 import {initialLoadingKey} from "@/AppKeys";
 
-const BYTES_PER_LINE = 10
-
 export default defineComponent({
   name: "HexaValue",
   props: {
@@ -60,20 +58,7 @@ export default defineComponent({
   setup(props) {
     const isSmallScreen = inject('isSmallScreen', true)
 
-    // 1.a)
-    const split = (): string[] => {
-      const result = Array<string>()
-      if (props.byteString) {
-        const charPerLine = BYTES_PER_LINE * 2
-        for (let i = 0; i < props.byteString.length; i += charPerLine) {
-          const line = props.byteString.substring(i, i + charPerLine)
-          result.push(makeByteLine(line))
-        }
-      }
-      return result
-    }
-
-    // 1.b)
+    // 1)
     const flow = (): string => {
       return props.byteString ? makeByteLine(props.byteString) : ""
     }
@@ -96,7 +81,6 @@ export default defineComponent({
     return {
       isSmallScreen,
       flow,
-      split,
       copyToClipboard,
       isCopyEnabled,
       initialLoading

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -138,6 +138,12 @@
                 <HexaValue :byteString="formattedSolidity" :show-none="true"/>
               </template>
             </Property>
+            <Property :id="'evmAddress'">
+              <template v-slot:name>EVM Address</template>
+              <template v-slot:value>
+                <HexaValue :byte-string="contract?.evm_address" :show-none="true"/>
+              </template>
+            </Property>
             <Property :id="'ethereumAddress'">
               <template v-slot:name>ERC20 Address</template>
               <template v-slot:value>

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -382,6 +382,7 @@ export interface Contract {
     contract_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     created_timestamp: string | null | undefined
     deleted: boolean | undefined
+    evm_address: string | undefined
     expiration_timestamp: string | null | undefined
     file_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     memo: string | undefined

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -29,7 +29,7 @@ import axios from "axios";
 import {TransactionID} from "@/utils/TransactionID";
 import {DeferredPromise} from "@/utils/DeferredPromise";
 import {EntityID} from "@/utils/EntityID";
-import {aliasToBase32, hexToByte} from "@/utils/B64Utils";
+import {aliasToBase32, byteToHex, hexToByte} from "@/utils/B64Utils";
 
 
 export class SearchRequest {
@@ -59,6 +59,7 @@ export class SearchRequest {
         const transactionID = TransactionID.parse(this.searchedId)
         const normTransactionID = transactionID != null ? transactionID.toString(false) : null
         const hexBytes = hexToByte(this.searchedId)
+        const hexByteString = (hexBytes !== null && hexBytes.length >= 15) ? byteToHex(hexBytes) : null
         const hexByteString32 = (hexBytes !== null && hexBytes.length >= 15) ? aliasToBase32(hexBytes) : null
 
         // 1) Searches accounts
@@ -143,9 +144,10 @@ export class SearchRequest {
         }
 
         // 5) Searches contracts
-        if (normEntityID !== null) {
+        if (normEntityID !== null || hexByteString !== null) {
+            const entityOrAddress = hexByteString ? hexByteString : normEntityID
             axios
-                .get<ContractResponse>("api/v1/contracts/" + normEntityID)
+                .get<ContractResponse>("api/v1/contracts/" + entityOrAddress)
                 .then(response => {
                     this.contract = response.data
                 })

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -93,6 +93,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#validUntilValue").text()).toBe("None")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
         expect(wrapper.get("#solidityValue").text()).toBe("None")
+        expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000b 70cfCopy to Clipboard")
 
     });
 
@@ -132,6 +133,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
         expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
+        expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000b 70cfCopy to Clipboard")
 
         const contract2 = SAMPLE_CONTRACT_DUDE
         matcher1 = "/api/v1/contracts/" + contract2.contract_id
@@ -151,6 +153,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.803267")
+        expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000c 41dfCopy to Clipboard")
 
     });
 

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -52,6 +52,9 @@ mock.onGet(matcher_topic).reply(200, SAMPLE_TOPIC_MESSAGES)
 const matcher_contracts = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
 mock.onGet(matcher_contracts).reply(200, SAMPLE_CONTRACT)
 
+const matcher_contracts_with_evm_address = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address.slice(2)
+mock.onGet(matcher_contracts_with_evm_address).reply(200, SAMPLE_CONTRACT)
+
 
 describe("SearchRequest.ts", () => {
 
@@ -137,6 +140,19 @@ describe("SearchRequest.ts", () => {
         await r.run()
 
         expect(r.searchedId).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(r.account).toBeNull()
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
+
+    })
+
+    test("contract (with evm address)", async () => {
+        const r = new SearchRequest(SAMPLE_CONTRACT.evm_address)
+        await r.run()
+
+        expect(r.searchedId).toBe(SAMPLE_CONTRACT.evm_address)
         expect(r.account).toBeNull()
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()

--- a/tests/unit/values/HexaValue.spec.ts
+++ b/tests/unit/values/HexaValue.spec.ts
@@ -77,5 +77,23 @@ describe("HexaValue.vue", () => {
         // Clipboard copy must be tested in e2e tests
     });
 
+    //
+    // byteString set
+    //
+
+    it("props.byteString set (with 0x)", async () => {
+
+        const wrapper = mount(HexaValue, {
+            props: {
+                byteString: "0x" + BYTE_STRING
+            }
+        });
+        await flushPromises()
+
+        // console.log(wrapper.html())
+
+        expect(wrapper.text()).toBe("0102 0304 0506 0708 090A 0B0C 0D0E 0FCopy to Clipboard")
+    });
+
 
 });


### PR DESCRIPTION
**Description**:

With the changes below, explorer:
1) displays EVM address in contract detail page
2) enables to search a contract using its EVM address

**Related issue(s)**:

Fixes #30

**Notes for reviewer**:

On mainnet, contract 0.0.749775 can be used for testing.

This can be squashed-merged and the branch can be deleted.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
