### PR TITLE
00063 token symbol for metamask

### DIFF
--- a/src/components/values/TokenExtra.vue
+++ b/src/components/values/TokenExtra.vue
@@ -45,6 +45,7 @@ import {defineComponent, ref} from "vue";
 import {AxiosResponse} from "axios";
 import {TokenInfo} from "@/schemas/HederaSchemas";
 import {TokenInfoCollector} from "@/utils/TokenInfoCollector";
+import {makeTokenSymbol} from "@/schemas/HederaUtils";
 
 export default defineComponent({
   name: "TokenExtra",
@@ -71,7 +72,8 @@ export default defineComponent({
         if (props.showName) {
           extra.value = r.data.name ?? ""
         } else {
-          extra.value = makeExtra(r)
+          // extra.value = makeExtra(r)
+          extra.value = makeTokenSymbol(r.data, 40)
         }
       }, (reason: unknown) => {
         console.warn("TokenInfoCollector did fail to fetch " + props.tokenId + " with reason: " + reason)
@@ -82,25 +84,6 @@ export default defineComponent({
     return { extra }
   }
 });
-
-
-function makeExtra(response: AxiosResponse<TokenInfo>): string {
-  const name = response.data?.name
-  const symbol = response.data?.symbol
-  const maxLength = 40
-
-  let candidate1: string | null
-  if (symbol) {
-    const usable = symbol.search("://") == -1 && symbol.length < maxLength
-    candidate1 = usable ? symbol : null
-  } else {
-    candidate1 = null;
-  }
-
-  const candidate2 = name && name.length < maxLength ? name : null
-
-  return candidate1 ?? candidate2 ?? response.data.token_id ?? "?"
-}
 
 </script>
 

--- a/src/components/values/TokenExtra.vue
+++ b/src/components/values/TokenExtra.vue
@@ -72,7 +72,6 @@ export default defineComponent({
         if (props.showName) {
           extra.value = r.data.name ?? ""
         } else {
-          // extra.value = makeExtra(r)
           extra.value = makeTokenSymbol(r.data, 40)
         }
       }, (reason: unknown) => {

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -119,7 +119,7 @@
               <template v-slot:value>
                 <EthAddress v-if="ethereumAddress"
                             :address="ethereumAddress"
-                            :symbol="tokenInfo?.symbol"
+                            :symbol="tokenSymbol"
                             :decimals="tokenInfo?.decimals"
                             :show-import="true"
                             :show-none="true"/>
@@ -174,7 +174,7 @@ import Footer from "@/components/Footer.vue";
 import EthAddress from "@/components/values/EthAddress.vue";
 import {EntityID} from "@/utils/EntityID";
 import Property from "@/components/Property.vue";
-import {makeEthAddressForToken} from "@/schemas/HederaUtils";
+import {makeEthAddressForToken, makeTokenSymbol} from "@/schemas/HederaUtils";
 import NotificationBanner from "@/components/NotificationBanner.vue";
 
 export default defineComponent({
@@ -259,6 +259,8 @@ export default defineComponent({
       return tokenInfo.value !== null ? makeEthAddressForToken(tokenInfo.value) : null
     })
 
+    const tokenSymbol = computed( () => makeTokenSymbol(tokenInfo.value, 11))
+
     return {
       isSmallScreen,
       isTouchDevice,
@@ -268,7 +270,8 @@ export default defineComponent({
       notification,
       showTokenDetails,
       parseIntString,
-      ethereumAddress
+      ethereumAddress,
+      tokenSymbol
     }
   },
 });

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -59,4 +59,18 @@ export function makeEthAddressForToken(token: TokenInfo): string|null {
         result = null
     }
     return result
- }
+}
+
+export function makeTokenSymbol(token: TokenInfo | null, maxLength: number): string {
+    const symbol = token?.symbol
+    const name = token?.name
+
+    const symbolUsable = symbol && symbol.search("://") == -1
+
+    const candidate1 = symbol && symbolUsable && symbol.length <= maxLength ? symbol : null
+    const candidate2 = name && name.length <= maxLength ? name : null
+    const candidate3 = symbol && symbolUsable ? symbol.slice(0, maxLength) : null
+    const candidate4 = name ? name.slice(0, maxLength) : null
+
+    return candidate1 ?? candidate2 ?? candidate3 ?? candidate4 ?? token?.token_id ?? "?"
+}


### PR DESCRIPTION
**Description**:

This is a follow-up for PR #72 which make sure the token symbol provided for importing into Metamask is no longer than 11 char. Use best effort to derive this from the actual token symbol or name.

**Related issue(s)**:

Follow-up for #63 

**Notes for reviewer**:

Squash-merge and delete branch.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
