### PR TITLE
Bump bulma dependency from 0.9.3 to 0.9.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,9 @@
 ### The name of the product as shown in the footer tagline
 VUE_APP_PRODUCT_NAME="Hedera Mirror Node Explorer"
 
+### The prefix used in the document title
+VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
+
 ### The URL to which a click on the bottom-right sponsor logo will navigate
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 

--- a/.github/workflows/explorer-e2e-tests.yml
+++ b/.github/workflows/explorer-e2e-tests.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
+          install-command: npm install
           browser: chrome
           headless: true
           start: npm run serve:prod

--- a/.github/workflows/explorer-unit-tests.yml
+++ b/.github/workflows/explorer-unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set-up project dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build production bits
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "axios": "^0.24.0",
         "base32-decode": "^1.0.0",
         "base32-encode": "^1.2.0",
-        "bulma": "^0.9.3",
+        "bulma": "^0.9.4",
         "core-js": "^3.6.5",
         "js-sha3": "^0.8.0",
         "vue": "^3.0.0",
@@ -8208,9 +8208,9 @@
       "dev": true
     },
     "node_modules/bulma": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.3.tgz",
-      "integrity": "sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g=="
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
+      "integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ=="
     },
     "node_modules/busboy": {
       "version": "0.3.1",
@@ -35105,9 +35105,9 @@
       "dev": true
     },
     "bulma": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.3.tgz",
-      "integrity": "sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g=="
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
+      "integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ=="
     },
     "busboy": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.0-5",
     "@oruga-ui/oruga-next": "^0.5.5",
     "axios": "^0.24.0",
-    "bulma": "^0.9.3",
+    "bulma": "^0.9.4",
     "core-js": "^3.6.5",
     "vue": "^3.0.0",
     "vue-axios": "^3.4.0",

--- a/src/router.ts
+++ b/src/router.ts
@@ -197,36 +197,38 @@ router.beforeEach((to, from) => {
 })
 
 router.beforeEach((to) => {
+  const titlePrefix = process.env.VUE_APP_DOCUMENT_TITLE_PREFIX ?? "Hedera"
+
   switch (to.name as string) {
     case "MainDashboard":
-      document.title = "Hedera Explorer | Dashboard";
+      document.title = titlePrefix + " | Dashboard";
       break;
     case "TransactionDetails":
-      document.title = "Hedera Explorer | Transaction " + to.params.transactionId;
+      document.title = titlePrefix + " | Transaction " + to.params.transactionId;
       break;
     case "TokenDetails":
-      document.title = "Hedera Explorer | Token " + to.params.tokenId;
+      document.title = titlePrefix + " | Token " + to.params.tokenId;
       break;
     case "TopicDetails":
-      document.title = "Hedera Explorer | Topic " + to.params.topicId;
+      document.title = titlePrefix + " | Topic " + to.params.topicId;
       break;
     case "ContractDetails":
-      document.title = "Hedera Explorer | Contract " + to.params.contractId;
+      document.title = titlePrefix + " | Contract " + to.params.contractId;
       break;
     case "AccountDetails":
-      document.title = "Hedera Explorer | Account " + to.params.accountId;
+      document.title = titlePrefix + " | Account " + to.params.accountId;
       break;
     case "AccountBalances":
-      document.title = "Hedera Explorer | Balances for Account " + to.params.accountId;
+      document.title = titlePrefix + " | Balances for Account " + to.params.accountId;
       break;
     case "NoSearchResult":
-      document.title = "Hedera Explorer | Search Results";
+      document.title = titlePrefix + " | Search Results";
       break;
     case "PageNotFound":
-      document.title = "Hedera Explorer | Page Not Found";
+      document.title = titlePrefix + " | Page Not Found";
       break;
     default:
-      document.title = "Hedera Explorer | " + (to.name as string);
+      document.title = titlePrefix + " | " + (to.name as string);
   }
 });
 


### PR DESCRIPTION
**Description**:

* Bump Bulma to 0.9.4
* Replace 'npm ci' by 'npm install' in GitHub actions to avoid current build failure until we figure out why 'npm ci' believes our package.json and package-lock.json are not in sync, even after a fresh npm install...
* Control document title prefix with environment variable

PR can be squashed-merged and branch can be deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
