### PR TITLE
solidity_address does not exist anymore, it became evm_address

### DIFF
--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -132,12 +132,6 @@
                 <StringValue :string-value="contract?.file_id"/>
               </template>
             </Property>
-            <Property :id="'solidity'">
-              <template v-slot:name>Solidity</template>
-              <template v-slot:value>
-                <HexaValue :byteString="formattedSolidity" :show-none="true"/>
-              </template>
-            </Property>
             <Property :id="'evmAddress'">
               <template v-slot:name>EVM Address</template>
               <template v-slot:value>
@@ -288,19 +282,6 @@ export default defineComponent({
     const balance = computed(() => account.value?.balance?.balance)
     const tokens = computed(() => account.value?.balance?.tokens)
     const displayAllTokenLinks = computed(() => tokens.value ? tokens.value.length > MAX_TOKEN_BALANCES : false)
-    const formattedSolidity = computed(() => {
-      let result: string
-
-      const solidityAddress = contract.value?.solidity_address
-      if (solidityAddress && solidityAddress.indexOf("0x") == 0) {
-        // solidityAddress starts with 0x
-        result = solidityAddress.substring(2)
-      } else {
-        result = solidityAddress ?? ""
-      }
-
-      return result
-    })
     const notification = computed(() => {
       const expiration = contract.value?.expiration_timestamp
       let result
@@ -381,7 +362,6 @@ export default defineComponent({
       notification,
       obtainerId,
       proxyAccountId,
-      formattedSolidity,
       normalizedContractId,
       ethereumAddress,
       aliasByteString

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -388,7 +388,6 @@ export interface Contract {
     memo: string | undefined
     obtainer_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     proxy_account_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    solidity_address: string | undefined
     timestamp: TimestampRange | undefined   // timestamp range the entity is valid for
 
 }

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -92,7 +92,6 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#validFromValue").text()).toBe("3:09:15.9474 PMMar 7, 2022")
         expect(wrapper.get("#validUntilValue").text()).toBe("None")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
-        expect(wrapper.get("#solidityValue").text()).toBe("None")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000b 70cfCopy to Clipboard")
 
     });


### PR DESCRIPTION
**Description**:
`solidity_address` does not exist anymore, it became `evm_address` (see https://github.com/hashgraph/hedera-mirror-node/pull/3217).

Another field is already present to handle `evm_address`, so this PR modifies the smart contract's page in order to remove all references to `solidity_address`.

**Related issue(s)**:

N/D

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x]  Tested (unit, integration, etc.)
