### PR TITLE
00074 optional staking page

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,9 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 ### The URL to which a click on the bottom-right sponsor logo will navigate
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
+### When set to 'true', this variable will enable the 'Staking' page
+VUE_APP_ENABLE_STAKING=true
+
 ### When set, these variables will cause the insertion of a custom menu item
 ### in the network selector pull-down menu of the TopNavBar
 # VUE_APP_LOCAL_MIRROR_NODE_NAME=<network menu item for mirror node>

--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
 ### When set to 'true', this variable will enable the 'Staking' page
-VUE_APP_ENABLE_STAKING=true
+VUE_APP_ENABLE_STAKING=false
 
 ### When set, these variables will cause the insertion of a custom menu item
 ### in the network selector pull-down menu of the TopNavBar

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -98,9 +98,13 @@
         <a class="button is-ghost h-is-navbar-item h-is-dense"
            :class="{ 'is-rimmed': isAccountRoute}"
            @click="$router.push({name: 'Accounts'})">Accounts</a>
-        <a class="button is-ghost is-last h-is-navbar-item h-is-dense"
-           :class="{ 'is-rimmed': isNodeRoute}"
+        <a class="button is-ghost h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isNodeRoute, 'is-last': !isStakingEnabled}"
            @click="$router.push({name: 'Nodes'})">Nodes</a>
+        <a v-if="isStakingEnabled"
+           class="button is-ghost is-last h-is-navbar-item h-is-dense"
+           :class="{ 'is-rimmed': isStakingRoute}"
+           @click="$router.push({name: 'Staking'})">Staking</a>
       </div>
       <SearchBar style="margin-top: 4px"/>
     </div>
@@ -118,7 +122,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, ref, watch, WatchStopHandle} from "vue";
+import {computed, defineComponent, inject, onMounted, ref, watch, WatchStopHandle} from "vue";
 import {useRoute} from "vue-router";
 import router from "@/router";
 import SearchBar from "@/components/SearchBar.vue";
@@ -137,6 +141,9 @@ export default defineComponent({
     const buildTime = inject('buildTime', "not available")
 
     const productName = process.env.VUE_APP_PRODUCT_NAME ?? "Hedera Mirror Node Explorer"
+    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING == 'true'
+
+    onMounted(() => console.log("isStakingEnabled: " + isStakingEnabled))
 
     const showErrorDialog = ref(false)
 
@@ -196,12 +203,17 @@ export default defineComponent({
       return name.value === 'Nodes' || name.value === 'NodeDetails'
     })
 
+    const isStakingRoute = computed(() => {
+      return name.value === 'Staking'
+    })
+
     return {
       isSmallScreen,
       isMediumScreen,
       isTouchDevice,
       buildTime,
       productName,
+      isStakingEnabled,
       showErrorDialog,
       name,
       showTopRightLogo,
@@ -215,6 +227,7 @@ export default defineComponent({
       isContractRoute,
       isAccountRoute,
       isNodeRoute,
+      isStakingRoute
     }
   },
 })

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -141,7 +141,7 @@ export default defineComponent({
     const buildTime = inject('buildTime', "not available")
 
     const productName = process.env.VUE_APP_PRODUCT_NAME ?? "Hedera Mirror Node Explorer"
-    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING == 'true'
+    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
 
     onMounted(() => console.log("isStakingEnabled: " + isStakingEnabled))
 

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -99,7 +99,7 @@ export default defineComponent({
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
-    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING == 'true'
+    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
 
     const route = useRoute()
     const network = computed(() => { return route.params.network })

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -33,17 +33,10 @@
       <div class="is-flex is-flex-direction-column is-align-items-start">
         <div id="drop-down-menu" class="ml-1 mb-5 ">
           <o-field>
-            <o-select
-                v-model="selectedNetwork"
-                class="h-is-navbar-item"
-            >
+            <o-select v-model="selectedNetwork" class="h-is-navbar-item">
               <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">
                 {{ network.displayName }}
               </option>
-
-<!--              <option v-bind:key="HederaNetwork.MAINNET" v-bind:value="HederaNetwork.MAINNET">MAINNET</option>-->
-<!--              <option v-bind:key="HederaNetwork.TESTNET" v-bind:value="HederaNetwork.TESTNET">TESTNET</option>-->
-<!--              <option v-bind:key="HederaNetwork.PREVIEWNET" v-bind:value="HederaNetwork.PREVIEWNET">PREVIEWNET</option>-->
             </o-select>
           </o-field>
         </div>
@@ -69,6 +62,10 @@
         <a :class="{ 'is-rimmed': isNodeRoute}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace({name: 'Nodes'})">Nodes</a>
+        <a v-if="isStakingEnabled"
+           :class="{ 'is-rimmed': isStakingRoute}"
+           class="button is-ghost h-is-mobile-navbar-item h-is-dense"
+           @click="$router.replace({name: 'Staking'})">Staking</a>
       </div>
 
     </div>
@@ -102,10 +99,11 @@ export default defineComponent({
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
+    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING == 'true'
+
     const route = useRoute()
     const network = computed(() => { return route.params.network })
     const name = computed(() => { return route.query.from })
-
     const selectedNetwork = ref(network.value)
     watch(selectedNetwork, (selection) => {
       router.replace({
@@ -134,6 +132,9 @@ export default defineComponent({
     const isNodeRoute = computed(() => {
       return name.value === 'Nodes' || name.value === 'NodeDetails'
     })
+    const isStakingRoute = computed(() => {
+      return name.value === 'Staking'
+    })
 
     const  onResizeHandler = () => {
       if (window.innerWidth >= MEDIUM_BREAKPOINT) {
@@ -150,6 +151,7 @@ export default defineComponent({
     return {
       isSmallScreen,
       isTouchDevice,
+      isStakingEnabled,
       selectedNetwork,
       isDashboardRoute,
       isTransactionRoute,
@@ -158,6 +160,7 @@ export default defineComponent({
       isContractRoute,
       isAccountRoute,
       isNodeRoute,
+      isStakingRoute,
       networkRegistry
     }
   }

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -1,0 +1,93 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <hr class="h-top-banner" style="margin: 0; height: 4px"/>
+
+  <section :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}" class="section">
+
+    <DashboardCard>
+      <template v-slot:title>
+        <span class="h-is-primary-title">My Staking</span>
+      </template>
+      <template v-slot:table>
+
+        <section class="section has-text-centered" style="min-height: 450px">
+           <p class="h-is-tertiary-text" style="font-weight: 300">
+              To view or change your staking you first need to connect to your wallet.
+            </p>
+        </section>
+
+      </template>
+    </DashboardCard>
+
+  </section>
+
+  <Footer/>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, inject} from 'vue';
+import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
+
+export default defineComponent({
+  name: 'Staking',
+
+  props: {
+    network: String
+  },
+
+  components: {
+    Footer,
+    DashboardCard
+  },
+
+  setup() {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+
+    return {
+      isSmallScreen,
+      isTouchDevice,
+    }
+  }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -191,6 +191,18 @@ const router = createRouter({
   routes
 })
 
+router.beforeEach((to) => {
+  let result: boolean | string
+
+  if (to.name === 'Staking' && process.env.VUE_APP_ENABLE_STAKING !== 'true') {
+    // Staking page not enabled => re-route to PageNotFound
+    result = "/page-not-found"
+  } else {
+    result = true
+  }
+  return result
+})
+
 router.beforeEach((to, from) => {
   let result: boolean | string
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -42,6 +42,7 @@ import NodeDetails from "@/pages/NodeDetails.vue";
 import {NetworkEntry, networkRegistry} from "@/schemas/NetworkRegistry";
 import {AppStorage} from "@/AppStorage";
 import axios from "axios";
+import Staking from "@/pages/Staking.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -149,6 +150,12 @@ const routes: Array<RouteRecordRaw> = [
     path: '/:network/node/:nodeId',
     name: 'NodeDetails',
     component: NodeDetails,
+    props: true
+  },
+  {
+    path: '/:network/staking',
+    name: 'Staking',
+    component: Staking,
     props: true
   },
   {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -55,6 +55,10 @@ HMSF.forceUTC = true
 
 describe("App.vue", () => {
 
+    beforeEach(() => {
+        process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: false });
+    })
+
     test("normal screen", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -50,6 +50,10 @@ HMSF.forceUTC = true
 
 describe("TopNavBar.vue", () => {
 
+    beforeEach(() => {
+        process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: false });
+    })
+
     it("Should display logos, page links and search bar", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error


### PR DESCRIPTION
**Description**:

Add a new 'Staking' page which is activate only when the environment variable VUE_APP_ENABLE_STAKING has the value 'true'. When this condition is not met:

 * the 'Staking' menu item in the Top Nav Bar is not included
 * the routing does a redirect to PageNotFound when trying to route to #/<network>/staking

The Staking page is otherwise a place-holder for the time being.

**Related issue(s)**:

Fixes #74

**Notes for reviewer**:

This branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
