### PR TITLE
Remove unused SCSS definition

### DIFF
--- a/src/assets/styles/explorer-bulma.sass
+++ b/src/assets/styles/explorer-bulma.sass
@@ -36,7 +36,6 @@ $family-monospace: novamonoregular
 $button-color: white
 $control-border-width: 0.5px
 
-$info: $h-highlight-color
 $progress-bar-background-color: #444444
 $progress-border-radius: $box-radius
 


### PR DESCRIPTION
**Description**:

1 line change to remove unused SCSS definition clashing with upcoming use of CSS variables for theming.

**Notes for reviewer**:

Branch can be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
