### PR TITLE
00102 Remove about dialog and show build date in Footer

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -34,11 +34,14 @@
         <img alt="Built On Hedera" src="@/assets/built-on-hedera-white.svg" style="min-width: 104px;">
       </a>
 
-      <span v-if="!isTouchDevice && isSmallScreen"
-            class="h-is-property-text ml-5 pb-1"
-            style="font-weight:300; color: #DBDBDB">
-        {{ productName }} is a ledger explorer for the Hedera network.
-      </span>
+      <div v-if="!isTouchDevice && isSmallScreen" class="is-flex is-flex-direction-column is-align-items-flex-start">
+        <span class="h-is-property-text ml-5 pb-1" style="font-weight:300; color: #DBDBDB">
+          {{ productName }} is a ledger explorer for the Hedera network.
+        </span>
+        <span class="h-is-text-size-1 ml-5 pb-1" style="font-weight:300; color: #DBDBDB">
+          Built {{ buildTime }}
+        </span>
+      </div>
 
       <span class="is-flex-grow-1"/>
 
@@ -73,6 +76,8 @@ export default defineComponent({
   },
 
   setup() {
+    const buildTime = inject('buildTime', "not available")
+
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
@@ -80,6 +85,7 @@ export default defineComponent({
     const sponsorURL = process.env.VUE_APP_SPONSOR_URL ?? ""
 
     return {
+      buildTime,
       isSmallScreen,
       isTouchDevice,
       productName,

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -24,18 +24,11 @@
 
 <template>
 
-  <ModalDialog v-model:show-dialog="showErrorDialog" :iconClass="'fa fa-2x fa-info has-text-info'">
-    <template v-slot:dialogMessage>{{ productName }} is a ledger explorer for the Hedera network</template>
-    <template v-slot:dialogDetails>
-      <div>Build date: {{ buildTime }}</div>
-    </template>
-  </ModalDialog>
-
   <div v-if="!isMediumScreen"
        class="is-flex is-align-items-center is-justify-content-space-between pt-3 pb-4">
 
     <span class="is-inline-flex is-align-items-center is-flex-grow-0 is-flex-shrink-0">
-      <a class="mr-3" @click="showErrorDialog=true">
+      <a class="mr-3" @click="$router.push({name: 'MainDashboard'})">
         <img alt="Product Logo" class="image" src="@/assets/branding/brand-product-logo.png" style="max-width: 165px;">
       </a>
       <AxiosStatus/>
@@ -60,7 +53,7 @@
 
   <div v-else class="is-flex is-justify-content-space-between is-align-items-flex-end">
     <span class="is-inline-flex is-align-items-center is-flex-grow-0 is-flex-shrink-0">
-      <a id="product-logo" @click="showErrorDialog = true" class="mr-3">
+      <a id="product-logo" @click="$router.push({name: 'MainDashboard'})" class="mr-3">
         <img alt="Product Logo" class="image" src="@/assets/branding/brand-product-logo.png">
       </a>
       <AxiosStatus/>
@@ -128,11 +121,10 @@ import router from "@/router";
 import SearchBar from "@/components/SearchBar.vue";
 import AxiosStatus from "@/components/AxiosStatus.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import ModalDialog from "@/components/ModalDialog.vue";
 
 export default defineComponent({
   name: "TopNavBar",
-  components: {ModalDialog, AxiosStatus, SearchBar},
+  components: {AxiosStatus, SearchBar},
 
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)
@@ -142,8 +134,6 @@ export default defineComponent({
 
     const productName = process.env.VUE_APP_PRODUCT_NAME ?? "Hedera Mirror Node Explorer"
     const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
-
-    const showErrorDialog = ref(false)
 
     const route = useRoute()
     const network = computed( () => { return route.params.network })
@@ -212,7 +202,6 @@ export default defineComponent({
       buildTime,
       productName,
       isStakingEnabled,
-      showErrorDialog,
       name,
       showTopRightLogo,
       isMobileMenuOpen,

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -95,8 +95,6 @@ describe("App.vue", () => {
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
         expect(navBar.text()).toBe(
-            "Hedera Mirror Node Explorer is a ledger explorer for the Hedera network" +
-            "Build date: not available" +
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccountsNodes")
 
         expect(wrapper.findComponent(HbarMarketDashboard).exists()).toBe(true)

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -70,8 +70,6 @@ describe("TopNavBar.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe(
-            "Hedera Mirror Node Explorer is a ledger explorer for the Hedera network" +
-            "Build date: not available" +
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccountsNodes")
 
         const links = wrapper.findAll("a")


### PR DESCRIPTION
**Description**:

The build date is now shown in the Footer and a click on the top left product logo navigates to the MainDashboard page (as it used to do prior to the "about" dialog).

**Related issue(s)**:

Fixes #102

**Notes for reviewer**:

This branch may be squashed-merged and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
