### PR TITLE
00073 node info with staking

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
 ### When set to 'true', this variable will enable the 'Staking' page
-VUE_APP_ENABLE_STAKING=true
+VUE_APP_ENABLE_STAKING=false
 
 ### When set, these variables will cause the insertion of a custom menu item
 ### in the network selector pull-down menu of the TopNavBar

--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
 ### When set to 'true', this variable will enable the 'Staking' page
-VUE_APP_ENABLE_STAKING=false
+VUE_APP_ENABLE_STAKING=true
 
 ### When set, these variables will cause the insertion of a custom menu item
 ### in the network selector pull-down menu of the TopNavBar

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -58,6 +58,29 @@
         </div>
       </o-table-column>
 
+      <div v-if="isStakingEnabled">
+        <o-table-column v-slot="props" field="stake" label="Stake" position="right">
+          <HbarAmount :amount="props.row.stake" :decimals="0"/>
+          <span>{{ ' (' + makeStakePercentage(props.row) + '%)' }}</span>
+        </o-table-column>
+
+        <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
+          <HbarAmount :amount="props.row.stake_not_rewarded" :decimals="0"/>
+        </o-table-column>
+
+<!--        <o-table-column field="stake_range" label="Stake Range">-->
+<!--          <div class="is-flex-direction-column h-is-stake-range-bar">-->
+<!--            <progress id="range" class="progress is-large is-info h-is-progress-bar" max="100"-->
+<!--                      style="max-height: 8px; margin-bottom: 1px;" :value="45"></progress>-->
+<!--            <div class="is-flex is-justify-content-space-between">-->
+<!--              <img alt="Minimum staking mark" class="image" src="@/assets/min-mark.png"-->
+<!--                   style="max-height: 8px; margin-left: 16px">-->
+<!--              <img alt="Maximum staking mark" class="image" src="@/assets/max-mark.png" style="max-height: 8px">-->
+<!--            </div>-->
+<!--          </div>-->
+<!--        </o-table-column>-->
+
+      </div>
     </o-table>
   </div>
 
@@ -76,8 +99,9 @@ import {NetworkNode} from "@/schemas/HederaSchemas";
 import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
-import router from "@/router";
 import {operatorRegistry} from "@/schemas/OperatorRegistry";
+import HbarAmount from "@/components/values/HbarAmount.vue";
+import router from "@/router";
 
 
 //
@@ -87,28 +111,36 @@ import {operatorRegistry} from "@/schemas/OperatorRegistry";
 export default defineComponent({
   name: 'NodeTable',
 
-  components: {EmptyTable, BlobValue},
+  components: {HbarAmount, EmptyTable, BlobValue},
 
   props: {
     nodes: Object as PropType<Array<NetworkNode> | undefined>,
+    totalStaked: Number
   },
 
-  setup() {
+  setup(props) {
+    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
+
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
     const makeHost = (node: NetworkNode) => node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.name : null
     const makeLocation = (node: NetworkNode) => node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.location : null
+    const makeStakePercentage = (node: NetworkNode) => {
+      return node.stake && props.totalStaked ? node.stake / props.totalStaked : 0
+    }
 
-    const handleClick = (n: NetworkNode) => {
-      router.push({name: 'NodeDetails', params: {nodeId: n.node_id}})
+    const handleClick = (node: NetworkNode) => {
+      router.push({name: 'NodeDetails', params: {nodeId: node.node_id}})
     }
 
     return {
+      isStakingEnabled,
       isTouchDevice,
       isMediumScreen,
       makeHost,
       makeLocation,
+      makeStakePercentage,
       handleClick,
       ORUGA_MOBILE_BREAKPOINT
     }

--- a/src/components/values/HbarAmount.vue
+++ b/src/components/values/HbarAmount.vue
@@ -56,6 +56,10 @@ export default defineComponent({
       type: Number,
       default: 0
     },
+    decimals: {
+      type: Number,
+      default: 8
+    },
     showExtra: {
       type: Boolean,
       default: false
@@ -79,7 +83,7 @@ export default defineComponent({
       return props.amount / 100000000
     })
     const formattedAmount = computed(() => {
-      return hbarAmount.value.toFixed(8)
+      return hbarAmount.value.toFixed(props.decimals)
     })
 
     const isGrey = computed(() => {

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -40,7 +40,12 @@ export interface AccountInfo {
     memo: string | undefined
     receiver_sig_required: boolean
     alias: string | null | undefined  // RFC4648 no-padding base32 encoded account alias
-    evm_address: string | null | undefined
+    ethereum_nonce: number | null
+    evm_address: string | null // A network entity encoded as an EVM address in hex.
+    decline_reward: boolean
+    staked_account_id: string | null
+    staked_node_id: number | null
+    stake_period_start : string | null
 }
 
 export interface AccountBalanceTransactions extends AccountInfo {
@@ -440,6 +445,12 @@ export interface NetworkNode {
     public_key: string | null | undefined   // hex encoded X509 RSA public key used to sign stream files
     service_endpoints: [ServiceEndPoint] | undefined
     timestamp: TimestampRange | undefined
+    max_stake: number | null // The maximum stake (rewarded or not rewarded) this node can have as consensus weight
+    min_stake: number | null // The minimum stake (rewarded or not rewarded) this node must reach before having non-zero consensus weight
+    stake: number | null // The node consensus weight at the beginning of the staking period
+    stake_not_rewarded: number | null // The sum (balance + stakedToMe) for all accounts staked to this node with declineReward=true at the beginning of the staking period
+    stake_rewarded: number | null // The sum (balance + staked) for all accounts staked to the node that are not declining rewards at the beginning of the staking period
+    staking_period: TimestampRange | null
 }
 
 export interface ServiceEndPoint {

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -974,7 +974,13 @@ export const SAMPLE_NETWORK_NODES = {
             "timestamp": {
                 "from": "1654531806.041135961",
                 "to": null
-            }
+            },
+            "max_stake":         1000000000000000,
+            "min_stake":          100000000000000,
+            "stake":              600000000000000,
+            "stake_not_rewarded": 100000000000000,
+            "stake_rewarded":     500000000000000,
+            "staking_period": null
         },
         {
             "description": "",
@@ -996,7 +1002,13 @@ export const SAMPLE_NETWORK_NODES = {
             "timestamp": {
                 "from": "1654531806.041135961",
                 "to": null
-            }
+            },
+            "max_stake":         2000000000000000,
+            "min_stake":          100000000000000,
+            "stake":              900000000000000,
+            "stake_not_rewarded": 200000000000000,
+            "stake_rewarded":     700000000000000,
+            "staking_period": null
         },
         {
             "description": "",
@@ -1018,7 +1030,13 @@ export const SAMPLE_NETWORK_NODES = {
             "timestamp": {
                 "from": "1654531806.041135961",
                 "to": null
-            }
+            },
+            "max_stake":         3000000000000000,
+            "min_stake":          100000000000000,
+            "stake":              900000000000000,
+            "stake_not_rewarded": 200000000000000,
+            "stake_rewarded":     700000000000000,
+            "staking_period": null
         }
     ],
 }

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -53,14 +53,21 @@ describe("NodeTable.vue", () => {
 
     it("should list the 3 nodes in the table", async () => {
 
+        process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: true });
+
         await router.push("/") // To avoid "missing required param 'network'" error
 
+        let testTotalStaked = 0
+        for (let node of SAMPLE_NETWORK_NODES.nodes) {
+            testTotalStaked += node.stake
+        }
         const wrapper = mount(NodeTable, {
             global: {
                 plugins: [router, Oruga]
             },
             props: {
-                nodes: SAMPLE_NETWORK_NODES.nodes as Array<NetworkNode>
+                nodes: SAMPLE_NETWORK_NODES.nodes as Array<NetworkNode>,
+                totalStaked: testTotalStaked
             }
         });
 
@@ -68,12 +75,12 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location")
+        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" +
-            "1" + "0.0.4" + "testnet" + "None"+
-            "2" + "0.0.5" + "testnet" + "None"
+            "0" + "0.0.3" + "testnet" + "None" + "6000000 (0.25%)" + "1000000" +
+            "1" + "0.0.4" + "testnet" + "None" + "9000000 (0.375%)" + "2000000" +
+            "2" + "0.0.5" + "testnet" + "None" + "9000000 (0.375%)" + "2000000"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -57,6 +57,8 @@ describe("Nodes.vue", () => {
 
     it("should display the nodes pages containing the node table", async () => {
 
+        process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: true });
+
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios);
@@ -78,17 +80,17 @@ describe("Nodes.vue", () => {
 
         expect(cards[0].text()).toMatch(RegExp("^Network"))
         const items = cards[0].findAllComponents(NetworkDashboardItem)
-        expect(items.length).toBe(1)
+        expect(items.length).toBe(6)
         expect(items[0].text()).toMatch(RegExp("Total Nodes"))
 
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Account Hosted By Location")
+        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" +
-            "1" + "0.0.4" + "testnet" + "None" +
-            "2" + "0.0.5" + "testnet" + "None"
+            "0" + "0.0.3" + "testnet" + "None" + "6000000 (0.25%)" + "1000000" +
+            "1" + "0.0.4" + "testnet" + "None" + "9000000 (0.375%)" + "2000000" +
+            "2" + "0.0.5" + "testnet" + "None" + "9000000 (0.375%)" + "2000000"
         )
     });
 


### PR DESCRIPTION
**Description**:

First pass at adding staking information to the Nodes and NodeDetails pages.
Display of this information in deployment is currently prevented by leaving the environment variable  VUE_APP_ENABLE_STAKING=false.

The "Stake Range" progress bar is not yet implemented, current attempts to use the default HTML progress bar being unsuccessful so far.

**Related issue(s)**:

Partial implementation of #73

**Notes for reviewer**:

This PR is currently deployed on staging, otherwise pull it and set VUE_APP_ENABLE_STAKING=true

Branch can be squashed-merged.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
