### PR TITLE
120 - Add staking information in AccountDetails.

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -89,35 +89,37 @@
         <div class="columns h-is-property-text">
 
           <div class="column">
-            <Property v-if="account?.staked_account_id" :id="'stakedAccount'">
-              <template v-slot:name>Staked Account</template>
-              <template v-slot:value>
-                <AccountLink :accountId="account.staked_account_id" v-bind:show-extra="true"/>
-              </template>
-            </Property>
-            <Property v-else :id="'stakedNode'">
-              <template v-slot:name>Staked to</template>
-              <template v-slot:value>
-                <div v-if="account?.staked_node_id != null">
-                  <router-link :to="{name: 'NodeDetails', params: {nodeId: account?.staked_node_id}}">
-                    {{ stakedNodeDescription ?? "Node " +  account.staked_node_id}}
-                  </router-link>
-                </div>
-                <span v-else class="has-text-grey">None</span>
-              </template>
-            </Property>
-            <Property :id="'stakePeriodStart'">
-              <template v-slot:name>Stake Period Started</template>
-              <template v-slot:value>
-                <TimestampValue :timestamp="account?.stake_period_start" :show-none="true"/>
-              </template>
-            </Property>
-            <Property :id="'declineReward'" >
-              <template v-slot:name>Decline Reward</template>
-              <template v-slot:value>
-                <StringValue :string-value="account?.decline_reward?.toString()"/>
-              </template>
-            </Property>
+            <div v-if="isStakingEnabled">
+              <Property v-if="account?.staked_account_id" :id="'stakedAccount'">
+                <template v-slot:name>Staked Account</template>
+                <template v-slot:value>
+                  <AccountLink :accountId="account.staked_account_id" v-bind:show-extra="true"/>
+                </template>
+              </Property>
+              <Property v-else :id="'stakedNode'">
+                <template v-slot:name>Staked to</template>
+                <template v-slot:value>
+                  <div v-if="account?.staked_node_id != null">
+                    <router-link :to="{name: 'NodeDetails', params: {nodeId: account?.staked_node_id}}">
+                      {{ stakedNodeDescription ?? "Node " +  account.staked_node_id}}
+                    </router-link>
+                  </div>
+                  <span v-else class="has-text-grey">None</span>
+                </template>
+              </Property>
+              <Property :id="'stakePeriodStart'">
+                <template v-slot:name>Stake Period Started</template>
+                <template v-slot:value>
+                  <TimestampValue :timestamp="account?.stake_period_start" :show-none="true"/>
+                </template>
+              </Property>
+              <Property :id="'declineReward'" >
+                <template v-slot:name>Decline Reward</template>
+                <template v-slot:value>
+                  <StringValue :string-value="account?.decline_reward?.toString()"/>
+                </template>
+              </Property>
+            </div>
             <Property :id="'memo'">
               <template v-slot:name>Memo</template>
               <template v-slot:value>
@@ -136,21 +138,37 @@
                 <DurationValue v-bind:number-value="account?.auto_renew_period"/>
               </template>
             </Property>
-          </div>
+            <div v-if="!isStakingEnabled">
+              <Property :id="'maxAutoAssociation'">
+                <template v-slot:name>Max. Auto. Association</template>
+                <template v-slot:value>
+                  <StringValue :string-value="account?.max_automatic_token_associations?.toString()"/>
+                </template>
+              </Property>
+              <Property :id="'receiverSigRequired'">
+                <template v-slot:name>Receiver Sig. Required</template>
+                <template v-slot:value>
+                  <StringValue :string-value="account?.receiver_sig_required?.toString()"/>
+                </template>
+              </Property>
+            </div>
+            </div>
 
           <div class="column">
-            <Property :id="'maxAutoAssociation'">
-              <template v-slot:name>Max. Auto. Association</template>
-              <template v-slot:value>
-                <StringValue :string-value="account?.max_automatic_token_associations?.toString()"/>
-              </template>
-            </Property>
-            <Property :id="'receiverSigRequired'">
-              <template v-slot:name>Receiver Sig. Required</template>
-              <template v-slot:value>
-                <StringValue :string-value="account?.receiver_sig_required?.toString()"/>
-              </template>
-            </Property>
+            <div v-if="isStakingEnabled">
+              <Property :id="'maxAutoAssociation'">
+                <template v-slot:name>Max. Auto. Association</template>
+                <template v-slot:value>
+                  <StringValue :string-value="account?.max_automatic_token_associations?.toString()"/>
+                </template>
+              </Property>
+              <Property :id="'receiverSigRequired'">
+                <template v-slot:name>Receiver Sig. Required</template>
+                <template v-slot:value>
+                  <StringValue :string-value="account?.receiver_sig_required?.toString()"/>
+                </template>
+              </Property>
+            </div>
             <Property :id="'key'">
               <template v-slot:name>Key</template>
               <template v-slot:value>
@@ -258,6 +276,8 @@ export default defineComponent({
   },
 
   setup(props) {
+    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
+
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
@@ -486,6 +506,7 @@ export default defineComponent({
     }
 
     return {
+      isStakingEnabled,
       isSmallScreen,
       isTouchDevice,
       transactions: transactionCache.transactions,

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -192,7 +192,6 @@ export default defineComponent({
         endTimeInSec = null
       }
       stakingPeriod.value = new StakingPeriod(startTimeInSec, endTimeInSec)
-      console.log("Period duration:" + stakingPeriod.value.durationMin)
     }
 
     return {

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -42,10 +42,13 @@ export interface AccountInfo {
     alias: string | null | undefined  // RFC4648 no-padding base32 encoded account alias
     ethereum_nonce: number | null
     evm_address: string | null // A network entity encoded as an EVM address in hex.
-    decline_reward: boolean
-    staked_account_id: string | null
-    staked_node_id: number | null
-    stake_period_start : string | null
+    decline_reward: boolean | null      // Whether the account declines receiving a staking reward
+    staked_account_id: string | null    // The account to which this account is staking
+    staked_node_id: number | null       // The id of the node to which this account is staking
+    stake_period_start : string | null  // The staking period during which either the staking settings for this account
+                                        // changed (such as starting staking or changing stakedNode) or the most recent
+                                        // reward was earned, whichever is later. If this account is not currently
+                                        // staked to a node, then the value is null
 }
 
 export interface AccountBalanceTransactions extends AccountInfo {

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -654,7 +654,13 @@ export const SAMPLE_ACCOUNT = {
         },
     "max_automatic_token_associations": 0,
     "memo": "",
-    "receiver_sig_required": false
+    "receiver_sig_required": false,
+    "evm_address": null,
+    "ethereum_nonce": null,
+    "decline_reward": null,
+    "staked_node_id": null,
+    "staked_account_id": null,
+    "stake_period_start" : null
 }
 
 //
@@ -681,6 +687,58 @@ export const SAMPLE_ACCOUNT_DUDE = {
     "max_automatic_token_associations": 10,
     "memo": "Account Dude Memo in clear",
     "receiver_sig_required": true,
+    "evm_address": null,
+    "ethereum_nonce": null,
+    "decline_reward": null,
+    "staked_node_id": null,
+    "staked_account_id": null,
+    "stake_period_start" : null
+}
+
+export const SAMPLE_ACCOUNT_STAKING_NODE = {
+    "account": "0.0.730632",
+    "alias": null,
+    "auto_renew_period": 6666000,
+    "balance": {
+        "balance": 31669471,
+        "timestamp": "1648548001.410978000",
+        "tokens": []
+    },
+    "deleted": false,
+    "expiry_timestamp": "1649648001.410978000",
+    "key": {"_type": "ED25519", "key": "38f1ea460e95d97eea13aefac760eaf990154b80a3608ab01d4a264944d68746"},
+    "max_automatic_token_associations": 10,
+    "memo": "Account staking to account",
+    "receiver_sig_required": true,
+    "evm_address": null,
+    "ethereum_nonce": null,
+    "decline_reward": false,
+    "staked_node_id": 1,
+    "staked_account_id": null,
+    "stake_period_start" : "1646333100.356842286"
+}
+
+export const SAMPLE_ACCOUNT_STAKING_ACCOUNT = {
+    "account": "0.0.730632",
+    "alias": null,
+    "auto_renew_period": 6666000,
+    "balance": {
+        "balance": 31669471,
+        "timestamp": "1648548001.410978000",
+        "tokens": []
+    },
+    "deleted": false,
+    "expiry_timestamp": "1649648001.410978000",
+    "key": {"_type": "ED25519", "key": "38f1ea460e95d97eea13aefac760eaf990154b80a3608ab01d4a264944d68746"},
+    "max_automatic_token_associations": 10,
+    "memo": "Account staking to account",
+    "receiver_sig_required": true,
+    "evm_address": null,
+    "ethereum_nonce": null,
+    "decline_reward": true,
+    "staked_node_id": null,
+    "staked_account_id": "0.0.5",
+    "stake_period_start" : "1646333100.356842286"
 }
 
 export const SAMPLE_ACCOUNTS = {
@@ -705,6 +763,17 @@ export const SAMPLE_ACCOUNT_BALANCES = {
                     "balance": 1
                 }
             ]
+        }
+    ]
+}
+
+export const SAMPLE_ACCOUNT_HBAR_BALANCE = {
+    "timestamp": "1646728200.821070000",
+    "balances": [
+        {
+            "account": "0.0.730631",
+            "balance": 2342647909,
+            "tokens": []
         }
     ]
 }

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -26,6 +26,11 @@ import {
     SAMPLE_ACCOUNT,
     SAMPLE_ACCOUNT_BALANCES, SAMPLE_ACCOUNT_DUDE,
     SAMPLE_COINGECKO,
+    SAMPLE_ACCOUNT_HBAR_BALANCE,
+    SAMPLE_ACCOUNT_STAKING_ACCOUNT,
+    SAMPLE_ACCOUNT_STAKING_NODE,
+    SAMPLE_FAILED_TRANSACTIONS,
+    SAMPLE_NETWORK_NODES,
     SAMPLE_NONFUNGIBLE,
     SAMPLE_TOKEN, SAMPLE_TOKEN_DUDE,
     SAMPLE_TRANSACTIONS
@@ -212,5 +217,83 @@ describe("AccountDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.get("#notificationBanner").text()).toBe("Invalid account ID: " + invalidAccountId)
+    });
+
+    it("Should display account staking to node", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_NODE.account
+        mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT_STAKING_NODE);
+
+        const matcher2 = "/api/v1/transactions"
+        mock.onGet(matcher2).reply(200, SAMPLE_FAILED_TRANSACTIONS);
+
+        const matcher3 = "/api/v1/network/nodes"
+        mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
+
+        const matcher4 = "/api/v1/balances"
+        mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT_HBAR_BALANCE);
+
+        const matcher5 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher5).reply(200, SAMPLE_COINGECKO);
+
+        const wrapper = mount(AccountDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                accountId: SAMPLE_ACCOUNT_STAKING_NODE.account ?? undefined
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(wrapper.get("#stakedNodeValue").text()).toBe("Node 0 - testnet")
+        expect(wrapper.find("#stakedAccount").exists()).toBe(false)
+        expect(wrapper.get("#stakePeriodStartValue").text()).toBe("6:45:00.3568 PMMar 3, 2022")
+        expect(wrapper.get("#declineRewardValue").text()).toBe("false")
+    });
+
+    it("Should display account staking to account", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_ACCOUNT.account
+        mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT_STAKING_ACCOUNT);
+
+        const matcher2 = "/api/v1/transactions"
+        mock.onGet(matcher2).reply(200, SAMPLE_FAILED_TRANSACTIONS);
+
+        const matcher3 = "/api/v1/network/nodes"
+        mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
+
+        const matcher4 = "/api/v1/balances"
+        mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT_HBAR_BALANCE);
+
+        const matcher5 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher5).reply(200, SAMPLE_COINGECKO);
+
+        const wrapper = mount(AccountDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                accountId: SAMPLE_ACCOUNT_STAKING_NODE.account ?? undefined
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(wrapper.get("#stakedAccountValue").text()).toBe("0.0.5Node 2 - testnet")
+        expect(wrapper.find("#stakedNodeValue").exists()).toBe(false)
+        expect(wrapper.get("#stakePeriodStartValue").text()).toBe("6:45:00.3568 PMMar 3, 2022")
+        expect(wrapper.get("#declineRewardValue").text()).toBe("true")
     });
 });

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -221,6 +221,7 @@ describe("AccountDetails.vue", () => {
 
     it("Should display account staking to node", async () => {
 
+        process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: true });
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios);
@@ -260,6 +261,7 @@ describe("AccountDetails.vue", () => {
 
     it("Should display account staking to account", async () => {
 
+        process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: true });
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios);


### PR DESCRIPTION
**Description**:

Add additional info to the AccountDetails page:

- Account or Node staked to
- Start of stake period
- Decline Reward

The current approach is to always show these fields (hence displaying None when they are null). A slight shuffling of the properties is also done to balance them between the 2 columns.
As usual, it may be arguable to completely hide these 3 properties when there is no staking for the account.

**Related issue(s)**:

Fixes #120 

**Notes for reviewer**:

These properties are currently only exercised by unit tests, since preview and testnet always return null staking info.
Branch may be squashed-merged and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
