### PR TITLE
Activate staking information on Nodes and NodeDetails page.

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -58,7 +58,6 @@
         </div>
       </o-table-column>
 
-      <div v-if="isStakingEnabled">
         <o-table-column v-slot="props" field="stake" label="Stake" position="right">
           <HbarAmount :amount="props.row.stake" :decimals="0"/>
           <span>{{ ' (' + makeStakePercentage(props.row) + '%)' }}</span>
@@ -80,7 +79,6 @@
 <!--          </div>-->
 <!--        </o-table-column>-->
 
-      </div>
     </o-table>
   </div>
 
@@ -119,8 +117,6 @@ export default defineComponent({
   },
 
   setup(props) {
-    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
-
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
@@ -135,7 +131,6 @@ export default defineComponent({
     }
 
     return {
-      isStakingEnabled,
       isTouchDevice,
       isMediumScreen,
       makeHost,

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -89,8 +89,7 @@
             </Property>
           </div>
 
-          <div class="column" :class="{'h-has-column-separator': isStakingEnabled}">
-            <div v-if="isStakingEnabled">
+          <div class="column h-has-column-separator">
               <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="totalStaked.toString()"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
               <br/><br/>
@@ -100,7 +99,6 @@
               <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>
               <p class="h-is-property-text h-is-extra-text mt-1">from 00:00 am today to 11:59 pm today UTC</p>
               <div class="mt-6"/>
-            </div>
           </div>
 
         </div>
@@ -167,8 +165,6 @@ export default defineComponent({
   },
 
   setup(props) {
-    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
-
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
     let nodes = ref<Array<NetworkNode> | null>([])
@@ -255,7 +251,6 @@ export default defineComponent({
     }
 
     return {
-      isStakingEnabled,
       isSmallScreen,
       isTouchDevice,
       node,

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -32,7 +32,6 @@
       </template>
       <template v-slot:table>
 
-        <div v-if="isStakingEnabled">
           <div v-if="isSmallScreen" class="is-flex is-justify-content-space-between">
             <div class="is-flex-direction-column">
               <NetworkDashboardItem :title="'Total Nodes'" :value="totalNodes"/>
@@ -66,20 +65,6 @@
               <div class="mt-6"/>
             </div>
           </div>
-        </div>
-        <div v-else>
-          <div v-if="isSmallScreen" class="is-flex is-justify-content-space-between">
-            <div class="is-flex-direction-column">
-              <NetworkDashboardItem :title="'Total Nodes'" :value="totalNodes"/>
-            </div>
-          </div>
-          <div v-else>
-            <div class="is-flex-direction-column">
-              <NetworkDashboardItem :title="'Total Nodes'" :value="totalNodes"/>
-              <div class="mt-6"/>
-            </div>
-          </div>
-        </div>
 
       </template>
     </DashboardCard>
@@ -130,8 +115,6 @@ export default defineComponent({
   },
 
   setup() {
-    const isStakingEnabled = process.env.VUE_APP_ENABLE_STAKING === 'true'
-
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
@@ -195,7 +178,6 @@ export default defineComponent({
     }
 
     return {
-      isStakingEnabled,
       isSmallScreen,
       isTouchDevice,
       nodes,


### PR DESCRIPTION
*Description**:

With these trivial changes, the display of information related to staking in the Nodes and NodeDetails page is no longer subject to the environment variable VUE_APP_ENABLE_STAKING being set to true.

**Notes for reviewer**:

This branch may be squashed-merged and then deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
