### PR TITLE
00138 Fix bugs and number of decimals shown in Node staking info.

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -59,8 +59,8 @@
       </o-table-column>
 
         <o-table-column v-slot="props" field="stake" label="Stake" position="right">
-          <HbarAmount :amount="props.row.stake" :decimals="0"/>
-          <span>{{ ' (' + makeStakePercentage(props.row) + '%)' }}</span>
+            <HbarAmount :amount="props.row.stake ?? 0" :decimals="0"/>
+            <span class="ml-1">{{ '(' + makeStakePercentage(props.row) + '%)' }}</span>
         </o-table-column>
 
         <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
@@ -123,7 +123,7 @@ export default defineComponent({
     const makeHost = (node: NetworkNode) => node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.name : null
     const makeLocation = (node: NetworkNode) => node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.location : null
     const makeStakePercentage = (node: NetworkNode) => {
-      return node.stake && props.totalStaked ? node.stake / props.totalStaked : 0
+      return node.stake && props.totalStaked ? Math.round(node.stake / props.totalStaked * 1000) / 10 : 0
     }
 
     const handleClick = (node: NetworkNode) => {

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -90,11 +90,11 @@
           </div>
 
           <div class="column h-has-column-separator">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="totalStaked.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toString()"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="totalRewarded.toString()"/>
-              <p class="h-is-property-text h-is-extra-text mt-1">{{ rewardPercentage }}% of total</p>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="stakeRewarded.toString()"/>
+              <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>
               <p class="h-is-property-text h-is-extra-text mt-1">from 00:00 am today to 11:59 pm today UTC</p>
@@ -167,17 +167,18 @@ export default defineComponent({
   setup(props) {
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
-    let nodes = ref<Array<NetworkNode> | null>([])
+    const nodes = ref<Array<NetworkNode> | null>([])
     const node = ref<NetworkNode | null>(null)
 
-    const totalStaked = ref(0)
-    const totalRewarded = ref(0)
+    const stake = computed(() => node.value?.stake ? Math.round(node.value.stake / 100000000) : 0)
+    const stakeTotal = ref(0)
     const stakePercentage = computed(() =>
-      node.value?.stake && totalStaked.value ? node.value.stake / totalStaked.value : 0
-    )
-    const rewardPercentage = computed(() =>
-        node.value?.stake_rewarded && totalRewarded.value ? node.value.stake_rewarded / totalRewarded.value : 0
-    )
+        stakeTotal.value ? Math.round(stake.value / stakeTotal.value * 10000) / 100 : 0)
+
+    const stakeRewarded = computed(() => node.value?.stake_rewarded ? Math.round(node.value.stake_rewarded / 100000000) : 0)
+    const stakeRewardedTotal = ref(0)
+    const stakeRewardedPercentage = computed(() =>
+        stakeRewardedTotal.value ? Math.round(stakeRewarded.value / stakeRewardedTotal.value * 10000) / 100 : 0)
 
     const unknownNodeId = ref(false)
     const notification = computed(() => {
@@ -216,10 +217,10 @@ export default defineComponent({
               for (const n of result.data.nodes) {
 
                 if (n.stake) {
-                  totalStaked.value += n.stake
+                  stakeTotal.value += n.stake/100000000
                 }
                 if (n.stake_rewarded) {
-                  totalRewarded.value += n.stake_rewarded
+                  stakeRewardedTotal.value += n.stake_rewarded/100000000
                 }
               }
             }
@@ -254,10 +255,10 @@ export default defineComponent({
       isSmallScreen,
       isTouchDevice,
       node,
-      totalStaked,
-      totalRewarded,
+      stake,
       stakePercentage,
-      rewardPercentage,
+      stakeRewarded,
+      stakeRewardedPercentage,
       notification,
       nodeDescription,
       formatHash

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -78,9 +78,9 @@ describe("NodeTable.vue", () => {
         expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6000000 (0.25%)" + "1000000" +
-            "1" + "0.0.4" + "testnet" + "None" + "9000000 (0.375%)" + "2000000" +
-            "2" + "0.0.5" + "testnet" + "None" + "9000000 (0.375%)" + "2000000"
+            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" +
+            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" +
+            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -88,9 +88,9 @@ describe("Nodes.vue", () => {
         expect(table.exists()).toBe(true)
         expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6000000 (0.25%)" + "1000000" +
-            "1" + "0.0.4" + "testnet" + "None" + "9000000 (0.375%)" + "2000000" +
-            "2" + "0.0.5" + "testnet" + "None" + "9000000 (0.375%)" + "2000000"
+            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" +
+            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" +
+            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000"
         )
     });
 


### PR DESCRIPTION
**Description**:

This PR fixes various issues in the display of data related to Node staking:
 - number of decimals of percentages
 - actually show percentages instead of ratios
 - fix confusion between the values for one node and the totals for all nodes.
 
**Related issue(s)**:

Fixes #138 

**Notes for reviewer**:

PreviewNet now shows certains Nodes which are staked. The numbers do not make any sense without the fixes...

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
