### PR TITLE
000142 last reward rate

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -64,8 +64,12 @@
         </o-table-column>
 
         <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
-          <HbarAmount :amount="props.row.stake_not_rewarded" :decimals="0"/>
+          <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
         </o-table-column>
+
+      <o-table-column v-slot="props" field="last_reward_rate" label="Last Reward Rate" position="right">
+        {{ makeApproxYearlyRate(props.row) }}
+      </o-table-column>
 
 <!--        <o-table-column field="stake_range" label="Stake Range">-->
 <!--          <div class="is-flex-direction-column h-is-stake-range-bar">-->
@@ -125,6 +129,13 @@ export default defineComponent({
     const makeStakePercentage = (node: NetworkNode) => {
       return node.stake && props.totalHbarStaked ? Math.round(node.stake / props.totalHbarStaked / 100000) / 10 : 0
     }
+    const makeApproxYearlyRate = (node: NetworkNode) => {
+      const formatter = new Intl.NumberFormat("en-US", {
+        style: 'percent',
+        maximumFractionDigits: 2
+      })
+      return formatter.format(node.reward_rate_start ? node.reward_rate_start * 365 : 0);
+    }
 
     const handleClick = (node: NetworkNode) => {
       router.push({name: 'NodeDetails', params: {nodeId: node.node_id}})
@@ -136,6 +147,7 @@ export default defineComponent({
       makeHost,
       makeLocation,
       makeStakePercentage,
+      makeApproxYearlyRate,
       handleClick,
       ORUGA_MOBILE_BREAKPOINT
     }

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -400,9 +400,9 @@ export default defineComponent({
           if (balanceCache.balanceTimeStamp.value) {
             const duration = Duration.decompose(new Date().getTime() / 1000 - Number.parseFloat(balanceCache.balanceTimeStamp.value))
             if (duration.minutes >= 2) {
-              result = duration.minutes + " minutes"
+              result = duration.minutes + "min"
             } else if (duration.minutes == 1) {
-              result = "1 minute"
+              result = "1min"
             } else {
               result = "just moments"
             }

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -90,6 +90,9 @@
           </div>
 
           <div class="column h-has-column-separator">
+              <NetworkDashboardItem :name="'APPROX YEARLY EQUIVALENT'" :title="'Last Period Reward Rate'"
+                                    :value="approxYearlyRate.toString()"/>
+              <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toString()"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
               <br/><br/>
@@ -170,6 +173,13 @@ export default defineComponent({
     const nodes = ref<Array<NetworkNode> | null>([])
     const node = ref<NetworkNode | null>(null)
 
+    const approxYearlyRate = computed(() => {
+      const formatter = new Intl.NumberFormat("en-US", {
+        style: 'percent',
+        maximumFractionDigits: 2
+      })
+      return formatter.format(node.value?.reward_rate_start ? node.value.reward_rate_start * 365 : 0);
+    })
     const stake = computed(() => node.value?.stake ? Math.round(node.value.stake / 100000000) : 0)
     const stakeTotal = ref(0)
     const stakePercentage = computed(() =>
@@ -258,6 +268,7 @@ export default defineComponent({
       isSmallScreen,
       isTouchDevice,
       node,
+      approxYearlyRate,
       stake,
       stakePercentage,
       stakeRewarded,

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -454,6 +454,8 @@ export interface NetworkNode {
     stake_not_rewarded: number | null // The sum (balance + stakedToMe) for all accounts staked to this node with declineReward=true at the beginning of the staking period
     stake_rewarded: number | null // The sum (balance + staked) for all accounts staked to the node that are not declining rewards at the beginning of the staking period
     staking_period: TimestampRange | null
+    reward_rate_start: number | null
+    stake_total: number | null
 }
 
 export interface ServiceEndPoint {

--- a/src/utils/Duration.ts
+++ b/src/utils/Duration.ts
@@ -58,28 +58,25 @@ export function formatSeconds(secondCount: number|string|undefined): string {
             const duration = Duration.decompose(seconds)
             result = ""
             if (duration.days >= 2) {
-                result += duration.days + " days "
+                const dayUnit = (!duration.hours && !duration.minutes && !duration.seconds) ? " days" : "d "
+                result += duration.days + dayUnit
             } else if (duration.days == 1) {
-                if (!duration.hours && !duration.minutes && !duration.seconds) {
-                    result += "24 hours "
-                } else {
-                    result += "1 day "
-                }
+                result = (!duration.hours && !duration.minutes && !duration.seconds) ? "24h" : "1d "
             }
             if (duration.hours >= 2) {
-                result += duration.hours + " hours "
+                result += duration.hours + "h "
             } else if (duration.hours == 1) {
-                result += "1 hour "
+                result += "1h "
             }
             if (duration.minutes >= 2) {
-                result += duration.minutes + " minutes "
+                result += duration.minutes + "min "
             } else if (duration.minutes == 1) {
-                result += "1 minute "
+                result += "1min "
             }
             if (duration.seconds >= 2) {
-                result += duration.seconds + " seconds "
+                result += duration.seconds + "s "
             } else if (duration.seconds == 1) {
-                result += "1 second "
+                result += "1s "
             }
             result = result.trim()
         }

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -189,7 +189,7 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
         expect(wrapper.get("#aliasValue").text()).toBe("None")
         expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77 days 3 hours 40 minutes")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
 

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -162,7 +162,7 @@ describe("NodeDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
         expect(wrapper.get("#aliasValue").text()).toBe("None")
         expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77 days 3 hours 40 minutes")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
     });

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -75,12 +75,12 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake")
+        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" +
-            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" +
-            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000"
+            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -86,11 +86,11 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake")
+        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" +
-            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" +
-            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000"
+            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%"
         )
     });
 

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -83,7 +83,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#operatorAccountValue").text()).toBe("0.0.29624024")
         expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.7Node 4 - testnet")
-        expect(wrapper.get("#durationValue").text()).toBe("2 minutes")
+        expect(wrapper.get("#durationValue").text()).toBe("2min")
         expect(wrapper.get("#entityId").text()).toBe("Account ID0.0.29662956")
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)

--- a/tests/unit/utils/Duration.spec.ts
+++ b/tests/unit/utils/Duration.spec.ts
@@ -28,7 +28,7 @@ describe("Duration.ts", () => {
         const hours = 21
         const days = 42
         const secondCount = seconds + 60 * minutes + 3600 * hours + 3600 * 24 * days
-        const durationText = "42 days 21 hours 42 minutes 42 seconds"
+        const durationText = "42d 21h 42min 42s"
 
         const d = Duration.decompose(secondCount)
         expect(d.seconds).toBe(seconds)
@@ -39,11 +39,11 @@ describe("Duration.ts", () => {
         expect(formatSeconds(secondCount.toString())).toBe(durationText)
    })
 
-    test("42 days", () => {
+    test("42 days 42 seconds", () => {
         const seconds = 42
         const days = 42
         const secondCount = seconds + 3600 * 24 * days
-        const durationText = "42 days 42 seconds"
+        const durationText = "42d 42s"
 
         const d = Duration.decompose(secondCount)
         expect(d.seconds).toBe(seconds)
@@ -60,7 +60,7 @@ describe("Duration.ts", () => {
         const hours = 1
         const days = 1
         const secondCount = seconds + 60 * minutes + 3600 * hours + 3600 * 24 * days
-        const durationText = "1 day 1 hour 1 minute 1 second"
+        const durationText = "1d 1h 1min 1s"
 
         const d = Duration.decompose(secondCount)
         expect(d.seconds).toBe(seconds)

--- a/tests/unit/values/DurationValue.spec.ts
+++ b/tests/unit/values/DurationValue.spec.ts
@@ -49,7 +49,7 @@ describe("DurationValue.vue", () => {
         expect(wrapper.text()).toBe("None")
 
         const D = 3600 * 3 + 60 * 2 + 42
-        const S = "3 hours 2 minutes 42 seconds"
+        const S = "3h 2min 42s"
         await wrapper.setProps({
             numberValue: D,
             loading: true
@@ -57,7 +57,7 @@ describe("DurationValue.vue", () => {
         expect(wrapper.text()).toBe(S)
 
         const D1 = 3600 * 5 + 60 + 42
-        const S1 = "5 hours 1 minute 42 seconds"
+        const S1 = "5h 1min 42s"
         await wrapper.setProps({
             numberValue: undefined,
             stringValue: D1.toString(),


### PR DESCRIPTION
**Description**:

These changes add the display of Last Period Reward Rate (actually its approx. yearly equivalent) in:
 - the NodeTable
 - the NodeDetails page

PR also brings an unrelated shortening of time units when displaying a duration:
'1 day 2 hours 10 minutes 45 seconds' --> '1d 2h 10min 45s'

**Related issue(s)**:

Fixes #142

**Notes for reviewer**:

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
