### PR TITLE
Change border/background on hover (instead of opacity) in WalletChooser.

### DIFF
--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -37,6 +37,24 @@
     color: $h-radio-hover-color;
 }
 
+.h-chooser-figure {
+    width: 150px;
+    height: 80px;
+    line-height: 60px;
+    text-align: center;
+    padding: 8px;
+    border: solid 0.5px transparent;
+    border-radius: 6px;
+}
+.h-chooser-figure:hover {
+    border-color: var(--h-theme-highlight-color);
+    background-color: var(--h-theme-page-background-color);
+}
+
+.h-chooser-img {
+    vertical-align: middle;
+}
+
 //
 // TEXT
 //

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -39,8 +39,8 @@
         <div class="is-flex is-justify-content-left is-align-items-center">
           <div v-for="d in drivers" :key="d.name">
               <a @click="handleChoose(d)">
-                <figure class="image my-4 mr-6" style="width: 128px">
-                  <img alt="wallet logo" :src="d.iconURL">
+                <figure class="h-chooser-figure my-4 mr-6">
+                  <img class="h-chooser-img" alt="wallet logo" :src="d.iconURL">
                 </figure>
               </a>
           </div>
@@ -100,10 +100,4 @@ export default defineComponent({
 <!--                                                       STYLE                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style scoped>
-
-.image:hover {
-  opacity: 60%;
-}
-
-</style>
+<style/>


### PR DESCRIPTION
**Description**:

This modifies the WalletChooser such that wallets are highlighted on mouse hover by a colored border and a background change instead of a 60% opacity.

**Related issue(s)**:

None

**Notes for reviewer**:

Equivalent to what is currently displayed on staging server.
Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
