### PR TITLE
00122 stake range

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -35,53 +35,63 @@
         @click="handleClick"
     >
       <o-table-column v-slot="props" field="node_id" label="Node">
-        <div class="is-numeric">
+        <div class="is-numeric regular-node-column">
           {{ props.row.node_id }}
         </div>
       </o-table-column>
 
       <o-table-column v-slot="props" field="node_account_id" label="Account">
-        <div class="is-numeric">
+        <div class="is-numeric regular-node-column">
           {{ props.row.node_account_id }}
         </div>
       </o-table-column>
 
       <o-table-column v-slot="props" field="hosted_by" label="Hosted By">
-        <div class="should-wrap">
+        <div class="should-wrap regular-node-column">
           <BlobValue v-bind:blob-value="makeHost(props.row)" v-bind:show-none="true"/>
         </div>
       </o-table-column>
 
       <o-table-column v-slot="props" field="location" label="Location">
-        <div class="should-wrap">
+        <div class="should-wrap regular-node-column">
           <BlobValue v-bind:blob-value="makeLocation(props.row)" v-bind:show-none="true"/>
         </div>
       </o-table-column>
 
         <o-table-column v-slot="props" field="stake" label="Stake" position="right">
+          <span class="regular-node-column">
             <HbarAmount :amount="props.row.stake ?? 0" :decimals="0"/>
             <span class="ml-1">{{ '(' + makeStakePercentage(props.row) + '%)' }}</span>
+          </span>
         </o-table-column>
 
         <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
-          <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
+          <span class="regular-node-column">
+            <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
+          </span>
         </o-table-column>
 
       <o-table-column v-slot="props" field="last_reward_rate" label="Last Reward Rate" position="right">
-        {{ makeApproxYearlyRate(props.row) }}
+        <span class="regular-node-column">
+          {{ makeApproxYearlyRate(props.row) }}
+        </span>
       </o-table-column>
 
-<!--        <o-table-column field="stake_range" label="Stake Range">-->
-<!--          <div class="is-flex-direction-column h-is-stake-range-bar">-->
-<!--            <progress id="range" class="progress is-large is-info h-is-progress-bar" max="100"-->
-<!--                      style="max-height: 8px; margin-bottom: 1px;" :value="45"></progress>-->
-<!--            <div class="is-flex is-justify-content-space-between">-->
-<!--              <img alt="Minimum staking mark" class="image" src="@/assets/min-mark.png"-->
-<!--                   style="max-height: 8px; margin-left: 16px">-->
-<!--              <img alt="Maximum staking mark" class="image" src="@/assets/max-mark.png" style="max-height: 8px">-->
-<!--            </div>-->
-<!--          </div>-->
-<!--        </o-table-column>-->
+      <o-table-column id="stake-range-column" v-slot="props" field="stake-range" label="Stake Range" style="  padding-bottom: 2px; padding-top: 12px;">
+        <div  v-if="props.row.stake && props.row.max_stake" class="is-flex-direction-column stake-range-column">
+          <progress id="range" class="progress is-large stake-progress"
+                    :class="{'is-info': !isStakeInRange(props.row), 'is-success': isStakeInRange(props.row)}"
+                    style="width: 120px; max-height: 8px; margin-bottom: 1px;"
+                    max="100" v-bind:value="makeStakeProgress(props.row)">
+          </progress>
+          <div class="is-flex">
+            <img alt="Minimum staking mark" src="@/assets/min-mark.png"
+                 class="image min-offset" style="max-height: 8px">
+            <img alt="Maximum staking mark" src="@/assets/max-mark.png"
+                 class="image max-offset" style="max-height: 8px">
+          </div>
+        </div>
+      </o-table-column>
 
     </o-table>
   </div>
@@ -96,7 +106,7 @@
 
 <script lang="ts">
 
-import {defineComponent, inject, PropType} from 'vue';
+import {computed, defineComponent, inject, PropType} from 'vue';
 import {NetworkNode} from "@/schemas/HederaSchemas";
 import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
@@ -117,7 +127,9 @@ export default defineComponent({
 
   props: {
     nodes: Object as PropType<Array<NetworkNode> | undefined>,
-    totalHbarStaked: Number
+    totalHbarStaked: Number,
+    minStake: Number,
+    maxStake: Number,
   },
 
   setup(props) {
@@ -141,6 +153,38 @@ export default defineComponent({
       router.push({name: 'NodeDetails', params: {nodeId: node.node_id}})
     }
 
+    const progressSize = 120 // size (width) of progress in pixels
+    const progressScale = computed(() => props.maxStake ? props.maxStake * 1.2 : 0)
+
+    const minStakePercent = computed(() =>
+        props.minStake && progressScale.value ? props.minStake / progressScale.value * 100 : 0)
+    const minStakePix = computed(() => {
+      const pixels = Math.round(minStakePercent.value / 100 * progressSize)
+      return pixels.toString() + 'px'
+    })
+
+    const maxStakePercent = computed(() =>
+        props.maxStake && progressScale.value ? props.maxStake / progressScale.value * 100 : 0)
+    const maxStakePix = computed(() => {
+      const pixels = Math.round((maxStakePercent.value - minStakePercent.value) / 100 * progressSize - 20)
+      return pixels.toString() + 'px'
+    })
+
+    const makeStakeProgress = (node: NetworkNode) =>
+        node.stake && progressScale.value ? node.stake / progressScale.value * 100 : 0
+
+    const isStakeInRange =  (node: NetworkNode) => {
+      let result: boolean
+      const stake = node.stake
+      if (stake && props.minStake && props.maxStake) {
+        result = stake >= props.minStake && stake < props.maxStake
+      }
+      else {
+        result = false
+      }
+      return result
+    }
+
     return {
       isTouchDevice,
       isMediumScreen,
@@ -149,7 +193,11 @@ export default defineComponent({
       makeStakePercentage,
       makeApproxYearlyRate,
       handleClick,
-      ORUGA_MOBILE_BREAKPOINT
+      minStakePix,
+      maxStakePix,
+      isStakeInRange,
+      makeStakeProgress,
+      ORUGA_MOBILE_BREAKPOINT,
     }
   }
 });
@@ -161,5 +209,23 @@ export default defineComponent({
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style>
+.min-offset {
+  margin-left: v-bind(minStakePix);
+}
+.max-offset {
+  margin-left: v-bind(maxStakePix);
+}
 
+#node-table table.o-table > tbody > tr > td {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.regular-node-column {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+.stake-range-column {
+  padding-bottom: 2px;
+  padding-top: 12px;
+}
 </style>

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -59,9 +59,9 @@
       </div>
 
       <div class="is-flex is-justify-content-space-between">
-        <NetworkDashboardItem :name="'HBAR'" :title="'Current 24h Period Earning'" :value="currentEarning.toString()"/>
-        <NetworkDashboardItem :name="'HBAR'" :title="'Approx Monthly Earning'" :value="monthlyEarning.toString()"/>
-        <NetworkDashboardItem :name="'HBAR'" :title="'Approx Yearly Earning'" :value="yearlyEarning.toString()"/>
+        <NetworkDashboardItem :name="'HBAR'" :title="'Current 24h Period Reward'" :value="currentReward.toString()"/>
+        <NetworkDashboardItem :name="'HBAR'" :title="'Approx Monthly Reward'" :value="monthlyReward.toString()"/>
+        <NetworkDashboardItem :name="'HBAR'" :title="'Approx Yearly Reward'" :value="yearlyReward.toString()"/>
         <NetworkDashboardItem :title="'Approx Yearly Reward Rate'" :value="yearlyRate*100 + '%'"/>
       </div>
 
@@ -110,9 +110,9 @@ export default defineComponent({
         (nodes.value && selectedNodeId.value !== null && selectedNodeId.value < nodes.value.length)
             ? nodes.value[selectedNodeId.value].reward_rate_start
             : 0)
-    const currentEarning = computed(() => rewardRate.value && amountStaked.value ? Math.round(amountStaked.value * rewardRate.value * 10000) / 10000 : 0)
-    const monthlyEarning = computed(() => currentEarning.value ? Math.round(currentEarning.value * 30 * 100) / 100 : 0)
-    const yearlyEarning = computed(() => currentEarning.value ? Math.round(currentEarning.value * 365 * 10) / 10 : 0)
+    const currentReward = computed(() => rewardRate.value && amountStaked.value ? Math.round(amountStaked.value * rewardRate.value * 10000) / 10000 : 0)
+    const monthlyReward = computed(() => currentReward.value ? Math.round(currentReward.value * 30 * 100) / 100 : 0)
+    const yearlyReward = computed(() => currentReward.value ? Math.round(currentReward.value * 365 * 10) / 10 : 0)
     const yearlyRate = computed(() => rewardRate.value ? Math.round(rewardRate.value * 365 * 10000) / 10000  : 0)
 
     //
@@ -194,9 +194,9 @@ export default defineComponent({
       selectedNodeId,
       amountStaked,
       rewardRate,
-      currentEarning,
-      monthlyEarning,
-      yearlyEarning,
+      currentReward,
+      monthlyReward,
+      yearlyReward,
       yearlyRate,
       nodes,
       makeNodeDescription,

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -65,6 +65,15 @@
         <NetworkDashboardItem :title="'Approx Yearly Reward Rate'" :value="yearlyRate*100 + '%'"/>
       </div>
 
+      <div class="mt-2 h-is-text-size-2 is-italic has-text-grey" style="font-weight:300">
+        These numbers are not individualized and only for illustrative purposes.
+        Please see the
+        <a href="https://docs.hedera.com/guides/core-concepts/staking" class="is-underlined has-text-grey">
+          staking documentation
+        </a>
+        for factors that can influence these numbers.
+      </div>
+
     </template>
   </DashboardCard>
 

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -69,14 +69,17 @@
             Stake To
           </div>
           <div class="column">
-            <div class="is-flex">
-              <div class="control" style="width: 10rem">
-                <label class="radio h-radio-button">
-                  <input name="stakeTarget" type="radio" value="node" v-model="stakeChoice">
-                  Node
-                </label>
+            <div class="columns">
+              <div class="column is-one-fifth">
+                <div class="control" style="width: 100px">
+                  <label class="radio h-radio-button">
+                    <input name="stakeTarget" type="radio" value="node" v-model="stakeChoice">
+                    Node
+                  </label>
+                </div>
               </div>
-              <o-field>
+              <div class="column">
+                <o-field>
                 <o-select v-model="selectedNode"
                           class="h-is-text-size-1" style="border-radius: 4px"  @focus="stakeChoice='node'">
                   <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
@@ -85,28 +88,39 @@
                   </option>
                 </o-select>
               </o-field>
+              </div>
             </div>
-            <div class="is-flex mt-2">
-              <div class="control" style="width: 10rem">
+            <div class="columns">
+              <div class="column is-one-fifth pt-0">
+                <div class="control" style="width: 100px">
                 <label class="radio h-radio-button ml-0">
                   <input name="stakeTarget" type="radio" value="account" v-model="stakeChoice">
-                  Other Account
+                  Account
                 </label>
+                </div>
               </div>
-              <o-field>
-                <o-input v-model="selectedAccount" placeholder="0.0.1234" @focus="stakeChoice='account'"
-                         style="width: 12rem; color: white; background-color: var(--h-theme-box-background-color) ">
-                </o-input>
-              </o-field>
-            </div>
+              <div class="column pt-0">
+                <div class="is-flex is-align-items-flex-start">
+                  <o-field>
+                    <o-input v-model="selectedAccount" placeholder="0.0.1234" @focus="stakeChoice='account'"
+                             style="width: 9rem; color: white; background-color: var(--h-theme-box-background-color) ">
+                    </o-input>
+                  </o-field>
+                  <div class="is-inline-block h-is-text-size-1 is-italic has-text-grey ml-2" style="height:22px; margin-top:2px; font-weight:300">
+                    When staked to another account, the rewards are paid to that account, not this one.
+                  </div>
+                </div>
+              </div>
+
+
           </div>
         </div>
-
+        </div>
         <div class="columns">
-          <div class="column is-one-third has-text-weight-light">
+          <div class="column is-one-third has-text-weight-light pt-0">
             Decline Rewards
           </div>
-          <div class="column">
+          <div class="column pt-0">
             <label class="checkbox">
               <input checked="checked" type="checkbox" v-model="declineChoice" :disabled="!isNodeSelected || selectedNode == null">
             </label>

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -74,7 +74,7 @@
         <span class="h-is-primary-title">Nodes</span>
       </template>
       <template v-slot:table>
-        <NodeTable :nodes="nodes" :total-hbar-staked="totalStaked"/>
+        <NodeTable :nodes="nodes" :total-hbar-staked="totalStaked" :min-stake="minStake" :max-stake="maxStake"/>
       </template>
     </DashboardCard>
 
@@ -121,6 +121,8 @@ export default defineComponent({
     let nodes = ref<Array<NetworkNode> | null>([])
     const totalNodes = computed(() => nodes.value?.length.toString() ?? "")
 
+    const minStake = ref(0)
+    const maxStake = ref(0)
     const totalStaked = ref(0)
     const totalRewarded = ref(0)
     const stakingPeriod = ref<StakingPeriod | null>(null)
@@ -149,6 +151,11 @@ export default defineComponent({
           .then(result => {
             if (result.data.nodes) {
               nodes.value = nodes.value ? nodes.value.concat(result.data.nodes) : result.data.nodes
+              if (nodes.value.length) {
+                totalStaked.value = nodes.value[0].stake_total ?? 0
+                minStake.value = nodes.value[0].min_stake ?? 0
+                maxStake.value = nodes.value[0].max_stake ?? 0
+              }
               let staked = 0
               let rewarded = 0
               for (const n of result.data.nodes) {
@@ -187,6 +194,8 @@ export default defineComponent({
       nodes,
       totalNodes,
       totalStaked,
+      minStake,
+      maxStake,
       totalRewarded,
       durationMin,
       elapsedMin,

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -128,7 +128,7 @@
 
     <DashboardCard v-if="accountId" :class="{'h-has-opacity-20': isIndirectStaking}">
       <template v-slot:title>
-        <span class="h-is-primary-title">Staking Rewards Transactions</span>
+        <span class="h-is-primary-title">Recent Staking Rewards Transactions</span>
       </template>
       <template v-slot:control>
         <div class="is-flex is-align-items-flex-end">

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -75,7 +75,7 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate")
+        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
             "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" + "0%" +

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -86,7 +86,7 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate")
+        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
             "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" + "0%" +
             "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%" +


### PR DESCRIPTION
**Description**:

This PR mainly adds a new column in the Node Table which represents the Staking progress of a node compared to the minimum and maximum stake. This initial implementation is based on the standard _progress_ component and the layout of the min/max scale is CSS-based. This implies that, initially, all nodes share the same min and max stake.

Also included:

- A few trivial terminology changes (earning -> rewards)
- A disclaimer at the bottom of the RewardsCalculator (trivial)
- An explanatory note in the Staking dialog (less trivial, the layout had to be adjusted)

**Related issue(s)**:

Fixes #122 

**Notes for reviewer**:

Branch may be squashed + deleted 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
