### PR TITLE
Stake input validation

### DIFF
--- a/src/assets/styles/explorer-bulma.sass
+++ b/src/assets/styles/explorer-bulma.sass
@@ -35,7 +35,7 @@ $family-primary: 'Styrene A Web', sans-serif
 $family-monospace: novamonoregular
 $button-color: white
 $control-border-width: 0.5px
-
+$input-placeholder-color: grey
 $progress-bar-background-color: #444444
 $progress-border-radius: $box-radius
 

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -65,7 +65,7 @@
         <NetworkDashboardItem :title="'Approx Yearly Reward Rate'" :value="yearlyRate*100 + '%'"/>
       </div>
 
-      <div class="mt-2 h-is-text-size-2 is-italic has-text-grey" style="font-weight:300">
+      <div class="mt-2 h-is-text-size-2 is-italic has-text-grey">
         These numbers are not individualized and only for illustrative purposes.
         Please see the
         <a href="https://docs.hedera.com/guides/core-concepts/staking" class="is-underlined has-text-grey">

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -80,7 +80,7 @@
               </div>
               <div class="column">
                 <o-field>
-                <o-select v-model="selectedNode"
+                <o-select v-model="selectedNode" :class="{'has-text-grey': !isNodeSelected}"
                           class="h-is-text-size-1" style="border-radius: 4px"  @focus="stakeChoice='node'">
                   <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
                           style="background-color: var(--h-theme-box-background-color)">
@@ -100,20 +100,29 @@
                 </div>
               </div>
               <div class="column pt-0">
-                <div class="is-flex is-align-items-flex-start">
-                  <input class="input is-small has-text-right" type="text" placeholder="0.0.1234"
+                <div class="is-flex is-align-items-center">
+                  <input class="input is-small has-text-right has-text-white" type="text" placeholder="0.0.1234"
+                         :class="{'has-text-grey': !isAccountSelected}"
                          :value="selectedAccount"
                          @focus="stakeChoice='account'"
                          @input="event => handleInput(event.target.value)"
                          style="width: 9rem; height:26px; margin-top: 1px; border-radius: 4px; border-width: 1px;
-                         color: white; background-color: var(--h-theme-box-background-color)">
+                         background-color: var(--h-theme-box-background-color)">
 
-                  <div class="is-inline-block h-is-text-size-1 is-italic has-text-grey ml-2" style="height:22px; margin-top:2px; font-weight:300">
-                    When staked to another account, the rewards are paid to that account, not this one.
+                  <div v-if="isAccountSelected && showUnknownAccountMessage"
+                       class="is-inline-block h-is-text-size-2 has-text-danger ml-3">
+                    This account does not exist
+                  </div>
+                  <div v-else-if="isAccountSelected && showInvalidAccountIDMessage"
+                       class="is-inline-block h-is-text-size-2 has-text-danger ml-3">
+                    Invalid account ID
+                  </div>
+                  <div v-else-if="isAccountSelected && isSelectedAccountValidated"
+                       class="is-inline-block h-is-text-size-2 is-italic has-text-grey ml-3">
+                    Rewards will now be paid to that account.
                   </div>
                 </div>
               </div>
-
 
           </div>
         </div>
@@ -197,13 +206,27 @@ export default defineComponent({
     const isNodeSelected = computed(() => stakeChoice.value === 'node')
     const isAccountSelected = computed(() => stakeChoice.value === 'account')
 
-    const selectedAccount = ref<string|null>(null)
-    const isSelectedAccountValid = ref(true)
+    const selectedAccount = ref<string | null>(null)
+    const isSelectedAccountValidated = ref(false)
+    const showUnknownAccountMessage = ref(false)
+    const showInvalidAccountIDMessage = ref(false)
+
+    let validationTimerId = -1
+
     watch(selectedAccount, () => {
+      showUnknownAccountMessage.value = false
+      showInvalidAccountIDMessage.value = false
+      isSelectedAccountValidated.value = false
+
+      if (validationTimerId != -1) {
+        window.clearTimeout(validationTimerId)
+        validationTimerId = -1
+      }
       if (selectedAccount.value?.length) {
-        isSelectedAccountValid.value = isValidEntityId(selectedAccount.value ?? "")
+        validationTimerId = window.setTimeout(
+            () => validateAccount(selectedAccount.value ?? ""),
+            500)
       } else {
-        isSelectedAccountValid.value = false
         selectedAccount.value = null
       }
     })
@@ -222,7 +245,8 @@ export default defineComponent({
     watch(accountId, () => declineChoice.value = props.account?.decline_reward ?? false)
 
     const enableChangeButton = computed(() => {
-      return (isAccountSelected.value && isSelectedAccountValid.value && props.account?.staked_account_id != selectedAccount.value)
+      return (
+          isAccountSelected.value && isSelectedAccountValidated.value && props.account?.staked_account_id != selectedAccount.value)
           || (isNodeSelected.value  && selectedNode.value && props.account?.staked_node_id != selectedNode.value)
           || (props.account?.decline_reward != declineChoice.value)
     })
@@ -330,6 +354,22 @@ export default defineComponent({
       }
     }
 
+    const validateAccount = (accountId: string) => {
+      if (isValidEntityId(accountId ?? "")) {
+        const params = {} as {
+          limit: 1
+        }
+        if (accountId) {
+          axios
+              .get<AccountBalanceTransactions>("api/v1/accounts/" + accountId, {params: params})
+              .then(() => isSelectedAccountValidated.value = true)
+              .catch(() => showUnknownAccountMessage.value = true)
+        }
+      } else {
+        showInvalidAccountIDMessage.value = true
+      }
+    }
+
     return {
       accountId,
       showConfirmDialog,
@@ -337,6 +377,9 @@ export default defineComponent({
       stakeChoice,
       isNodeSelected,
       isAccountSelected,
+      showUnknownAccountMessage,
+      showInvalidAccountIDMessage,
+      isSelectedAccountValidated,
       selectedAccount,
       selectedNode,
       selectedNodeDescription,

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -101,11 +101,13 @@
               </div>
               <div class="column pt-0">
                 <div class="is-flex is-align-items-flex-start">
-                  <o-field>
-                    <o-input v-model="selectedAccount" placeholder="0.0.1234" @focus="stakeChoice='account'"
-                             style="width: 9rem; color: white; background-color: var(--h-theme-box-background-color) ">
-                    </o-input>
-                  </o-field>
+                  <input class="input is-small has-text-right" type="text" placeholder="0.0.1234"
+                         :value="selectedAccount"
+                         @focus="stakeChoice='account'"
+                         @input="event => handleInput(event.target.value)"
+                         style="width: 9rem; height:26px; margin-top: 1px; border-radius: 4px; border-width: 1px;
+                         color: white; background-color: var(--h-theme-box-background-color)">
+
                   <div class="is-inline-block h-is-text-size-1 is-italic has-text-grey ml-2" style="height:22px; margin-top:2px; font-weight:300">
                     When staked to another account, the rewards are paid to that account, not this one.
                   </div>
@@ -311,7 +313,22 @@ export default defineComponent({
       return result
     }
 
-    const testOnFocus = () => { console.log("onfocus triggered") }
+    const handleInput = (value: string) => {
+      const previousValue = selectedAccount.value
+      let isValid = true
+      for (const c of value) {
+        if ((c < '0' || c > '9') && c !== '.') {
+          isValid = false
+          break
+        }
+      }
+      if (isValid) {
+        selectedAccount.value = value
+      } else {
+        selectedAccount.value = ""
+        selectedAccount.value = previousValue
+      }
+    }
 
     return {
       accountId,
@@ -333,7 +350,7 @@ export default defineComponent({
       handleConfirmChange,
       makeNodeDescription,
       makeNodeStake,
-      testOnFocus
+      handleInput
     }
   }
 });

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -110,7 +110,7 @@ export class EntityID {
     private static readonly MAX_INT = Math.pow(2, 32) // Max supported by mirror node rest api on May 30, 2022
 
     public static parsePositiveInt(s: string): number|null {
-        const n = Number(s)
+        const n = s.length >= 1 ? Number(s) : -1
         return (isNaN(n) || Math.floor(n) != n || n < 0 || n >= EntityID.MAX_INT) ? null : n
     }
 

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -103,6 +103,31 @@ describe("EntityID.ts", () => {
         expect(obj).toBeNull()
     })
 
+    test("0.0.", () => {
+        const obj = EntityID.parse("0.0.")
+        expect(obj).toBeNull()
+    })
+
+    test("0.0", () => {
+        const obj = EntityID.parse("0.0")
+        expect(obj).toBeNull()
+    })
+
+    test("0.", () => {
+        const obj = EntityID.parse("0.")
+        expect(obj).toBeNull()
+    })
+
+    test("..", () => {
+        const obj = EntityID.parse("..")
+        expect(obj).toBeNull()
+    })
+
+    test(".", () => {
+        const obj = EntityID.parse(".")
+        expect(obj).toBeNull()
+    })
+
     test("Too Big Number", () => {
         const tooBigNum = Math.pow(2, 32)
         const obj = EntityID.parse(tooBigNum.toString())


### PR DESCRIPTION
**Description**:

This brings on the fly input validation (and error messages) for the "Stake To Account" field of the StakingDialog. We wait 500ms after the last user input and go query the REST API to check that account exists.

The PR also brings a cosmetics change in RewardsCalcutator disclaimer notice.

**Related issue(s)**:

Follow-up for #75

**Notes for reviewer**:

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
