### PR TITLE
#153 - user balance as default in the RewardsCalculator

### DIFF
--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -97,6 +97,7 @@ export default defineComponent({
 
   props: {
     network: String,
+    amountInHbar: Number,
     nodeId: Number as PropType<number|null>
   },
 
@@ -113,7 +114,12 @@ export default defineComponent({
     const selectedNodeId = ref<number | null>(props.nodeId ?? null)
     watch(() => props.nodeId, () => selectedNodeId.value = props.nodeId ?? null)
 
-    const amountStaked = ref<number|null>(100)
+    const amountStaked = ref<number>( 100)
+    watch(() => props.amountInHbar, () => {
+      if (props.amountInHbar) {
+        amountStaked.value = props.amountInHbar
+      }
+    })
 
     const rewardRate = computed(() =>
         (nodes.value && selectedNodeId.value !== null && selectedNodeId.value < nodes.value.length)
@@ -191,7 +197,7 @@ export default defineComponent({
       if (!Number.isNaN(newAmount) && newAmount >= 0 && newAmount <= 50000000000) {
         amountStaked.value = newAmount
       } else {
-        amountStaked.value = null
+        amountStaked.value = -1
         amountStaked.value = previousAmount
       }
     }

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -144,7 +144,9 @@
       </template>
     </DashboardCard>
 
-    <RewardsCalculator v-if="accountId" :class="{'h-has-opacity-20': isIndirectStaking}" :node-id="stakedNode?.node_id"/>
+    <RewardsCalculator v-if="accountId" :class="{'h-has-opacity-20': isIndirectStaking}"
+                       :amount-in-hbar="balanceInHbar"
+                       :node-id="stakedNode?.node_id"/>
 
   </section>
 
@@ -243,7 +245,7 @@ export default defineComponent({
       walletManager
           .connect()
           .catch((reason) => {
-            console.log("handleChooseWallet - reason:" + reason.toString())
+            console.warn("Failed to connect wallet - reason:" + reason.toString())
             showProgressDialog.value = true
             progressDialogMode.value = Mode.Error
             progressDialogTitle.value = "Could not connect wallet"
@@ -289,6 +291,12 @@ export default defineComponent({
       } else {
         result = null
       }
+      return result
+    })
+
+    const balanceInHbar = computed(() => {
+      const balance = account.value?.balance?.balance ?? 0
+      const result = balance / 100000000
       return result
     })
 
@@ -493,6 +501,7 @@ export default defineComponent({
       isIndirectStaking,
       stakedTo,
       stakedNode,
+      balanceInHbar,
       stakedAmount,
       stakedSince,
       declineReward,


### PR DESCRIPTION
**Description**:

Take the user balance as default value (instead of 100) for the amount staked, in the RewardsCalculator.

**Related issue(s)**:

Fixes #153

**Notes for reviewer**:

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
