### PR TITLE
#153 follow-up: added some missing logic in RewardsCalculator

### DIFF
--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -85,7 +85,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onMounted, PropType, ref, watch} from 'vue';
+import {computed, defineComponent, inject, onBeforeMount, onMounted, PropType, ref, watch} from 'vue';
 import NetworkDashboardItem from "@/components/node/NetworkDashboardItem.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
 import {NetworkNode, NetworkNodesResponse} from "@/schemas/HederaSchemas";
@@ -115,11 +115,11 @@ export default defineComponent({
     watch(() => props.nodeId, () => selectedNodeId.value = props.nodeId ?? null)
 
     const amountStaked = ref<number>( 100)
-    watch(() => props.amountInHbar, () => {
-      if (props.amountInHbar) {
-        amountStaked.value = props.amountInHbar
-      }
-    })
+    const updateAmountStaked = () => {
+      amountStaked.value = props.amountInHbar ?? 100
+    }
+    watch(() => props.amountInHbar, updateAmountStaked)
+    onBeforeMount(updateAmountStaked)
 
     const rewardRate = computed(() =>
         (nodes.value && selectedNodeId.value !== null && selectedNodeId.value < nodes.value.length)


### PR DESCRIPTION

Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Changes below adds extra logic to #153 implementation.
This ensures that sequence below correctly:
1) Goto Staking page
2) Connect to Wallet A
     => user balance is used as default value for reward calculator : OK
3) Disconnect A
4) Connect to Wallet A (or B)
     => without this fix: user balance is no longer used as default (100 is) : KO
     => with this fix: user balance is used as default value for reward calculator : OK

**Related issue(s)**:

Fixes #153 

**Notes for reviewer**:

Branch can be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
