### PR TITLE
00162 fix stake range progress

### DIFF
--- a/src/components/values/HbarAmount.vue
+++ b/src/components/values/HbarAmount.vue
@@ -83,7 +83,13 @@ export default defineComponent({
       return props.amount / 100000000
     })
     const formattedAmount = computed(() => {
-      return hbarAmount.value.toFixed(props.decimals)
+      const amountFormatter = new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: props.decimals,
+        maximumFractionDigits: 8
+      })
+      return amountFormatter.format(hbarAmount.value)
+
+      // return hbarAmount.value.toFixed(props.decimals)
     })
 
     const isGrey = computed(() => {

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -90,7 +90,7 @@
 
           <div class="column">
               <Property v-if="account?.staked_account_id" id="stakedAccount">
-                <template v-slot:name>Staked Account</template>
+                <template v-slot:name>Staked to Account</template>
                 <template v-slot:value>
                   <AccountLink :accountId="account.staked_account_id" v-bind:show-extra="true"/>
                 </template>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -151,7 +151,6 @@
 
         <ContractTransactionTable
             v-if="contract"
-            v-bind:narrowed="true"
             v-bind:transactions="transactions"
             v-bind:nb-items="10"
         />

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -100,8 +100,11 @@
               <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="maxStake.toString()"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="stakeRewarded.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Rewarded Stake'" :value="stakeRewarded.toString()"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
+              <br/><br/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Unrewarded Stake'" :value="stakeUnrewarded.toString()"/>
+              <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of total</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>
               <p class="h-is-property-text h-is-extra-text mt-1">from 00:00 am today to 11:59 pm today UTC</p>
@@ -200,6 +203,11 @@ export default defineComponent({
     const stakeRewardedPercentage = computed(() =>
         stakeRewardedTotal.value ? Math.round(stakeRewarded.value / stakeRewardedTotal.value * 10000) / 100 : 0)
 
+    const stakeUnrewarded = computed(() => node.value?.stake_not_rewarded ? Math.round(node.value.stake_not_rewarded / 100000000) : 0)
+    const stakeUnrewardedTotal = ref(0)
+    const stakeUnrewardedPercentage = computed(() =>
+        stakeUnrewardedTotal.value ? Math.round(stakeUnrewarded.value / stakeUnrewardedTotal.value * 10000) / 100 : 0)
+
     const unknownNodeId = ref(false)
     const notification = computed(() => {
       let result
@@ -278,6 +286,8 @@ export default defineComponent({
       stakePercentage,
       stakeRewarded,
       stakeRewardedPercentage,
+      stakeUnrewarded,
+      stakeUnrewardedPercentage,
       notification,
       nodeDescription,
       formatHash

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -96,14 +96,14 @@
               <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toString()"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="minStake.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="minStake.toLocaleString('en-US')"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="maxStake.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="maxStake.toLocaleString('en-US')"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Rewarded Stake'" :value="stakeRewarded.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Rewarded Stake'" :value="stakeRewarded.toLocaleString('en-US')"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Unrewarded Stake'" :value="stakeUnrewarded.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Unrewarded Stake'" :value="stakeUnrewarded.toLocaleString('en-US')"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of total</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -39,7 +39,7 @@
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + ' ago'"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="totalStaked.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="stakeTotal.toString()"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in ' + formatSeconds(remainingMin*60)"/>
             </div>
@@ -55,7 +55,7 @@
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + 'ago'"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="totalStaked.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="stakeTotal.toString()"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in' + formatSeconds(remainingMin*60)"/>
               <div class="mt-4"/>
@@ -74,7 +74,7 @@
         <span class="h-is-primary-title">Nodes</span>
       </template>
       <template v-slot:table>
-        <NodeTable :nodes="nodes" :total-hbar-staked="totalStaked" :min-stake="minStake" :max-stake="maxStake"/>
+        <NodeTable :nodes="nodes" :total-hbar-staked="unclampedStakeTotal" :min-stake="minStake" :max-stake="maxStake"/>
       </template>
     </DashboardCard>
 
@@ -123,7 +123,8 @@ export default defineComponent({
 
     const minStake = ref(0)
     const maxStake = ref(0)
-    const totalStaked = ref(0)
+    const stakeTotal = ref(0)
+    const unclampedStakeTotal = ref(0)
     const totalRewarded = ref(0)
     const stakingPeriod = ref<StakingPeriod | null>(null)
 
@@ -152,13 +153,14 @@ export default defineComponent({
             if (result.data.nodes) {
               nodes.value = nodes.value ? nodes.value.concat(result.data.nodes) : result.data.nodes
               if (nodes.value.length) {
-                totalStaked.value = Math.round((nodes.value[0].stake_total ?? 0) / 100000000)
+                stakeTotal.value = Math.round((nodes.value[0].stake_total ?? 0) / 100000000)
                 minStake.value = Math.round((nodes.value[0].min_stake ?? 0) / 100000000)
                 maxStake.value = Math.round((nodes.value[0].max_stake ?? 0) / 100000000)
               }
               for (const n of result.data.nodes) {
                 if (n.stake_rewarded) {
                   totalRewarded.value += n.stake_rewarded/100000000
+                  unclampedStakeTotal.value += (n.stake_rewarded + (n.stake_not_rewarded ?? 0))/100000000
                 }
               }
             }
@@ -186,7 +188,8 @@ export default defineComponent({
       isTouchDevice,
       nodes,
       totalNodes,
-      totalStaked,
+      stakeTotal,
+      unclampedStakeTotal,
       minStake,
       maxStake,
       totalRewarded,

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -39,12 +39,12 @@
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + ' ago'"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="stakeTotal.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="unclampedStakeTotal.toLocaleString('en-US')"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in ' + formatSeconds(remainingMin*60)"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Rewarded'" :value="totalRewarded.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Rewarded'" :value="totalRewarded.toLocaleString('en-US')"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
             </div>
@@ -55,11 +55,11 @@
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + 'ago'"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="stakeTotal.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="unclampedStakeTotal.toLocaleString('en-US')"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in' + formatSeconds(remainingMin*60)"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Rewarded'" :value="totalRewarded.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Rewarded'" :value="totalRewarded.toLocaleString('en-US')"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
               <div class="mt-6"/>
@@ -74,7 +74,7 @@
         <span class="h-is-primary-title">Nodes</span>
       </template>
       <template v-slot:table>
-        <NodeTable :nodes="nodes" :total-hbar-staked="unclampedStakeTotal" :min-stake="minStake" :max-stake="maxStake"/>
+        <NodeTable :nodes="nodes" :unclamped-stake-total="unclampedStakeTotal" :min-stake="minStake" :max-stake="maxStake"/>
       </template>
     </DashboardCard>
 

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -303,7 +303,10 @@ export default defineComponent({
     const stakedAmount = computed(() => {
       let result
       if ( isStaked.value && account.value?.balance?.balance != null) {
-        result = (account.value.balance.balance / 100000000).toString()
+        const amountFormatter = new Intl.NumberFormat("en-US", {
+          maximumFractionDigits: 8
+        })
+        result = amountFormatter.format(account.value.balance.balance / 100000000)
       }
       else {
         result = null

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1044,7 +1044,7 @@ export const SAMPLE_NETWORK_NODES = {
                 "from": "1654531806.041135961",
                 "to": null
             },
-            "max_stake":         1000000000000000,
+            "max_stake":         3000000000000000,
             "min_stake":          100000000000000,
             "stake_total":       2400000000000000,
             "stake":              600000000000000,
@@ -1073,7 +1073,7 @@ export const SAMPLE_NETWORK_NODES = {
                 "from": "1654531806.041135961",
                 "to": null
             },
-            "max_stake":         2000000000000000,
+            "max_stake":         3000000000000000,
             "min_stake":          100000000000000,
             "stake_total":       2400000000000000,
             "stake":              900000000000000,

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -67,7 +67,9 @@ describe("NodeTable.vue", () => {
             },
             props: {
                 nodes: SAMPLE_NETWORK_NODES.nodes as Array<NetworkNode>,
-                totalHbarStaked: testTotalStaked/100000000
+                unclampedStakeTotal: testTotalStaked/100000000,
+                minStake: SAMPLE_NETWORK_NODES.nodes[0].min_stake,
+                maxStake: SAMPLE_NETWORK_NODES.nodes[0].max_stake
             }
         });
 
@@ -78,9 +80,9 @@ describe("NodeTable.vue", () => {
         expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + "1,000,000" + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -88,9 +88,9 @@ describe("Nodes.vue", () => {
         expect(table.exists()).toBe(true)
         expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6000000(25%)" + "1000000" + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + "9000000(37.5%)" + "2000000" + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + "1,000,000" + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%"
         )
     });
 


### PR DESCRIPTION
**Description**:

These changes:

- Fix the stake range progress bars in the Nodes page. Values should be correct and the progress bars should show up in all cases, even with no staking.
- Address a couple of unrelated issues:
   - get rid of recent warnings in unit tests
   - display all amounts with thousands separators

**Related issue(s)**:

Fixes #162

**Notes for reviewer**:

Branch may be squashed and deleted

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
