### PR TITLE
00092 topnavbar responsiveness

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,11 +40,11 @@ import {useRoute} from "vue-router";
 
 export const XLARGE_BREAKPOINT = 1450
 export const LARGE_BREAKPOINT = 1280
-export const MEDIUM_BREAKPOINT = 1080
+export const MEDIUM_BREAKPOINT = 1140
 export const SMALL_BREAKPOINT = 768
 export const FINAL_BREAKPOINT = 640
 
-export const ORUGA_MOBILE_BREAKPOINT = "1080px"
+export const ORUGA_MOBILE_BREAKPOINT = "1140px"
 
 export default defineComponent({
   name: 'App',
@@ -113,7 +113,7 @@ section.section.is-top-section {
   background-size: 104px
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1140px) {
   section.section.is-top-section {
     padding-top: 0;
     padding-bottom: 30px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
 
 <template>
 
-  <section class="section is-top-section">
+  <section class="section is-top-section" :class="{'is-medium-screen': isMediumScreen}">
     <TopNavBar/>
   </section>
 
@@ -97,6 +97,7 @@ export default defineComponent({
     })
 
     return {
+      isMediumScreen,
       onMainDashboardPage
     }
   },
@@ -112,15 +113,9 @@ section.section.is-top-section {
   background-repeat: no-repeat;
   background-size: 104px
 }
-
-@media (min-width: 1140px) {
-  section.section.is-top-section {
-    padding-top: 0;
-    padding-bottom: 30px;
-    background-image: url("assets/block-chain-bg.png");
-    background-repeat: no-repeat;
-    background-size: 112px
-  }
+section.section.is-top-section.is-medium-screen {
+  padding-bottom: 30px;
+  background-size: 112px
 }
 
 </style>

--- a/src/assets/styles/explorer-bulma.sass
+++ b/src/assets/styles/explorer-bulma.sass
@@ -38,6 +38,7 @@ $control-border-width: 0.5px
 $input-placeholder-color: grey
 $progress-bar-background-color: #444444
 $progress-border-radius: $box-radius
+$desktop: 1140px
 
 // Import Bulma
 @import '../../../node_modules/bulma/bulma'

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -238,17 +238,20 @@ body {
 #drop-down-menu .o-sel-arrow {
     background-position: calc(100% - 7px) calc(100% - 10px);
 }
-@media (max-width: 1139px) {
-    #drop-down-menu .o-sel {
-        width: 322px;
-        border-width: 0.5px;
-        padding-top: 13px;
-        padding-bottom: 13px;
-        padding-left: 13px;
-    }
-    #drop-down-menu .o-sel-arrow {
-        background-position: calc(100% - 13px) calc(100% - 16px);
-    }
+#mobile-drop-down-menu .o-sel {
+    height: 44.5px;
+    width: 322px;
+    font-weight: bold;
+    color: $h-highlight-color;
+    border-color: $h-highlight-color;
+    background-color: $h-page-background-color;
+    border-width: 0.5px;
+    padding-top: 13px;
+    padding-bottom: 13px;
+    padding-left: 13px;
+}
+#mobile-drop-down-menu .o-sel-arrow {
+    background-position: calc(100% - 13px) calc(100% - 16px);
 }
 a.button {
     padding-top: 28px;

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -238,7 +238,7 @@ body {
 #drop-down-menu .o-sel-arrow {
     background-position: calc(100% - 7px) calc(100% - 10px);
 }
-@media (max-width: 1023px) {
+@media (max-width: 1139px) {
     #drop-down-menu .o-sel {
         width: 322px;
         border-width: 0.5px;

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -229,7 +229,7 @@ export default defineComponent({
 
 @media (max-width: 1239px) {
   #product-logo {
-    max-width: 200px;
+    max-width: 220px;
   }
 }
 

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -101,9 +101,6 @@
       </div>
       <SearchBar style="margin-top: 4px"/>
     </div>
-    <a v-if="showTopRightLogo" id="built-on-hedera-logo" href="https://hedera.com" style="line-height: 1">
-      <img alt="Built On Hedera" src="@/assets/built-on-hedera-white.svg" style="min-width: 104px;">
-    </a>
 
   </div>
 
@@ -138,8 +135,6 @@ export default defineComponent({
     const route = useRoute()
     const network = computed( () => { return route.params.network })
     const name = computed( () => { return route.name })
-
-    const showTopRightLogo = inject('isLargeScreen', true)
 
     const isMobileMenuOpen = ref(false)
 
@@ -203,7 +198,6 @@ export default defineComponent({
       productName,
       isStakingEnabled,
       name,
-      showTopRightLogo,
       isMobileMenuOpen,
       networkRegistry,
       selectedNetwork,
@@ -235,19 +229,7 @@ export default defineComponent({
 
 @media (max-width: 1239px) {
   #product-logo {
-    max-width: 220px;
-  }
-}
-
-@media (max-width: 1119px) {
-  #product-logo {
-    max-width: 220px;
-  }
-}
-
-@media (max-width: 1023px) {
-  #product-logo {
-    max-width: 220px;
+    max-width: 200px;
   }
 }
 

--- a/src/components/dashboard/DashboardItem.vue
+++ b/src/components/dashboard/DashboardItem.vue
@@ -88,7 +88,7 @@ export default defineComponent({
   letter-spacing: -0.05em;
 }
 
-@media (min-width: 1080px) {
+@media (min-width: 1140px) {
   .dashboard-value {
     font-style: normal;
     font-weight: 300;

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -29,7 +29,7 @@
     <div class="is-flex is-justify-content-center">
 
       <div class="is-flex is-flex-direction-column is-align-items-start">
-        <div id="drop-down-menu" class="ml-1 mb-5 ">
+        <div id="mobile-drop-down-menu" class="ml-1 mb-5 ">
           <o-field>
             <o-select v-model="selectedNetwork" class="h-is-navbar-item">
               <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -106,13 +106,12 @@ describe("App.vue", () => {
         expect(cards[2].text()).toMatch(RegExp("^HCS Messages"))
 
         const logos = wrapper.findAll("img")
-        expect(logos.length).toBe(6)
+        expect(logos.length).toBe(5)
         expect(logos[0].attributes('alt')).toBe("Product Logo")
-        expect(logos[1].attributes('alt')).toBe("Built On Hedera")
+        expect(logos[1].attributes('alt')).toBe("Trend Up")
         expect(logos[2].attributes('alt')).toBe("Trend Up")
-        expect(logos[3].attributes('alt')).toBe("Trend Up")
-        expect(logos[4].attributes('alt')).toBe("Built On Hedera")
-        expect(logos[5].attributes('alt')).toBe("Sponsor Logo")
+        expect(logos[3].attributes('alt')).toBe("Built On Hedera")
+        expect(logos[4].attributes('alt')).toBe("Sponsor Logo")
 
         wrapper.unmount()
     });

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -73,7 +73,7 @@ describe("TopNavBar.vue", () => {
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccountsNodes")
 
         const links = wrapper.findAll("a")
-        expect(links.length).toBe(9)
+        expect(links.length).toBe(8)
         expect(links[1].text()).toBe("Dashboard")
         expect(links[2].text()).toBe("Transactions")
         expect(links[3].text()).toBe("Tokens")
@@ -84,9 +84,8 @@ describe("TopNavBar.vue", () => {
         expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
 
         const logos = wrapper.findAll("img")
-        expect(logos.length).toBe(2)
+        expect(logos.length).toBe(1)
         expect(logos[0].attributes('alt')).toBe("Product Logo")
-        expect(logos[1].attributes('alt')).toBe("Built On Hedera")
 
         wrapper.unmount()
     });


### PR DESCRIPTION
**Description**:

With the following changes:

- Several responsiveness issues are fixed -- most important one being the TopNavBar just above the 1140 breakpoint, messed up on Safari
- The top-right 'Built-on-Hedera' logo is gone (at the request of mkt) -- the bottom-left one is still there of course

**Related issue(s)**:

Fixes #92 

**Notes for reviewer**:

Responsiveness on Safari remains a bit sub-optimal compared to Chrome, since the media queries do not behave the same way. Painful.

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
