### PR TITLE
Staking fixes and cosmetic changes

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -112,7 +112,7 @@
                   <TimestampValue :timestamp="account?.stake_period_start" :show-none="true"/>
                 </template>
               </Property>
-              <Property id="declineReward" >
+              <Property id="declineReward" v-if="account?.staked_node_id != null">
                 <template v-slot:name>Rewards</template>
                 <template v-slot:value>
                   <StringValue :string-value="account?.decline_reward ? 'Declined' : 'Accepted'"/>

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -246,6 +246,9 @@ export default defineComponent({
                 if (n.stake_rewarded) {
                   stakeRewardedTotal.value += n.stake_rewarded/100000000
                 }
+                if (n.stake_not_rewarded) {
+                  stakeUnrewardedTotal.value += n.stake_not_rewarded/100000000
+                }
               }
             }
             const next = result.data.links?.next

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -93,7 +93,7 @@
               <NetworkDashboardItem :name="'APPROX YEARLY EQUIVALENT'" :title="'Last Period Reward Rate'"
                                     :value="approxYearlyRate.toString()"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toString()"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toLocaleString('en-US')"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="minStake.toLocaleString('en-US')"/>

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -296,6 +296,6 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#stakedAccountValue").text()).toBe("0.0.5Node 2 - testnet")
         expect(wrapper.find("#stakedNodeValue").exists()).toBe(false)
         expect(wrapper.get("#stakePeriodStartValue").text()).toBe("6:45:00.3568 PMMar 3, 2022, UTC")
-        expect(wrapper.get("#declineRewardValue").text()).toBe("Declined")
+        expect(wrapper.find("#declineRewardValue").exists()).toBe(false)
     });
 });


### PR DESCRIPTION
**Description**:

These changes bring miscellaneous fixes and cosmetics changes around the Staking functionality:

- Fix unrewarded percentage in NodeDetails (was off)
- Fix node staking info displayed in node selector in RewardsCalculator and StakingDialog
- Display 'Stake for Consensus' amount with thousands separator in NodeDetails
- Show 'Rewards' property in AccountDetails only when staking to a Node

**Notes for reviewer**:

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
