### PR TITLE
Staking fixes

### DIFF
--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -29,8 +29,8 @@
     background: $h-background-color;
 }
 
-.h-has-opacity-20 {
-    opacity: 20%;
+.h-has-opacity-40 {
+    opacity: 0.4;
 }
 
 .h-radio-button:hover {

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -61,7 +61,8 @@
         <o-table-column v-slot="props" field="stake" label="Stake" position="right">
           <span class="regular-node-column">
             <HbarAmount :amount="makeUnclampedStake(props.row)" :decimals="0"/>
-            <span class="ml-1">{{ '(' + makeWeightPercentage(props.row) + ')' }}</span>
+            <span v-if="props.row.stake" class="ml-1">{{ '(' + makeWeightPercentage(props.row) + ')' }}</span>
+            <span v-else class="ml-1 has-text-grey">(&lt;Min)</span>
           </span>
         </o-table-column>
 

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -26,7 +26,7 @@
 
   <DashboardCard>
     <template v-slot:title>
-      <p class="h-is-primary-title">Rewards Calculator</p>
+      <p class="h-is-primary-title">Rewards Estimator</p>
     </template>
     <template v-slot:table>
 

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -71,7 +71,7 @@
             <div class="is-flex is-justify-content-space-between">
               <NetworkDashboardItem :name="stakedSince" :title="'Staked to'" :value="stakedTo"/>
               <NetworkDashboardItem :name="stakedAmount ? 'HBAR' : ''" :title="'My Stake'" :value="stakedAmount"/>
-              <NetworkDashboardItem :title="'Rewards'" :value="declineReward" :class="{'h-has-opacity-20': ignoreReward}"/>
+              <NetworkDashboardItem :title="'Rewards'" :value="declineReward" :class="{'h-has-opacity-40': ignoreReward}"/>
             </div>
             <br/>
             <div class="is-flex is-justify-content-space-between">
@@ -89,7 +89,7 @@
               <div class="mt-4"/>
               <NetworkDashboardItem :name="stakedAmount ? 'HBAR' : ''" :title="'My Stake'" :value="stakedAmount"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :title="'Rewards'" :value="declineReward" :class="{'h-has-opacity-20': ignoreReward}"/>
+              <NetworkDashboardItem :title="'Rewards'" :value="declineReward" :class="{'h-has-opacity-40': ignoreReward}"/>
               <div class="mt-4"/>
             </div>
               <div class="is-flex is-justify-content-center">
@@ -126,7 +126,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard v-if="accountId" :class="{'h-has-opacity-20': isIndirectStaking}">
+    <DashboardCard v-if="accountId" :class="{'h-has-opacity-40': isIndirectStaking}">
       <template v-slot:title>
         <span class="h-is-primary-title">Recent Staking Rewards Transactions</span>
       </template>
@@ -145,7 +145,7 @@
       </template>
     </DashboardCard>
 
-    <RewardsCalculator v-if="accountId" :class="{'h-has-opacity-20': isIndirectStaking}"
+    <RewardsCalculator v-if="accountId" :class="{'h-has-opacity-40': isIndirectStaking}"
                        :amount-in-hbar="balanceInHbar"
                        :node-id="stakedNode?.node_id"/>
 

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -189,6 +189,7 @@ import WalletChooser from "@/components/staking/WalletChooser.vue";
 import {WalletDriver} from "@/utils/wallet/WalletDriver";
 import {WalletDriverError} from "@/utils/wallet/WalletDriverError";
 import {RewardsTransactionCache} from '@/components/staking/RewardsTransactionCache';
+import {normalizeTransactionId} from "@/utils/TransactionID";
 
 export default defineComponent({
   name: 'Staking',
@@ -419,8 +420,7 @@ export default defineComponent({
         progressExtraMessage.value = "Check your wallet for any approval request"
         progressExtraTransaction.value = null
         showProgressSpinner.value = false
-        const transactionID = await walletManager.changeStaking(nodeId, accountId, declineReward)
-
+        const transactionID = normalizeTransactionId(await walletManager.changeStaking(nodeId, accountId, declineReward))
         progressMainMessage.value = "Completing operation…"
         progressExtraMessage.value = "This may take a few seconds"
         showProgressSpinner.value = true


### PR DESCRIPTION
**Description**:

This PR brings a set of unrelated fixes and cosmetic changes related to Staking:

- fix of opacity on Staking page (Txn table and Reward Estimator disabled in case of indirect staking)
- rename Rewards Calculator --> Rewards Estimator
- normalize transactionID received from wallet before querying the REST API with it
- indicate when node stake is < min instead of displaying 0% as its consensus weight

**Notes for reviewer**:

- these changes are deployed on staging server
- branch may be squashed and deleted

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
