### PR TITLE
Indicate node stake below min (instead of 0%) also in NodeDetails

### DIFF
--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -94,7 +94,8 @@
                                     :value="approxYearlyRate.toString()"/>
               <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toLocaleString('en-US')"/>
-              <p class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
+                <p v-if="stake" class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
+                <p v-else class="h-is-property-text h-is-extra-text mt-1">(&lt;Min)</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="minStake.toLocaleString('en-US')"/>
               <br/><br/>


### PR DESCRIPTION
**Description**:

1 line follow-up change for PR #167
Indicating Stake is '<Min' instead of '0% of total' also applies to NodeDetails page.

**Notes for reviewer**:

Branch may be deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
