### PR TITLE
Fixed AccountID mistaken for TokenID

### DIFF
--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
+import { Transaction, TransactionType } from "@/schemas/HederaSchemas";
 
 export class EntityDescriptor {
 
@@ -56,6 +56,10 @@ export class EntityDescriptor {
             case TransactionType.TOKENDISSOCIATE:
             case TransactionType.CRYPTOAPPROVEALLOWANCE:
             case TransactionType.CRYPTODELETEALLOWANCE:
+            case TransactionType.TOKENGRANTKYC:
+            case TransactionType.TOKENREVOKEKYC:
+            case TransactionType.TOKENFREEZE:
+            case TransactionType.TOKENUNFREEZE:
                 result = new EntityDescriptor("Account ID", "AccountDetails")
                 break;
 
@@ -78,12 +82,8 @@ export class EntityDescriptor {
             case TransactionType.TOKENDELETION:
             case TransactionType.TOKENUPDATE:
             case TransactionType.TOKENFEESCHEDULEUPDATE:
-            case TransactionType.TOKENFREEZE:
-            case TransactionType.TOKENGRANTKYC:
             case TransactionType.TOKENMINT:
             case TransactionType.TOKENPAUSE:
-            case TransactionType.TOKENREVOKEKYC:
-            case TransactionType.TOKENUNFREEZE:
             case TransactionType.TOKENUNPAUSE:
             case TransactionType.TOKENWIPE:
                 result = new EntityDescriptor("Token ID", "TokenDetails");

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
+import { Transaction, TransactionType } from "@/schemas/HederaSchemas";
 
 export function makeSummaryLabel(row: Transaction): string {
     let result: string
@@ -42,6 +42,10 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.CRYPTOUPDATEACCOUNT:
         case TransactionType.TOKENASSOCIATE:
         case TransactionType.TOKENDISSOCIATE:
+        case TransactionType.TOKENGRANTKYC:
+        case TransactionType.TOKENREVOKEKYC:
+        case TransactionType.TOKENFREEZE:
+        case TransactionType.TOKENUNFREEZE:
             result = row.entity_id ? "Account ID: " + row.entity_id : ""
             break
         case TransactionType.TOKENBURN:
@@ -49,12 +53,9 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.TOKENCREATION:
         case TransactionType.TOKENDELETION:
         case TransactionType.TOKENFEESCHEDULEUPDATE:
-        case TransactionType.TOKENFREEZE:
-        case TransactionType.TOKENUNFREEZE:
         case TransactionType.TOKENPAUSE:
         case TransactionType.TOKENUNPAUSE:
         case TransactionType.TOKENUPDATE:
-        case TransactionType.TOKENGRANTKYC:
             result = row.entity_id ? "Token ID: " + row.entity_id : ""
             break
         case TransactionType.CONTRACTCREATEINSTANCE:
@@ -130,7 +131,7 @@ export function showPositiveNetAmount(row: Transaction): boolean {
     const netAmount = computeNetAmount(row)
     switch (row.name) {
         case TransactionType.CRYPTOTRANSFER:
-            result= true
+            result = true
             break
         default:
             result = netAmount > 0


### PR DESCRIPTION
**Description**:

This PR modifies transactions list and transaction detail pages to fix `AccountID` mistaken for `TokenID`.

**Related issue(s)**:

#191 

**Notes for reviewer**:

To see this, go to <https://hashscan.io/#/testnet/transaction/0.0.2032637-1659717478-488793135>, click the Token ID link `0.0.47848342`, result `Token with ID 0.0.47848342 was not found`. This is because that is an AccountID.

Same problem in the transaction list <https://hashscan.io/#/testnet/transactions>.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
