### PR TITLE
Updated Code label

### DIFF
--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -92,7 +92,7 @@
               </template>
             </Property>
             <Property id="code">
-              <template v-slot:name>Code</template>
+              <template v-slot:name>Initcode</template>
               <template v-slot:value>
                 <ByteCodeValue :byte-code="contract?.bytecode"/>
               </template>


### PR DESCRIPTION
**Description**:

This PR modifies the _Code_ label to _Initcode_ (thanks @steven-sheehy).

Advantages:

* _Code_ can be mistaken by the actual deployed bytecode. Currently, you cannot recover the deployed bytecode via REST API. That bytecode is the actual [`initcode`](https://github.com/hashgraph/hedera-protobufs/blob/71e0b20b25aee4369c19c66eacdf5a97e5ca61bd/streams/contract_bytecode.proto#L39)
* We use consistent terminology across Hedera's applications

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
