### PR TITLE
Fix Last Period Reward on Nodes page.

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -66,11 +66,16 @@
           </span>
         </o-table-column>
 
-        <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
-          <span class="regular-node-column">
-            <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
+       <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
+         <o-tooltip label="This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
+                    multiline
+                    delay="500"
+                    class="h-tooltip">
+           <span class="regular-node-column">
+             <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
           </span>
-        </o-table-column>
+         </o-tooltip>
+       </o-table-column>
 
       <o-table-column v-slot="props" field="last_reward_rate" label="Last Reward Rate" position="right">
         <span class="regular-node-column">
@@ -220,6 +225,11 @@ export default defineComponent({
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style>
+.h-tooltip {
+  --oruga-tooltip-background-color:var(--h-theme-highlight-color);
+  --oruga-tooltip-arrow-margin:5px;
+  --oruga-tooltip-content-font-size:0.75rem;
+}
 .min-offset {
   margin-left: v-bind(minStakePix);
 }

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -58,16 +58,21 @@
         </div>
       </o-table-column>
 
-        <o-table-column v-slot="props" field="stake" label="Stake" position="right">
+      <o-table-column v-slot="props" field="stake" label="Stake" position="right">
+        <o-tooltip :label="tooltipStake"
+                   multiline
+                   :delay="tooltipDelay"
+                   class="h-tooltip">
           <span class="regular-node-column">
             <HbarAmount :amount="makeUnclampedStake(props.row)" :decimals="0"/>
             <span v-if="props.row.stake" class="ml-1">{{ '(' + makeWeightPercentage(props.row) + ')' }}</span>
             <span v-else class="ml-1 has-text-grey">(&lt;Min)</span>
           </span>
-        </o-table-column>
+        </o-tooltip>
+      </o-table-column>
 
        <o-table-column v-slot="props" field="stake_not_rewarded" label="Stake Not Rewarded" position="right">
-         <o-tooltip label="This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
+         <o-tooltip :label="tooltipNotRewarded"
                     multiline
                     :delay="tooltipDelay"
                     class="h-tooltip">
@@ -78,9 +83,14 @@
        </o-table-column>
 
       <o-table-column v-slot="props" field="last_reward_rate" label="Last Reward Rate" position="right">
-        <span class="regular-node-column">
-          {{ makeApproxYearlyRate(props.row) }}
-        </span>
+        <o-tooltip :label="tooltipRewardRate"
+                   multiline
+                   :delay="tooltipDelay"
+                   class="h-tooltip">
+          <span class="regular-node-column">
+            {{ makeApproxYearlyRate(props.row) }}
+          </span>
+        </o-tooltip>
       </o-table-column>
 
       <o-table-column id="stake-range-column" v-slot="props" field="stake-range" label="Stake Range" style="  padding-bottom: 2px; padding-top: 12px;">
@@ -140,6 +150,12 @@ export default defineComponent({
 
   setup(props) {
     const tooltipDelay = 500
+    const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight " +
+        "(absent when amount staked is below the minimum, and until stake-based consensus is activated)."
+    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
+        "to decline rewards (and all accounts staked to those accounts)."
+    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +
+        "last 24h period."
 
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
@@ -204,6 +220,9 @@ export default defineComponent({
 
     return {
       tooltipDelay,
+      tooltipStake,
+      tooltipNotRewarded,
+      tooltipRewardRate,
       isTouchDevice,
       isMediumScreen,
       makeHost,
@@ -232,6 +251,7 @@ export default defineComponent({
   --oruga-tooltip-background-color:var(--h-theme-highlight-color);
   --oruga-tooltip-arrow-margin:5px;
   --oruga-tooltip-content-font-size:0.75rem;
+  --oruga-tooltip-content-weight-normal:300;
 }
 .min-offset {
   margin-left: v-bind(minStakePix);

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -69,7 +69,7 @@
        <o-table-column v-slot="props" field="stake_not_rewarded" label="Stake Not Rewarded" position="right">
          <o-tooltip label="This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
                     multiline
-                    delay="500"
+                    :delay="tooltipDelay"
                     class="h-tooltip">
            <span class="regular-node-column">
              <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
@@ -139,6 +139,8 @@ export default defineComponent({
   },
 
   setup(props) {
+    const tooltipDelay = 500
+
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
@@ -201,6 +203,7 @@ export default defineComponent({
     }
 
     return {
+      tooltipDelay,
       isTouchDevice,
       isMediumScreen,
       makeHost,

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -66,7 +66,7 @@
           </span>
         </o-table-column>
 
-       <o-table-column v-slot="props" field="stake_not_rewarded" label="Unrewarded Stake" position="right">
+       <o-table-column v-slot="props" field="stake_not_rewarded" label="Stake Not Rewarded" position="right">
          <o-tooltip label="This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
                     multiline
                     delay="500"

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -101,10 +101,10 @@
               <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="maxStake.toLocaleString('en-US')"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Rewarded Stake'" :value="stakeRewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="stakeRewarded.toLocaleString('en-US')"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Unrewarded Stake'" :value="stakeUnrewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Not Rewarded'" :value="stakeUnrewarded.toLocaleString('en-US')"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of total</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -90,7 +90,7 @@
           </div>
 
           <div class="column h-has-column-separator">
-              <NetworkDashboardItem :name="'APPROX YEARLY EQUIVALENT'" :title="'Last Period Reward Rate'"
+              <NetworkDashboardItem :name="'APPROX ANNUAL EQUIVALENT'" :title="'Last Period Reward Rate'"
                                     :value="approxYearlyRate.toString()"/>
               <br/><br/>
               <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toLocaleString('en-US')"/>

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -44,7 +44,7 @@
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in ' + formatSeconds(remainingMin*60)"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Rewarded'" :value="totalRewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="totalRewarded.toLocaleString('en-US')"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
             </div>
@@ -59,7 +59,7 @@
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in' + formatSeconds(remainingMin*60)"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Rewarded'" :value="totalRewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="totalRewarded.toLocaleString('en-US')"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
               <div class="mt-6"/>
@@ -158,10 +158,8 @@ export default defineComponent({
                 maxStake.value = Math.round((nodes.value[0].max_stake ?? 0) / 100000000)
               }
               for (const n of result.data.nodes) {
-                if (n.stake_rewarded) {
-                  totalRewarded.value += n.stake_rewarded/100000000
-                  unclampedStakeTotal.value += (n.stake_rewarded + (n.stake_not_rewarded ?? 0))/100000000
-                }
+                totalRewarded.value += (n.reward_rate_start ?? 0)/100000000
+                unclampedStakeTotal.value += ((n.stake_rewarded ?? 0) + (n.stake_not_rewarded ?? 0))/100000000
               }
             }
             const next = result.data.links?.next

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -51,7 +51,12 @@ HMSF.forceUTC = true
 
 describe("NodeTable.vue", () => {
 
-    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
+    const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight" +
+        " (absent when amount staked is below the minimum, and until stake-based consensus is activated)."
+    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
+        "to decline rewards (and all accounts staked to those accounts)."
+    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +
+        "last 24h period."
 
     it("should list the 3 nodes in the table", async () => {
 
@@ -82,9 +87,9 @@ describe("NodeTable.vue", () => {
         expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -51,6 +51,8 @@ HMSF.forceUTC = true
 
 describe("NodeTable.vue", () => {
 
+    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
+
     it("should list the 3 nodes in the table", async () => {
 
         process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: true });
@@ -77,12 +79,12 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate Stake Range")
+        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + "1,000,000" + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -55,6 +55,8 @@ HMSF.forceUTC = true
 
 describe("Nodes.vue", () => {
 
+    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
+
     it("should display the nodes pages containing the node table", async () => {
 
         process.env = Object.assign(process.env, { VUE_APP_ENABLE_STAKING: true });
@@ -86,11 +88,11 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Unrewarded Stake Last Reward Rate Stake Range")
+        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + "1,000,000" + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + "2,000,000" + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%"
         )
     });
 

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -55,7 +55,12 @@ HMSF.forceUTC = true
 
 describe("Nodes.vue", () => {
 
-    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen to decline rewards (and all accounts staked to those accounts)."
+    const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight" +
+        " (absent when amount staked is below the minimum, and until stake-based consensus is activated)."
+    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
+        "to decline rewards (and all accounts staked to those accounts)."
+    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +
+        "last 24h period."
 
     it("should display the nodes pages containing the node table", async () => {
 
@@ -90,9 +95,9 @@ describe("Nodes.vue", () => {
         expect(table.exists()).toBe(true)
         expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "0%" +
+            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%" +
+            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%"
         )
     });
 


### PR DESCRIPTION
**Description**:

These changes:

- fix the computation of the "Total Rewarded" data on the Nodes page, now a sum of the `reward_rate_start` field for all nodes (instead of `stake_rewarded` field).
- do a bit of renaming
- start introducing tooltips for certain columns in the NodeTable.

Related to #177 (more to come in that chapter)

**Notes for reviewer**:

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
