### PR TITLE
00164 improve search by account alias

### DIFF
--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -59,7 +59,7 @@ export class SearchRequest {
         const transactionID = TransactionID.parse(this.searchedId)
         const normTransactionID = transactionID != null ? transactionID.toString(false) : null
         const hexBytes = hexToByte(this.searchedId)
-        const hexByteString = (hexBytes !== null && hexBytes.length >= 15) ? byteToHex(hexBytes) : null
+        const evmAddress = (hexBytes !== null && hexBytes.length == 20) ? byteToHex(hexBytes) : null
         const hexByteString32 = (hexBytes !== null && hexBytes.length >= 15) ? aliasToBase32(hexBytes) : null
 
         // 1) Searches accounts
@@ -144,8 +144,8 @@ export class SearchRequest {
         }
 
         // 5) Searches contracts
-        if (normEntityID !== null || hexByteString !== null) {
-            const entityOrAddress = hexByteString ? hexByteString : normEntityID
+        if (normEntityID !== null || evmAddress !== null) {
+            const entityOrAddress = evmAddress ? evmAddress : normEntityID
             axios
                 .get<ContractResponse>("api/v1/contracts/" + entityOrAddress)
                 .then(response => {

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -183,7 +183,7 @@ export class SearchRequest {
     }
 
     private updateErrorCount(reason: unknown): void {
-        const notFound = axios.isAxiosError(reason) && reason.request?.status == 404
+        const notFound = axios.isAxiosError(reason) && reason.response?.status == 404
         if (!notFound) {
             this.errorCount += 1
         }

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -55,6 +55,10 @@ mock.onGet(matcher_contracts).reply(200, SAMPLE_CONTRACT)
 const matcher_contracts_with_evm_address = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address.slice(2)
 mock.onGet(matcher_contracts_with_evm_address).reply(200, SAMPLE_CONTRACT)
 
+const INVALID_EVM_ADDRESS = "0102030405060708090102030405060708"; // 19 bytes : should be 20
+const matcher_contracts_with_invalid_evm_address = "/api/v1/contracts/" + INVALID_EVM_ADDRESS
+mock.onGet(matcher_contracts_with_invalid_evm_address).reply(400)
+
 
 describe("SearchRequest.ts", () => {
 
@@ -68,6 +72,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -82,6 +87,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
         const aliasHex2 = "0x" + aliasHex
         const r2 = new SearchRequest(aliasHex2)
@@ -93,6 +99,7 @@ describe("SearchRequest.ts", () => {
         expect(r2.tokenInfo).toBeNull()
         expect(r2.topicMessages).toStrictEqual([])
         expect(r2.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -106,6 +113,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -119,6 +127,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toStrictEqual(SAMPLE_TOKEN)
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -132,6 +141,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual(SAMPLE_TOPIC_MESSAGES.messages)
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -145,6 +155,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -158,6 +169,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -172,6 +184,33 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
+
+    })
+
+    test("unknown account alias and invalid evm address", async () => {
+        const r = new SearchRequest(INVALID_EVM_ADDRESS)
+        await r.run()
+
+        expect(r.searchedId).toBe(INVALID_EVM_ADDRESS)
+        expect(r.account).toBeNull()
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
+
+        const aliasHex2 = "0x" + INVALID_EVM_ADDRESS
+        const r2 = new SearchRequest(aliasHex2)
+        await r2.run()
+
+        expect(r2.searchedId).toBe(aliasHex2)
+        expect(r.account).toBeNull()
+        expect(r2.transactions).toStrictEqual([])
+        expect(r2.tokenInfo).toBeNull()
+        expect(r2.topicMessages).toStrictEqual([])
+        expect(r2.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 
@@ -186,6 +225,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
 
     })
 


### PR DESCRIPTION
**Description**:

When:
- an hexadecimal value is entered in search  bar
- this value does not match any existing account alias
- number of bytes in this value is not 20 (ie evm address length)

then Explorer reports an error in place of "nothing found" message

Changes below:
- fix the issue above
- improve unit search unit tests


**Related issue(s)**:

Fixes #00164

**Notes for reviewer**:

You can experiment with:
- https://hashscan.io
- 0102030405060708090102030405060708


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
