### PR TITLE
Fix filtering of rewards transactions

### DIFF
--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -626,6 +626,154 @@ export const SAMPLE_CREATETOPIC_TRANSACTIONS = {
     ]
 }
 
+export const SAMPLE_REWARDS_TRANSACTIONS = {
+    "transactions": [
+        {
+            "bytes": null,
+            "charged_tx_fee": 78643,
+            "consensus_timestamp": "1646746059.558562000",
+            "entity_id": null,
+            "max_fee": "4000000",
+            "memo_base64": "",
+            "name": "CRYPTOTRANSFER",
+            "node": "0.0.17",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "RYfHjZoGCeAr9K1CNwVMztmx/F2im7Ae3yHkI3thlluzucsoP0uEuj3bKq+Qh84x",
+            "transaction_id": "0.0.14622-1646746046-722961649",
+            "transfers": [
+                {
+                    "account": "0.0.17",
+                    "amount": 2017
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 76626
+                },
+                {
+                    "account": "0.0.14622",
+                    "amount": -78643
+                },
+                {
+                    "account": "0.0.800",
+                    "amount": -123456789,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.15818224",
+                    "amount": 123456789,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.14684",
+                    "amount": 90000
+                },
+                {
+                    "account": "0.0.14698",
+                    "amount": -90000
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1646746046.722961649"
+        },
+        {
+            "bytes": null,
+            "charged_tx_fee": 273792,
+            "consensus_timestamp": "1660577929.534382083",
+            "entity_id": "0.0.47813131",
+            "max_fee": "200000000",
+            "memo_base64": "",
+            "name": "CRYPTOUPDATEACCOUNT",
+            "node": "0.0.3",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "j7iGcapZ01hw9tAmf5P1cojq3NEeONl5i43oBrknSD3uaPaS9BzKjkoEG4SHVWr3",
+            "transaction_id": "0.0.47813131-1660577918-385318328",
+            "transfers": [
+                {
+                    "account": "0.0.3",
+                    "amount": 11070,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 262722,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.800",
+                    "amount": -2334450720,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.15818224",
+                    "amount": 2334450720,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.47813131",
+                    "amount": -273792,
+                    "is_approval": false
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1660577918.385318328"
+        },
+        {
+            "bytes": null,
+            "charged_tx_fee": 78643,
+            "consensus_timestamp": "1646746059.040288661",
+            "entity_id": null,
+            "max_fee": "4000000",
+            "memo_base64": "",
+            "name": "CRYPTOTRANSFER",
+            "node": "0.0.5",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "+eQ70U7gSMiSavPTAr1RoKsWipe3H/oef5CiZ051Xli73Dc0XxXdQPnwT8Sml9sE",
+            "transaction_id": "0.0.19852-1646746046-457048377",
+            "transfers": [
+                {
+                    "account": "0.0.5",
+                    "amount": 2017
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 76626
+                },
+                {
+                    "account": "0.0.14684",
+                    "amount": 90000
+                },
+                {
+                    "account": "0.0.800",
+                    "amount": -234567890,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.15818224",
+                    "amount": 234567890,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.14698",
+                    "amount": -90000
+                },
+                {
+                    "account": "0.0.19852", "amount": -78643
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1646746046.457048377"
+        }
+    ]
+}
 
 //
 // Account inspired from: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts/0.0.730631

--- a/tests/unit/staking/RewardsTransactionTable.spec.ts
+++ b/tests/unit/staking/RewardsTransactionTable.spec.ts
@@ -1,0 +1,82 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {flushPromises, mount} from "@vue/test-utils"
+import router from "@/router";
+import {SAMPLE_REWARDS_TRANSACTIONS} from "../Mocks";
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import {Transaction} from "@/schemas/HederaSchemas";
+import RewardsTransactionTable from "@/components/staking/RewardsTransactionTable.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});
+
+HMSF.forceUTC = true
+
+describe("RewardsTransactionTable.vue", () => {
+
+    it("should display all rewards transactions", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(RewardsTransactionTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                narrowed: true,
+                nbItems: 42,
+                transactions: SAMPLE_REWARDS_TRANSACTIONS.transactions as Array<Transaction>,
+                accountId: SAMPLE_REWARDS_TRANSACTIONS.transactions[1].transfers[3].account
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.text())
+        // console.log(wrapper.html())
+
+        expect(wrapper.find('thead').text()).toBe("Time ID Type Amount Rewarded")
+        expect(wrapper.find('tbody').text()).toBe(
+            "1:27:39.5585 PMMar 8, 2022, UTC" + "0.0.14622@1646746046.722961649" + "CRYPTO TRANSFER" + "1.23456789" +
+            "3:38:49.5343 PMAug 15, 2022, UTC" + "0.0.47813131@1660577918.385318328" + "CRYPTO UPDATE ACCOUNT" + "23.34450720" +
+            "1:27:39.0402 PMMar 8, 2022, UTC" + "0.0.19852@1646746046.457048377" + "CRYPTO TRANSFER" + "2.34567890"
+        )
+    });
+
+});


### PR DESCRIPTION
**Description**:

This PR fixes the filtering of transactions which are paying rewards to the user.
Among all transactions related to the user account, we select those which have:

- an amount coming from 0.0.800
- and the same amount paid to the user account

That amount is considered the rewards amount.

**Notes for reviewer**:

Branch may be squashed and deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
