### PR TITLE
00179 rewards estimator always on

### DIFF
--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -114,7 +114,7 @@
         </template>
 
         <template v-else>
-          <section class="section has-text-centered" style="min-height: 450px">
+          <section class="section has-text-centered pt-0" :class="{'pb-0': isSmallScreen}">
             <p class="h-is-tertiary-text" style="font-weight: 300">
               To view or change your staking you first need to connect your wallet.
             </p>
@@ -145,8 +145,7 @@
       </template>
     </DashboardCard>
 
-    <RewardsCalculator v-if="accountId" :class="{'h-has-opacity-40': isIndirectStaking}"
-                       :amount-in-hbar="balanceInHbar"
+    <RewardsCalculator :amount-in-hbar="balanceInHbar"
                        :node-id="stakedNode?.node_id"/>
 
   </section>
@@ -297,7 +296,7 @@ export default defineComponent({
     })
 
     const balanceInHbar = computed(() => {
-      const balance = account.value?.balance?.balance ?? 0
+      const balance = account.value?.balance?.balance ?? 10000000000
       return balance / 100000000
     })
 

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -131,7 +131,7 @@
               </template>
             </Property>
             <Property id="nodeAccount">
-              <template v-slot:name>Node Account</template>
+              <template v-slot:name>Node Submitted To</template>
               <template v-slot:value>
                 <AccountLink v-bind:accountId="transaction?.node" v-bind:show-extra="true"/>
               </template>


### PR DESCRIPTION
**Description**:

The Rewards Estimator was previously shown on the Staking page only once the user had connected a wallet.
And when the user had chosen to stake to another account, the RE was disabled.
With these changes, the RE is always shown and always enabled.

There is also an unrelated renaming of Transaction property: 'Node Account' -> 'Node Submitted To'

**Related issue(s)**:

Fixes #179

**Notes for reviewer**:

These changes are currently deployed on the staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
