### PR TITLE
Make Rewards Estimator disclaimer notice part of branding.

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,9 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 ### The URL to which a click on the bottom-right sponsor logo will navigate
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
+### The HTML content of the disclaimer notice displayed on the Rewards Estimator
+# VUE_APP_ESTIMATOR_NOTICE="<HTML content>"
+
 ### When set to 'true', this variable will enable the 'Staking' page
 VUE_APP_ENABLE_STAKING=false
 

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -65,14 +65,7 @@
         <NetworkDashboardItem :title="'Approx Yearly Reward Rate'" :value="yearlyRate*100 + '%'"/>
       </div>
 
-      <div class="mt-2 h-is-text-size-2 is-italic has-text-grey">
-        These numbers are not individualized and only for illustrative purposes.
-        Please see the
-        <a href="https://docs.hedera.com/guides/core-concepts/staking" class="is-underlined has-text-grey">
-          <span>staking documentation</span>
-        </a>
-        for factors that can influence these numbers.
-      </div>
+      <div v-html="htmlNotice"/>
 
     </template>
   </DashboardCard>
@@ -107,6 +100,8 @@ export default defineComponent({
   },
 
   setup(props) {
+    const htmlNotice = process.env.VUE_APP_ESTIMATOR_NOTICE ?? ""
+
     const isSmallScreen = inject('isSmallScreen', true)
     const isMediumScreen = inject('isMediumScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
@@ -205,6 +200,7 @@ export default defineComponent({
     }
 
     return {
+      htmlNotice,
       isSmallScreen,
       isMediumScreen,
       isTouchDevice,


### PR DESCRIPTION
Signed-off-by: Simon Viénot <simon.vienot@icloud.com>

**Description**:

Title almost says everything...
With this change, the HTML content of the disclaimer notice shown at the bottom of the Rewards Estimator is now part of the branding, and empty by default.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Get an updated branding content to get back the initial notice.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
