### PR TITLE
00186 Adapt to new network/stake REST API

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -204,11 +204,11 @@ export default defineComponent({
     })
 
     const makeStakeProgress = (node: NetworkNode) =>
-        progressScale.value ? (makeUnclampedStake(node) / 100000000) / progressScale.value * 100 : 0
+        progressScale.value ? makeUnclampedStake(node)  / progressScale.value * 100 : 0
 
     const isStakeInRange = (node: NetworkNode) => {
       let result: boolean
-      const stake = (node.stake ?? 0) / 100000000
+      const stake = node.stake ?? 0
       if (stake && props.minStake && props.maxStake) {
         result = stake >= props.minStake && stake < props.maxStake
       }

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -144,6 +144,7 @@ export default defineComponent({
   props: {
     nodes: Object as PropType<Array<NetworkNode> | undefined>,
     unclampedStakeTotal: Number,
+    stakeTotal: Number,
     minStake: Number,
     maxStake: Number,
   },
@@ -168,7 +169,7 @@ export default defineComponent({
         style: 'percent',
         maximumFractionDigits: 1
       })
-      return formatter.format(node.stake && node.stake_total ? node.stake / node.stake_total : 0);
+      return formatter.format(node.stake && props.stakeTotal ? node.stake / props.stakeTotal : 0);
     }
 
     const rewardRate = (node: NetworkNode) => {

--- a/src/components/staking/StakeLoader.ts
+++ b/src/components/staking/StakeLoader.ts
@@ -1,0 +1,43 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityLoader} from "@/utils/EntityLoader";
+import {NetworkStake} from "@/schemas/HederaSchemas";
+import axios, {AxiosResponse} from "axios";
+
+export class StakeLoader extends EntityLoader<NetworkStake> {
+
+    //
+    // Public
+    //
+
+    public constructor() {
+        super()
+        this.requestLoad()
+    }
+
+    //
+    // EntityLoader
+    //
+
+    protected async load(): Promise<AxiosResponse<NetworkStake>> {
+        return axios.get<NetworkStake>("api/v1/network/stake")
+    }
+}

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -93,18 +93,18 @@
               <NetworkDashboardItem :name="'APPROX ANNUAL EQUIVALENT'" :title="'Last Period Reward Rate'"
                                     :value="approxYearlyRate.toString()"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="stake.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="makeFloorHbarAmount(stake)"/>
                 <p v-if="stake" class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
                 <p v-else class="h-is-property-text h-is-extra-text mt-1">(&lt;Min)</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="minStake.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="makeFloorHbarAmount(minStake)"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="maxStake.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="makeFloorHbarAmount(maxStake)"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="stakeRewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="makeFloorHbarAmount(stakeRewarded)"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Not Rewarded'" :value="stakeUnrewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Not Rewarded'" :value="makeFloorHbarAmount(stakeUnrewarded)"/>
               <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of total</p>
               <br/><br/>
               <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>
@@ -147,6 +147,7 @@ import HexaValue from "@/components/values/HexaValue.vue";
 import {operatorRegistry} from "@/schemas/OperatorRegistry";
 import Endpoints from "@/components/values/Endpoints.vue";
 import NetworkDashboardItem from "@/components/node/NetworkDashboardItem.vue";
+import {StakeLoader} from "@/components/staking/StakeLoader";
 
 export default defineComponent({
 
@@ -180,6 +181,7 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const nodes = ref<Array<NetworkNode> | null>([])
     const node = ref<NetworkNode | null>(null)
+    const stakeLoader = new StakeLoader()
 
     const rewardRate = computed(() =>
         node.value?.reward_rate_start && node.value?.stake_rewarded
@@ -192,19 +194,27 @@ export default defineComponent({
       })
       return formatter.format(rewardRate.value * 365);
     })
-    const stake = computed(() => node.value?.stake ? Math.round(node.value.stake / 100000000) : 0)
-    const minStake = computed(() => node.value?.min_stake ? Math.round(node.value.min_stake / 100000000) : 0)
-    const maxStake = computed(() => node.value?.max_stake ? Math.round(node.value.max_stake / 100000000) : 0)
-    const stakeTotal = computed(() => node.value?.stake_total ? Math.round(node.value.stake_total / 100000000) : 0)
+    const stake = computed(() => node.value?.stake ?? 0)
+    const minStake = computed(() => node.value?.min_stake ?? 0)
+    const maxStake = computed(() => node.value?.max_stake ?? 0)
+    const stakeTotal = computed(() => {
+      let result
+      if (stakeLoader.got404.value) {
+        result = (node.value?.stake_total ?? 0)
+      } else {
+        result = (stakeLoader.entity.value?.stake_total ?? 0)
+      }
+      return result
+    })
     const stakePercentage = computed(() =>
         stakeTotal.value ? Math.round(stake.value / stakeTotal.value * 10000) / 100 : 0)
 
-    const stakeRewarded = computed(() => node.value?.stake_rewarded ? Math.round(node.value.stake_rewarded / 100000000) : 0)
+    const stakeRewarded = computed(() => node.value?.stake_rewarded ?? 0)
     const stakeRewardedTotal = ref(0)
     const stakeRewardedPercentage = computed(() =>
         stakeRewardedTotal.value ? Math.round(stakeRewarded.value / stakeRewardedTotal.value * 10000) / 100 : 0)
 
-    const stakeUnrewarded = computed(() => node.value?.stake_not_rewarded ? Math.round(node.value.stake_not_rewarded / 100000000) : 0)
+    const stakeUnrewarded = computed(() => node.value?.stake_not_rewarded ?? 0)
     const stakeUnrewardedTotal = ref(0)
     const stakeUnrewardedPercentage = computed(() =>
         stakeUnrewardedTotal.value ? Math.round(stakeUnrewarded.value / stakeUnrewardedTotal.value * 10000) / 100 : 0)
@@ -245,10 +255,10 @@ export default defineComponent({
               nodes.value = nodes.value ? nodes.value.concat(result.data.nodes) : result.data.nodes
               for (const n of result.data.nodes) {
                 if (n.stake_rewarded) {
-                  stakeRewardedTotal.value += n.stake_rewarded/100000000
+                  stakeRewardedTotal.value += n.stake_rewarded
                 }
                 if (n.stake_not_rewarded) {
-                  stakeUnrewardedTotal.value += n.stake_not_rewarded/100000000
+                  stakeUnrewardedTotal.value += n.stake_not_rewarded
                 }
               }
             }
@@ -279,6 +289,8 @@ export default defineComponent({
       return hash != undefined ? byteToHex(base64DecToArr(hash)) : ""
     }
 
+    const makeFloorHbarAmount = (tinyBarAmount: number) => Math.floor((tinyBarAmount ?? 0) / 100000000).toLocaleString('en-US')
+
     return {
       isSmallScreen,
       isTouchDevice,
@@ -294,7 +306,8 @@ export default defineComponent({
       stakeUnrewardedPercentage,
       notification,
       nodeDescription,
-      formatHash
+      formatHash,
+      makeFloorHbarAmount
     }
   },
 });

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -90,24 +90,24 @@
           </div>
 
           <div class="column h-has-column-separator">
-              <NetworkDashboardItem :name="'APPROX ANNUAL EQUIVALENT'" :title="'Last Period Reward Rate'"
+              <NetworkDashboardItem id="yearlyRate" :name="'APPROX ANNUAL EQUIVALENT'" :title="'Last Period Reward Rate'"
                                     :value="approxYearlyRate.toString()"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake for Consensus'" :value="makeFloorHbarAmount(stake)"/>
-                <p v-if="stake" class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
+              <NetworkDashboardItem id="consensusStake" :name="'HBAR'" :title="'Stake for Consensus'" :value="makeFloorHbarAmount(stake)"/>
+                <p id="consensusStakePercent" v-if="stake" class="h-is-property-text h-is-extra-text mt-1">{{ stakePercentage }}% of total</p>
                 <p v-else class="h-is-property-text h-is-extra-text mt-1">(&lt;Min)</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Min Stake'" :value="makeFloorHbarAmount(minStake)"/>
+              <NetworkDashboardItem id="minStake" :name="'HBAR'" :title="'Min Stake'" :value="makeFloorHbarAmount(minStake)"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Max Stake'" :value="makeFloorHbarAmount(maxStake)"/>
+              <NetworkDashboardItem id="maxStake" :name="'HBAR'" :title="'Max Stake'" :value="makeFloorHbarAmount(maxStake)"/>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Rewarded'" :value="makeFloorHbarAmount(stakeRewarded)"/>
-              <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
+              <NetworkDashboardItem id="rewarded" :name="'HBAR'" :title="'Stake Rewarded'" :value="makeFloorHbarAmount(stakeRewarded)"/>
+              <p id="rewardedPercent" class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Stake Not Rewarded'" :value="makeFloorHbarAmount(stakeUnrewarded)"/>
-              <p class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of total</p>
+              <NetworkDashboardItem id="notRewarded" :name="'HBAR'" :title="'Stake Not Rewarded'" :value="makeFloorHbarAmount(stakeUnrewarded)"/>
+              <p id="notRewardedPercent" class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of total</p>
               <br/><br/>
-              <NetworkDashboardItem :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>
+              <NetworkDashboardItem id="stakingPeriod" :name="'HOURS'" :title="'Current Staking Period'" :value="'24'"/>
               <p class="h-is-property-text h-is-extra-text mt-1">from 00:00 am today to 11:59 pm today UTC</p>
               <div class="mt-6"/>
           </div>

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -39,12 +39,12 @@
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + ' ago'"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="makeHbarAmount(unclampedStakeTotal)"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="makeFloorHbarAmount(unclampedStakeTotal)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in ' + formatSeconds(remainingMin*60)"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="makeHbarAmount(totalRewarded)"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="makeFloorHbarAmount(totalRewarded)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
             </div>
@@ -55,11 +55,11 @@
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + 'ago'"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="makeHbarAmount(unclampedStakeTotal)"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="makeFloorHbarAmount(unclampedStakeTotal)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in' + formatSeconds(remainingMin*60)"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="makeHbarAmount(totalRewarded)"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="makeFloorHbarAmount(totalRewarded)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
               <div class="mt-6"/>
@@ -74,7 +74,11 @@
         <span class="h-is-primary-title">Nodes</span>
       </template>
       <template v-slot:table>
-        <NodeTable :nodes="nodes" :unclamped-stake-total="unclampedStakeTotal" :min-stake="minStake" :max-stake="maxStake"/>
+        <NodeTable :nodes="nodes"
+                   :unclamped-stake-total="unclampedStakeTotal"
+                   :stake-total="stakeTotal"
+                   :min-stake="minStake"
+                   :max-stake="maxStake"/>
       </template>
     </DashboardCard>
 
@@ -99,6 +103,7 @@ import axios from "axios";
 import {NetworkNode, NetworkNodesResponse} from "@/schemas/HederaSchemas";
 import {formatSeconds} from "@/utils/Duration";
 import {StakingPeriod} from "@/utils/StakingPeriod";
+import {StakeLoader} from "@/components/staking/StakeLoader";
 
 export default defineComponent({
   name: 'Nodes',
@@ -120,10 +125,22 @@ export default defineComponent({
 
     let nodes = ref<Array<NetworkNode> | null>([])
     const totalNodes = computed(() => nodes.value?.length.toString() ?? "")
+    const stakeLoader = new StakeLoader()
 
     const minStake = ref(0)
     const maxStake = ref(0)
-    const stakeTotal = ref(0)
+    const compatibilityStakeTotal = ref(0)
+
+    const stakeTotal = computed(() => {
+      let result
+      if (stakeLoader.got404.value) {
+        result = compatibilityStakeTotal.value
+      } else {
+        result = (stakeLoader.entity.value?.stake_total ?? 0)
+      }
+      return result
+    })
+
     const unclampedStakeTotal = ref(0)
     const totalRewarded = ref(0)
     const stakingPeriod = ref<StakingPeriod | null>(null)
@@ -153,9 +170,9 @@ export default defineComponent({
             if (result.data.nodes) {
               nodes.value = nodes.value ? nodes.value.concat(result.data.nodes) : result.data.nodes
               if (nodes.value.length) {
-                stakeTotal.value = (nodes.value[0].stake_total ?? 0)
-                minStake.value = (nodes.value[0].min_stake ?? 0)
-                maxStake.value = (nodes.value[0].max_stake ?? 0)
+                compatibilityStakeTotal.value = nodes.value[0].stake_total ?? 0
+                minStake.value = nodes.value[0].min_stake ?? 0
+                maxStake.value = nodes.value[0].max_stake ?? 0
               }
               for (const n of result.data.nodes) {
                 totalRewarded.value += (n.reward_rate_start ?? 0)
@@ -181,7 +198,7 @@ export default defineComponent({
       stakingPeriod.value = new StakingPeriod(startTimeInSec, endTimeInSec)
     }
 
-    const makeHbarAmount = (tinyBarAmount: number) => (tinyBarAmount/100000000).toLocaleString('en-US')
+    const makeFloorHbarAmount = (tinyBarAmount: number) => Math.floor((tinyBarAmount ?? 0) / 100000000).toLocaleString('en-US')
 
     return {
       isSmallScreen,
@@ -196,7 +213,7 @@ export default defineComponent({
       durationMin,
       elapsedMin,
       remainingMin,
-      makeHbarAmount,
+      makeFloorHbarAmount,
       formatSeconds
     }
   }

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -39,12 +39,12 @@
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + ' ago'"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="unclampedStakeTotal.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="makeHbarAmount(unclampedStakeTotal)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in ' + formatSeconds(remainingMin*60)"/>
             </div>
             <div class="is-flex-direction-column">
-              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="totalRewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="makeHbarAmount(totalRewarded)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
             </div>
@@ -55,11 +55,11 @@
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Last Staked'" :value="formatSeconds(elapsedMin*60) + 'ago'"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="unclampedStakeTotal.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Total Staked'" :value="makeHbarAmount(unclampedStakeTotal)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Next Staking Period'" :value="'in' + formatSeconds(remainingMin*60)"/>
               <div class="mt-4"/>
-              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="totalRewarded.toLocaleString('en-US')"/>
+              <NetworkDashboardItem :name="'HBAR'" :title="'Last Period Reward'" :value="makeHbarAmount(totalRewarded)"/>
               <div class="mt-4"/>
               <NetworkDashboardItem :title="'Staking Period'" :value="formatSeconds(durationMin*60)"/>
               <div class="mt-6"/>
@@ -153,13 +153,13 @@ export default defineComponent({
             if (result.data.nodes) {
               nodes.value = nodes.value ? nodes.value.concat(result.data.nodes) : result.data.nodes
               if (nodes.value.length) {
-                stakeTotal.value = Math.round((nodes.value[0].stake_total ?? 0) / 100000000)
-                minStake.value = Math.round((nodes.value[0].min_stake ?? 0) / 100000000)
-                maxStake.value = Math.round((nodes.value[0].max_stake ?? 0) / 100000000)
+                stakeTotal.value = (nodes.value[0].stake_total ?? 0)
+                minStake.value = (nodes.value[0].min_stake ?? 0)
+                maxStake.value = (nodes.value[0].max_stake ?? 0)
               }
               for (const n of result.data.nodes) {
-                totalRewarded.value += (n.reward_rate_start ?? 0)/100000000
-                unclampedStakeTotal.value += ((n.stake_rewarded ?? 0) + (n.stake_not_rewarded ?? 0))/100000000
+                totalRewarded.value += (n.reward_rate_start ?? 0)
+                unclampedStakeTotal.value += (n.stake_rewarded ?? 0) + (n.stake_not_rewarded ?? 0)
               }
             }
             const next = result.data.links?.next
@@ -181,6 +181,8 @@ export default defineComponent({
       stakingPeriod.value = new StakingPeriod(startTimeInSec, endTimeInSec)
     }
 
+    const makeHbarAmount = (tinyBarAmount: number) => (tinyBarAmount/100000000).toLocaleString('en-US')
+
     return {
       isSmallScreen,
       isTouchDevice,
@@ -194,6 +196,7 @@ export default defineComponent({
       durationMin,
       elapsedMin,
       remainingMin,
+      makeHbarAmount,
       formatSeconds
     }
   }

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -472,6 +472,18 @@ export interface NetworkSupplyResponse {
     total_supply:	string | undefined  // The network's total supply of hbars in tinybars
 }
 
+export interface  NetworkStake {
+    max_staking_reward_rate_per_hbar: number,
+    node_reward_fee_fraction: number,
+    stake_total: number,
+    staking_period: TimestampRange,
+    staking_period_duration: number,
+    staking_periods_stored: number,
+    staking_reward_fee_fraction: number,
+    staking_reward_rate: number,
+    staking_start_threshold: number
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 //                                                      Block
 // ---------------------------------------------------------------------------------------------------------------------

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1166,6 +1166,7 @@ export const SAMPLE_NETWORK_NODES = {
             "node_account_id": "0.0.3",
             "node_cert_hash": "0xffd6ada74a3a34a9",
             "public_key": "0x308201a2300d0609",
+            "reward_rate_start": 13698630137,
             "service_endpoints": [
                 {
                     "ip_address_v4": "3.211.248.172",
@@ -1208,6 +1209,7 @@ export const SAMPLE_NETWORK_NODES = {
             "node_account_id": "0.0.4",
             "node_cert_hash": "0xffd6ada74a3a34a9",
             "public_key": "0x308201a2300d0609",
+            "reward_rate_start": 38356164383,
             "service_endpoints": [
                 {
                     "ip_address_v4": "3.133.213.146",
@@ -1237,6 +1239,7 @@ export const SAMPLE_NETWORK_NODES = {
             "node_account_id": "0.0.5",
             "node_cert_hash": "0xffd6ada74a3a34a9",
             "public_key": "0x308201a2300d0609",
+            "reward_rate_start": 57534246575,
             "service_endpoints": [
                 {
                     "ip_address_v4": "3.133.213.146",

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1262,6 +1262,25 @@ export const SAMPLE_NETWORK_NODES = {
 }
 
 //
+// https://testnet.mirrornode.hedera.com/api/v1/network/stake
+//
+
+export const SAMPLE_NETWORK_STAKE = {
+    "max_staking_reward_rate_per_hbar": 0,
+    "node_reward_fee_fraction": 0,
+    "stake_total": 2400000000000000,
+    "staking_period": {
+        "from": "1661212800.000000000",
+        "to": "1661299200.000000000"
+    },
+    "staking_period_duration": 0,
+    "staking_periods_stored": 0,
+    "staking_reward_fee_fraction": 0,
+    "staking_reward_rate": 0,
+    "staking_start_threshold": 0
+}
+
+//
 // https://mainnet-public.mirrornode.hedera.com/api/v1/network/supply
 //
 

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -92,6 +92,18 @@ describe("NodeDetails.vue", () => {
         expect(wrapper.get("#rangeToValue").text()).toBe("None")
         expect(wrapper.get("#nodeCertHashValue").text()).toBe("d317 df77 a69d 6bbe 1add adf8 6bCopy to Clipboard")
         expect(wrapper.get("#serviceEndpointsValue").text()).toBe("3.211.248.172:502113.211.248.172:5021235.231.208.148:035.231.208.148:5021135.231.208.148:50212")
+
+        expect(wrapper.get("#yearlyRate").text()).toBe("Last Period Reward Rate1%APPROX ANNUAL EQUIVALENT")
+        expect(wrapper.get("#consensusStake").text()).toBe("Stake for Consensus6,000,000HBAR")
+        expect(wrapper.get("#consensusStakePercent").text()).toBe("25% of total")
+        expect(wrapper.get("#minStake").text()).toBe("Min Stake1,000,000HBAR")
+        expect(wrapper.get("#maxStake").text()).toBe("Max Stake30,000,000HBAR")
+        expect(wrapper.get("#rewarded").text()).toBe("Stake Rewarded5,000,000HBAR")
+        expect(wrapper.get("#rewardedPercent").text()).toBe("26.32% of total")
+        expect(wrapper.get("#notRewarded").text()).toBe("Stake Not Rewarded1,000,000HBAR")
+        expect(wrapper.get("#notRewardedPercent").text()).toBe("20% of total")
+        expect(wrapper.get("#stakingPeriod").text()).toBe("Current Staking Period24HOURS")
+
     });
 
     it("Should update when account id changes", async () => {

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -74,7 +74,7 @@ describe("NodeTable.vue", () => {
             },
             props: {
                 nodes: SAMPLE_NETWORK_NODES.nodes as Array<NetworkNode>,
-                unclampedStakeTotal: testTotalStaked/100000000,
+                unclampedStakeTotal: testTotalStaked,
                 minStake: SAMPLE_NETWORK_NODES.nodes[0].min_stake,
                 maxStake: SAMPLE_NETWORK_NODES.nodes[0].max_stake
             }

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -88,9 +88,9 @@ describe("NodeTable.vue", () => {
         expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
+            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
+            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -75,6 +75,7 @@ describe("NodeTable.vue", () => {
             props: {
                 nodes: SAMPLE_NETWORK_NODES.nodes as Array<NetworkNode>,
                 unclampedStakeTotal: testTotalStaked,
+                stakeTotal: testTotalStaked,
                 minStake: SAMPLE_NETWORK_NODES.nodes[0].min_stake,
                 maxStake: SAMPLE_NETWORK_NODES.nodes[0].max_stake
             }

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -88,7 +88,12 @@ describe("Nodes.vue", () => {
         expect(cards[0].text()).toMatch(RegExp("^Network"))
         const items = cards[0].findAllComponents(NetworkDashboardItem)
         expect(items.length).toBe(6)
-        expect(items[0].text()).toMatch(RegExp("Total Nodes"))
+        expect(items[0].text()).toMatch(RegExp("Total Nodes3"))
+        expect(items[1].text()).toMatch(RegExp("Last Staked"))
+        expect(items[2].text()).toMatch(RegExp("Total Staked24,000,000HBAR"))
+        expect(items[3].text()).toMatch(RegExp("Next Staking Periodin"))
+        expect(items[4].text()).toMatch(RegExp("Last Period Reward0HBAR"))
+        expect(items[5].text()).toMatch(RegExp("Staking Period24h"))
 
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -94,7 +94,7 @@ describe("Nodes.vue", () => {
         expect(items[1].text()).toMatch(RegExp("Last Staked"))
         expect(items[2].text()).toMatch(RegExp("Total Staked24,000,000HBAR"))
         expect(items[3].text()).toMatch(RegExp("Next Staking Periodin"))
-        expect(items[4].text()).toMatch(RegExp("Last Period Reward0HBAR"))
+        expect(items[4].text()).toMatch(RegExp("Last Period Reward1,095HBAR"))
         expect(items[5].text()).toMatch(RegExp("Staking Period24h"))
 
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
@@ -102,9 +102,9 @@ describe("Nodes.vue", () => {
         expect(table.exists()).toBe(true)
         expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "0%" +
-            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%" +
-            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "0%"
+            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
+            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
+            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
         )
     });
 

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -21,7 +21,7 @@
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
-import {SAMPLE_NETWORK_NODES} from "../Mocks";
+import {SAMPLE_NETWORK_NODES, SAMPLE_NETWORK_STAKE} from "../Mocks";
 import DashboardCard from "@/components/DashboardCard.vue";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
@@ -72,6 +72,8 @@ describe("Nodes.vue", () => {
 
         const matcher1 = "/api/v1/network/nodes"
         mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
+        const matcher2 = "/api/v1/network/stake"
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
 
         const wrapper = mount(Nodes, {
             global: {


### PR DESCRIPTION
**Description**:

With these changes:

- the new `api/v1/network/stake` REST API is used to obtain `stake_total` when available on a mirror-node. Otherwise this data is obtained from the node ( `api/v1/network/stake/node?node.id=:id` ) as was done previously.
- the code related to staking is refactored to always pass and manipulate tinybar (not hbar) amounts. Amounts staked are rounded down to the hbar, but only at the time of display.
- augment unit tests related to Node staking.

**Related issue(s)**:

Fixes #186 

**Notes for reviewer**:

Branch may be deleted.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
