### PR TITLE
Implement requests from legal team

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,9 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 ### The URL to which a click on the bottom-right sponsor logo will navigate
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
+### The URL of the 'Terms of Use' page
+# VUE_APP_TERMS_OF_USE_URL="<URL>"
+
 ### The HTML content of the disclaimer notice displayed on the Rewards Estimator
 # VUE_APP_ESTIMATOR_NOTICE='<HTML content>'
 

--- a/.env
+++ b/.env
@@ -8,7 +8,10 @@ VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"
 
 ### The HTML content of the disclaimer notice displayed on the Rewards Estimator
-# VUE_APP_ESTIMATOR_NOTICE="<HTML content>"
+# VUE_APP_ESTIMATOR_NOTICE='<HTML content>'
+
+### The HTML content of the disclaimer popup dialog displayed by the Wallet Chooser
+# VUE_APP_WALLET_CHOOSER_DISCLAIMER_POPUP='<HTML content>'
 
 ### When set to 'true', this variable will enable the 'Staking' page
 VUE_APP_ENABLE_STAKING=false

--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -41,6 +41,19 @@ export class AppStorage {
         this.setLocalStorageItem(this.LAST_USED_NETWORK_KEY, newItem)
     }
 
+    //
+    // skip disclaimer (wallet chooser)
+    //
+
+    private static readonly DISCLAIMER_SKIP_KEY = 'skipDisclaimer'
+
+    public static getSkipDisclaimer(): boolean {
+        return  this.getLocalStorageItem(this.DISCLAIMER_SKIP_KEY) != null
+    }
+
+    public static setSkipDisclaimer(newValue: boolean|null): void {
+        this.setLocalStorageItem(this.DISCLAIMER_SKIP_KEY, newValue ? "true" : null)
+    }
 
     //
     // Private

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -46,11 +46,18 @@
     border: solid 0.5px transparent;
     border-radius: 6px;
 }
-.h-chooser-figure:hover {
-    border-color: var(--h-theme-highlight-color);
+.h-chooser-figure:hover:not(.selected) {
+    border: solid 0.5px var(--h-theme-highlight-color);
+    background-color: initial;
+}
+.h-chooser-figure:active:not(.selected) {
+    border: solid 0.5px var(--h-theme-highlight-color);
     background-color: var(--h-theme-page-background-color);
 }
-
+.h-chooser-figure.selected {
+    border: solid 1.5px var(--h-theme-highlight-color);
+    background-color: initial;
+}
 .h-chooser-img {
     vertical-align: middle;
 }

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -34,23 +34,24 @@
         <img alt="Built On Hedera" src="@/assets/built-on-hedera-white.svg" style="min-width: 104px;">
       </a>
 
-      <div v-if="!isTouchDevice && isMediumScreen" class="is-flex is-flex-direction-column is-align-items-flex-start">
-        <span class="h-is-property-text ml-5 pb-1" style="font-weight:300; color: #DBDBDB">
-          {{ productName }} is a ledger explorer for the Hedera network.
+      <div class="is-flex is-flex-direction-column is-align-items-flex-start ml-5">
+        <span class="h-is-property-text pb-1" style="font-weight:300; color: #DBDBDB">
+          <span>{{ productName }}</span>
+          <span v-if="!isTouchDevice && isMediumScreen"> is a ledger explorer for the Hedera network.</span>
         </span>
-        <span class="h-is-text-size-1 ml-5 pb-1" style="font-weight:300; color: #DBDBDB">
+        <span class="h-is-text-size-1" style="font-weight:300; color: #DBDBDB">
           Built {{ buildTime }}
         </span>
+        <a v-if="termsOfUseURL" :href="termsOfUseURL" style="line-height: 1rem">
+          <span class="h-is-text-size-3" style="font-weight:300">
+           See Terms of Use
+          </span>
+        </a>
       </div>
 
       <span class="is-flex-grow-1"/>
 
-      <a v-if="termsOfUseURL" :href="termsOfUseURL">
-        <span class="h-is-text-size-3" style="font-weight:300">
-          Terms of Use
-        </span>
-      </a>
-      <a v-if="sponsorURL" :href="sponsorURL" class="ml-4" style="line-height: 1">
+      <a v-if="sponsorURL" :href="sponsorURL" class="ml-4">
         <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
       </a>
       <div v-else class="ml-4" style="line-height: 1">

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -46,7 +46,7 @@
       <span class="is-flex-grow-1"/>
 
       <a v-if="termsOfUseURL" :href="termsOfUseURL">
-        <span class="h-is-text-size-2" style="font-weight:300; color: #DBDBDB">
+        <span class="h-is-text-size-3" style="font-weight:300">
           Terms of Use
         </span>
       </a>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -34,7 +34,7 @@
         <img alt="Built On Hedera" src="@/assets/built-on-hedera-white.svg" style="min-width: 104px;">
       </a>
 
-      <div v-if="!isTouchDevice && isSmallScreen" class="is-flex is-flex-direction-column is-align-items-flex-start">
+      <div v-if="!isTouchDevice && isMediumScreen" class="is-flex is-flex-direction-column is-align-items-flex-start">
         <span class="h-is-property-text ml-5 pb-1" style="font-weight:300; color: #DBDBDB">
           {{ productName }} is a ledger explorer for the Hedera network.
         </span>
@@ -45,7 +45,12 @@
 
       <span class="is-flex-grow-1"/>
 
-      <a v-if="sponsorURL" class="ml-4" :href="sponsorURL" style="line-height: 1">
+      <a v-if="termsOfUseURL" :href="termsOfUseURL">
+        <span class="h-is-text-size-2" style="font-weight:300; color: #DBDBDB">
+          Terms of Use
+        </span>
+      </a>
+      <a v-if="sponsorURL" :href="sponsorURL" class="ml-4" style="line-height: 1">
         <img alt="Sponsor Logo" src="@/assets/branding/brand-sponsor-logo.png" style="max-width: 104px;">
       </a>
       <div v-else class="ml-4" style="line-height: 1">
@@ -78,18 +83,22 @@ export default defineComponent({
   setup() {
     const buildTime = inject('buildTime', "not available")
 
+    const isMediumScreen = inject('isMediumScreen', true)
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
     const productName = process.env.VUE_APP_PRODUCT_NAME ?? "Hedera Mirror Node Explorer"
     const sponsorURL = process.env.VUE_APP_SPONSOR_URL ?? ""
+    const termsOfUseURL = process.env.VUE_APP_TERMS_OF_USE_URL ?? ""
 
     return {
       buildTime,
       isSmallScreen,
+      isMediumScreen,
       isTouchDevice,
       productName,
-      sponsorURL
+      sponsorURL,
+      termsOfUseURL
     }
   },
 })

--- a/src/components/ModalDialog.vue
+++ b/src/components/ModalDialog.vue
@@ -24,23 +24,32 @@
 
 <template>
   <div class="modal has-text-white" v-bind:class="{'is-active': showDialog}">
-    <div class="modal-background" @click="handleClose"/>
-    <div class="modal-content">
+    <div class="modal-background"/>
+    <div class="modal-content" style="width: 768px; border-radius: 16px">
       <div class="box">
-        <div class="is-flex is-flex-direction-row is-align-items-start">
-          <span class="icon is-large mr-4"><i :class="iconClass"/></span>
-          <div>
+
+        <div class="is-flex is-justify-content-space-between is-align-items-baseline">
+          <div class="is-flex is-justify-content-start is-align-items-baseline">
+            <span v-if="iconClass" class="icon ml-2 mr-5"><i :class="iconClass"/></span>
             <div class="block h-is-tertiary-text mt-2">
               <slot name="dialogMessage"/>
             </div>
-            <div class="block h-is-property-text has-text-grey mb-2" style="line-height: 1.5">
-              <slot name="dialogDetails"/>
-            </div>
           </div>
+          <a class="ml-5 mr-2"
+             @click="handleClose">
+             <img alt="Close icon" src="@/assets/close-icon.png" style="max-height: 22px;">
+          </a>
+
         </div>
+
+        <hr class="h-card-separator"/>
+
+        <div class="block h-is-property-text has-text-grey mb-2" style="line-height: 1.5">
+          <slot name="dialogDetails"/>
+        </div>
+
       </div>
     </div>
-    <button class="modal-close is-large has-background-grey" aria-label="close" @click="handleClose"/>
   </div>
 </template>
 
@@ -66,6 +75,7 @@ export default defineComponent({
   setup(props, context) {
     const handleClose = () => {
       context.emit('update:showDialog', false)
+      context.emit('onClose')
     }
     return { handleClose }
   }

--- a/src/components/ModalDialog.vue
+++ b/src/components/ModalDialog.vue
@@ -36,7 +36,7 @@
             </div>
           </div>
           <a @click="handleClose">
-            <img alt="Close icon" src="@/assets/close-icon.png" style="max-height: 20px;">
+            <img alt="Modal close icon" src="@/assets/close-icon.png" style="max-height: 20px;">
           </a>
 
         </div>

--- a/src/components/ModalDialog.vue
+++ b/src/components/ModalDialog.vue
@@ -35,9 +35,8 @@
               <slot name="dialogMessage"/>
             </div>
           </div>
-          <a class="ml-5 mr-2"
-             @click="handleClose">
-             <img alt="Close icon" src="@/assets/close-icon.png" style="max-height: 22px;">
+          <a @click="handleClose">
+            <img alt="Close icon" src="@/assets/close-icon.png" style="max-height: 20px;">
           </a>
 
         </div>

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -1,0 +1,72 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <ModalDialog :show-dialog="showDialog" :icon-class="iconClass">
+    <template v-slot:dialogMessage>
+      <slot name="dialogMessage"/>
+    </template>
+    <template v-slot:dialogDetails>
+      <slot name="dialogDetails"/>
+
+      <div class="is-flex is-justify-content-end is-align-items-center">
+        <span>Please don't show me this next time</span>
+        <label class="checkbox ml-2 mt-1">
+          <input type="checkbox">
+        </label>
+      </div>
+    </template>
+  </ModalDialog>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent} from "vue";
+import ModalDialog from "@/components/ModalDialog.vue";
+
+export default defineComponent({
+  name: "OptOutDialog",
+  components: {ModalDialog},
+  props: {
+    showDialog: {
+      type: Boolean,
+      default: false
+    },
+    iconClass: String
+  }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+</style>
+

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -30,11 +30,11 @@
     <template v-slot:dialogDetails>
       <slot name="dialogDetails"/>
 
-      <div class="is-flex is-justify-content-end is-align-items-center mt-3 has-text-grey-light">
-        <span>Please don't show me this next time</span>
-        <label class="checkbox ml-2 mt-1">
+      <div class="is-flex is-justify-content-start is-align-items-center mt-3 has-text-grey-light">
+        <label class="checkbox mr-2 mt-1">
           <input type="checkbox">
         </label>
+        <span>Please don't show me this next time</span>
       </div>
     </template>
   </ModalDialog>

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -30,7 +30,7 @@
     <template v-slot:dialogDetails>
       <slot name="dialogDetails"/>
 
-      <div class="is-flex is-justify-content-end is-align-items-center">
+      <div class="is-flex is-justify-content-end is-align-items-center mt-3 has-text-grey-light">
         <span>Please don't show me this next time</span>
         <label class="checkbox ml-2 mt-1">
           <input type="checkbox">

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -56,6 +56,7 @@
 
 import {defineComponent, ref} from "vue";
 import ModalDialog from "@/components/ModalDialog.vue";
+import {AppStorage} from "@/AppStorage";
 
 export default defineComponent({
   name: "OptOutDialog",
@@ -71,12 +72,13 @@ export default defineComponent({
     const dontShowNextTime = ref(false)
     const handleAgree = () => {
       if (dontShowNextTime.value) {
-        console.log("Should store NOT NEXT TIME")
+        AppStorage.setSkipDisclaimer(true)
       }
       context.emit('update:showDialog', false)
       context.emit('onAgree')
     }
     const handleCancel = () => {
+      dontShowNextTime.value = false
       context.emit('update:showDialog', false)
       context.emit('onClose')
     }

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -23,19 +23,27 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <ModalDialog :show-dialog="showDialog" :icon-class="iconClass">
+  <ModalDialog :icon-class="iconClass" :show-dialog="showDialog">
     <template v-slot:dialogMessage>
       <slot name="dialogMessage"/>
     </template>
     <template v-slot:dialogDetails>
       <slot name="dialogDetails"/>
 
-      <div class="is-flex is-justify-content-start is-align-items-center mt-3 has-text-grey-light">
-        <label class="checkbox mr-2 mt-1">
-          <input type="checkbox">
-        </label>
-        <span>Please don't show me this next time</span>
+      <div class="is-flex is-justify-content-space-between is-align-items-baseline">
+        <div class="is-flex is-justify-content-start is-align-items-center mt-3 has-text-grey-light">
+          <label class="checkbox mr-2 mt-1">
+            <input v-model="dontShowNextTime" type="checkbox">
+          </label>
+          <span>Please don't show me this next time</span>
+        </div>
+
+        <div class="is-flex is-justify-content-flex-end">
+          <button class="button is-white is-small" @click="handleCancel">CANCEL</button>
+          <button class="button is-info is-small ml-4" @click="handleAgree">AGREE</button>
+        </div>
       </div>
+
     </template>
   </ModalDialog>
 </template>
@@ -46,7 +54,7 @@
 
 <script lang="ts">
 
-import {defineComponent} from "vue";
+import {defineComponent, ref} from "vue";
 import ModalDialog from "@/components/ModalDialog.vue";
 
 export default defineComponent({
@@ -58,6 +66,25 @@ export default defineComponent({
       default: false
     },
     iconClass: String
+  },
+  setup(props, context) {
+    const dontShowNextTime = ref(false)
+    const handleAgree = () => {
+      if (dontShowNextTime.value) {
+        console.log("Should store NOT NEXT TIME")
+      }
+      context.emit('update:showDialog', false)
+      context.emit('onAgree')
+    }
+    const handleCancel = () => {
+      context.emit('update:showDialog', false)
+      context.emit('onClose')
+    }
+    return {
+      dontShowNextTime,
+      handleAgree,
+      handleCancel
+    }
   }
 });
 

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -30,7 +30,7 @@
     <template v-slot:dialogDetails>
       <slot name="dialogDetails"/>
 
-      <div class="is-flex is-justify-content-space-between is-align-items-baseline">
+      <div class="is-flex is-justify-content-space-between is-align-items-baseline mt-4">
         <div class="is-flex is-justify-content-start is-align-items-center mt-3 has-text-grey-light">
           <label class="checkbox mr-2 mt-1">
             <input v-model="dontShowNextTime" type="checkbox">

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -39,7 +39,7 @@
     <div class="modal-content" style="width: 768px; border-radius: 16px">
       <div class="box">
         <div class="is-flex is-justify-content-space-between is-align-items-self-end">
-            <span class="h-is-primary-title">Choose Wallet</span>
+          <span class="h-is-primary-title">Connect Wallet</span>
           <a @click="handleCancel">
             <img alt="" src="@/assets/close-icon.png" style="max-height: 20px;">
           </a>
@@ -48,12 +48,18 @@
 
         <div class="is-flex is-justify-content-left is-align-items-center">
           <div v-for="d in drivers" :key="d.name">
-              <a :id="d.name" @click="handleChoose(d)">
-                <figure class="h-chooser-figure my-4 mr-6">
-                  <img class="h-chooser-img" alt="wallet logo" :src="d.iconURL">
-                </figure>
-              </a>
+            <a :id="d.name" @click="chosenWallet = d">
+              <figure :class="{'selected':isSelected(d)}" class="h-chooser-figure my-4 mr-6">
+                <img :src="d.iconURL" alt="wallet logo" class="h-chooser-img">
+              </figure>
+            </a>
           </div>
+        </div>
+
+        <div class="is-flex is-justify-content-flex-end">
+          <button id="cancelButton" class="button is-white is-small" @click="handleCancel">CANCEL</button>
+          <button id="connectButton" :disabled="!chosenWallet" class="button is-info is-small ml-4" @click="handleConnect">CONNECT
+          </button>
         </div>
 
       </div>
@@ -83,21 +89,24 @@ export default defineComponent({
     },
   },
 
-  emits: [ "chooseWallet", "update:showDialog"],
+  emits: ["chooseWallet", "update:showDialog"],
 
   setup(props, context) {
-    let chosenWallet: WalletDriver
+    const chosenWallet = ref<WalletDriver | null>(null)
     const showDisclaimerDialog = ref(false)
     const disclaimer = process.env.VUE_APP_WALLET_CHOOSER_DISCLAIMER_POPUP ?? ""
 
-    const handleChoose = (wallet: WalletDriver) => {
+    const handleConnect = () => {
       context.emit('update:showDialog', false)
-      chosenWallet = wallet
       if (disclaimer) {
         showDisclaimerDialog.value = true
       } else {
-        context.emit('chooseWallet', chosenWallet)
+        context.emit('chooseWallet', chosenWallet.value)
       }
+    }
+
+    const isSelected = (wallet: WalletDriver) => {
+      return chosenWallet.value && (chosenWallet.value.name === wallet.name)
     }
 
     const handleCancel = () => {
@@ -110,7 +119,7 @@ export default defineComponent({
 
     const handleAgreeDisclaimer = () => {
       showDisclaimerDialog.value = false
-      context.emit('chooseWallet', chosenWallet)
+      context.emit('chooseWallet', chosenWallet.value)
     }
 
     return {
@@ -118,9 +127,11 @@ export default defineComponent({
       disclaimer,
       handleCancelDisclaimer,
       handleAgreeDisclaimer,
+      isSelected,
+      chosenWallet,
       walletManager,
-      drivers:walletManager.getDrivers(),
-      handleChoose,
+      drivers: walletManager.getDrivers(),
+      handleConnect,
       handleCancel
     }
   }

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -24,14 +24,14 @@
 
 <template>
 
-  <ModalDialog v-model:show-dialog="showDisclaimerDialog" @onClose="handleCloseDisclaimer">
+  <OptOutDialog v-model:show-dialog="showDisclaimerDialog" @onClose="handleCloseDisclaimer">
     <template v-slot:dialogMessage>
       <span>Disclaimer</span>
     </template>
     <template v-slot:dialogDetails>
       <div v-html="disclaimer"/>
     </template>
-  </ModalDialog>
+  </OptOutDialog>
 
   <div :class="{'is-active': showDialog}" class="modal has-text-white">
     <div class="modal-background"/>
@@ -70,11 +70,11 @@
 import {defineComponent, ref} from "vue";
 import {walletManager} from "@/router";
 import {WalletDriver} from "@/utils/wallet/WalletDriver";
-import ModalDialog from "@/components/ModalDialog.vue";
+import OptOutDialog from "@/components/staking/OptOutDialog.vue";
 
 export default defineComponent({
   name: "WalletChooser",
-  components: {ModalDialog},
+  components: {OptOutDialog},
   props: {
     showDialog: {
       type: Boolean,

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -24,7 +24,8 @@
 
 <template>
 
-  <OptOutDialog v-model:show-dialog="showDisclaimerDialog" @onClose="handleCloseDisclaimer">
+  <OptOutDialog v-model:show-dialog="showDisclaimerDialog"
+                @onClose="handleCancelDisclaimer" @onAgree="handleAgreeDisclaimer">
     <template v-slot:dialogMessage>
       <span>Disclaimer</span>
     </template>
@@ -103,7 +104,11 @@ export default defineComponent({
       context.emit('update:showDialog', false)
     }
 
-    const handleCloseDisclaimer = () => {
+    const handleCancelDisclaimer = () => {
+      showDisclaimerDialog.value = false
+    }
+
+    const handleAgreeDisclaimer = () => {
       showDisclaimerDialog.value = false
       context.emit('chooseWallet', chosenWallet)
     }
@@ -111,7 +116,8 @@ export default defineComponent({
     return {
       showDisclaimerDialog,
       disclaimer,
-      handleCloseDisclaimer,
+      handleCancelDisclaimer,
+      handleAgreeDisclaimer,
       walletManager,
       drivers:walletManager.getDrivers(),
       handleChoose,

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -24,16 +24,6 @@
 
 <template>
 
-  <OptOutDialog v-model:show-dialog="showDisclaimerDialog"
-                @onClose="handleCancelDisclaimer" @onAgree="handleAgreeDisclaimer">
-    <template v-slot:dialogMessage>
-      <span>Disclaimer</span>
-    </template>
-    <template v-slot:dialogDetails>
-      <div v-html="disclaimer"/>
-    </template>
-  </OptOutDialog>
-
   <div :class="{'is-active': showDialog}" class="modal has-text-white">
     <div class="modal-background"/>
     <div class="modal-content" style="width: 768px; border-radius: 16px">
@@ -65,6 +55,17 @@
       </div>
     </div>
   </div>
+
+
+  <OptOutDialog v-model:show-dialog="showDisclaimerDialog"
+                @onClose="handleCancelDisclaimer" @onAgree="handleAgreeDisclaimer">
+    <template v-slot:dialogMessage>
+      <span>Disclaimer</span>
+    </template>
+    <template v-slot:dialogDetails>
+      <div v-html="disclaimer"/>
+    </template>
+  </OptOutDialog>
 
 </template>
 

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -38,7 +38,7 @@
 
         <div class="is-flex is-justify-content-left is-align-items-center">
           <div v-for="d in drivers" :key="d.name">
-            <a :id="d.name" @click="chosenWallet = d">
+            <a :id="d.name" @click="chosenWallet=d" @dblclick="handleConnect">
               <figure :class="{'selected':isSelected(d)}" class="h-chooser-figure my-4 mr-6">
                 <img :src="d.iconURL" alt="wallet logo" class="h-chooser-img">
               </figure>

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -79,6 +79,7 @@ import {defineComponent, ref} from "vue";
 import {walletManager} from "@/router";
 import {WalletDriver} from "@/utils/wallet/WalletDriver";
 import OptOutDialog from "@/components/staking/OptOutDialog.vue";
+import {AppStorage} from "@/AppStorage";
 
 export default defineComponent({
   name: "WalletChooser",
@@ -99,7 +100,7 @@ export default defineComponent({
 
     const handleConnect = () => {
       context.emit('update:showDialog', false)
-      if (disclaimer) {
+      if (disclaimer && !AppStorage.getSkipDisclaimer()) {
         showDisclaimerDialog.value = true
       } else {
         context.emit('chooseWallet', chosenWallet.value)

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -82,6 +82,13 @@
               </div>
               <button id="disconnectWalletButton" class="button is-white is-small" @click="disconnectFromWallet">DISCONNECT {{ walletName.toLocaleUpperCase() }}</button>
             </div>
+            <div class="mt-5 h-is-text-size-2 is-italic has-text-grey has-text-centered">
+              <span class="has-text-grey-light">Please Note: </span>
+              Staking is in Phase 1 and will not pay out rewards until Phase 3.<br/>
+              Your full balance is automatically staked.<br/>
+              Your funds are fully available for use while staked.<br/>
+              You can unstake or switch nodes freely.
+            </div>
           </div>
           <div v-else>
             <div class="is-flex-direction-column">
@@ -99,6 +106,13 @@
                 </div>
             <div class="is-flex is-justify-content-center mt-4">
               <button id="disconnectWalletButton" class="button is-white is-small" @click="disconnectFromWallet">DISCONNECT WALLET</button>
+            </div>
+            <div class="mt-5 h-is-text-size-2 is-italic has-text-grey has-text-centered">
+              <span class="has-text-grey-light">Please Note: </span>
+              Staking is in Phase 1 and will not pay out rewards until Phase 3.<br/>
+              Your full balance is automatically staked.<br/>
+              Your funds are fully available for use while staked.<br/>
+              You can unstake or switch nodes freely.
             </div>
             <div class="mt-6"/>
           </div>

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -100,12 +100,12 @@
               <div class="mt-4"/>
             </div>
               <div class="is-flex is-justify-content-center">
-                  <button id="stopStakingButton" class="button is-white is-small"
+                  <button id="stopStakingButtonSmall" class="button is-white is-small"
                           :disabled="!stakedTo" @click="showStopConfirmDialog = true">STOP STAKING</button>
-                  <button id="showStakingDialog" class="button is-white is-small ml-4" @click="showStakingDialog = true">CHANGE STAKED TO</button>
+                  <button id="showStakingDialogSmall" class="button is-white is-small ml-4" @click="showStakingDialog = true">CHANGE STAKED TO</button>
                 </div>
             <div class="is-flex is-justify-content-center mt-4">
-              <button id="disconnectWalletButton" class="button is-white is-small" @click="disconnectFromWallet">DISCONNECT WALLET</button>
+              <button id="disconnectWalletButtonSmall" class="button is-white is-small" @click="disconnectFromWallet">DISCONNECT WALLET</button>
             </div>
             <div class="mt-5 h-is-text-size-2 is-italic has-text-grey has-text-centered">
               <span class="has-text-grey-light">Please Note: </span>

--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
+import { Transaction, TransactionType } from "@/schemas/HederaSchemas";
 
 export class EntityDescriptor {
 
@@ -56,6 +56,10 @@ export class EntityDescriptor {
             case TransactionType.TOKENDISSOCIATE:
             case TransactionType.CRYPTOAPPROVEALLOWANCE:
             case TransactionType.CRYPTODELETEALLOWANCE:
+            case TransactionType.TOKENGRANTKYC:
+            case TransactionType.TOKENREVOKEKYC:
+            case TransactionType.TOKENFREEZE:
+            case TransactionType.TOKENUNFREEZE:
                 result = new EntityDescriptor("Account ID", "AccountDetails")
                 break;
 
@@ -78,12 +82,8 @@ export class EntityDescriptor {
             case TransactionType.TOKENDELETION:
             case TransactionType.TOKENUPDATE:
             case TransactionType.TOKENFEESCHEDULEUPDATE:
-            case TransactionType.TOKENFREEZE:
-            case TransactionType.TOKENGRANTKYC:
             case TransactionType.TOKENMINT:
             case TransactionType.TOKENPAUSE:
-            case TransactionType.TOKENREVOKEKYC:
-            case TransactionType.TOKENUNFREEZE:
             case TransactionType.TOKENUNPAUSE:
             case TransactionType.TOKENWIPE:
                 result = new EntityDescriptor("Token ID", "TokenDetails");

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
+import { Transaction, TransactionType } from "@/schemas/HederaSchemas";
 
 export function makeSummaryLabel(row: Transaction): string {
     let result: string
@@ -42,6 +42,10 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.CRYPTOUPDATEACCOUNT:
         case TransactionType.TOKENASSOCIATE:
         case TransactionType.TOKENDISSOCIATE:
+        case TransactionType.TOKENGRANTKYC:
+        case TransactionType.TOKENREVOKEKYC:
+        case TransactionType.TOKENFREEZE:
+        case TransactionType.TOKENUNFREEZE:
             result = row.entity_id ? "Account ID: " + row.entity_id : ""
             break
         case TransactionType.TOKENBURN:
@@ -49,12 +53,9 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.TOKENCREATION:
         case TransactionType.TOKENDELETION:
         case TransactionType.TOKENFEESCHEDULEUPDATE:
-        case TransactionType.TOKENFREEZE:
-        case TransactionType.TOKENUNFREEZE:
         case TransactionType.TOKENPAUSE:
         case TransactionType.TOKENUNPAUSE:
         case TransactionType.TOKENUPDATE:
-        case TransactionType.TOKENGRANTKYC:
             result = row.entity_id ? "Token ID: " + row.entity_id : ""
             break
         case TransactionType.CONTRACTCREATEINSTANCE:
@@ -130,7 +131,7 @@ export function showPositiveNetAmount(row: Transaction): boolean {
     const netAmount = computeNetAmount(row)
     switch (row.name) {
         case TransactionType.CRYPTOTRANSFER:
-            result= true
+            result = true
             break
         default:
             result = netAmount > 0

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -107,12 +107,13 @@ describe("App.vue", () => {
         expect(cards[2].text()).toMatch(RegExp("^HCS Messages"))
 
         const logos = wrapper.findAll("img")
-        expect(logos.length).toBe(5)
+        expect(logos.length).toBe(6)
         expect(logos[0].attributes('alt')).toBe("Product Logo")
-        expect(logos[1].attributes('alt')).toBe("Trend Up")
+        expect(logos[1].attributes('alt')).toBe("Modal close icon")
         expect(logos[2].attributes('alt')).toBe("Trend Up")
-        expect(logos[3].attributes('alt')).toBe("Built On Hedera")
-        expect(logos[4].attributes('alt')).toBe("Sponsor Logo")
+        expect(logos[3].attributes('alt')).toBe("Trend Up")
+        expect(logos[4].attributes('alt')).toBe("Built On Hedera")
+        expect(logos[5].attributes('alt')).toBe("Sponsor Logo")
 
         wrapper.unmount()
     });

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -71,7 +71,7 @@ describe("TopNavBar.vue", () => {
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccountsNodesStakingBlocks")
 
         const links = wrapper.findAll("a")
-        expect(links.length).toBe(10)
+        expect(links.length).toBe(11)
     })
 
     it("Should display logos, page links and full search bar", async () => {
@@ -95,22 +95,24 @@ describe("TopNavBar.vue", () => {
             "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccountsNodesStakingBlocks")
 
         const links = wrapper.findAll("a")
-        expect(links.length).toBe(10)
-        expect(links[1].text()).toBe("Dashboard")
-        expect(links[2].text()).toBe("Transactions")
-        expect(links[3].text()).toBe("Tokens")
-        expect(links[4].text()).toBe("Topics")
-        expect(links[5].text()).toBe("Contracts")
-        expect(links[6].text()).toBe("Accounts")
-        expect(links[7].text()).toBe("Nodes")
-        expect(links[8].text()).toBe("Staking")
-        expect(links[9].text()).toBe("Blocks")
+        expect(links.length).toBe(11)
+
+        expect(links[2].text()).toBe("Dashboard")
+        expect(links[3].text()).toBe("Transactions")
+        expect(links[4].text()).toBe("Tokens")
+        expect(links[5].text()).toBe("Topics")
+        expect(links[6].text()).toBe("Contracts")
+        expect(links[7].text()).toBe("Accounts")
+        expect(links[8].text()).toBe("Nodes")
+        expect(links[9].text()).toBe("Staking")
+        expect(links[10].text()).toBe("Blocks")
 
         expect(wrapper.findComponent(SearchBar).exists()).toBe(true)
 
         const logos = wrapper.findAll("img")
-        expect(logos.length).toBe(1)
+        expect(logos.length).toBe(2)
         expect(logos[0].attributes('alt')).toBe("Product Logo")
+        expect(logos[1].attributes('alt')).toBe("Modal close icon")
 
         wrapper.unmount()
     });

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -40,6 +40,7 @@ import ProgressDialog from "@/components/staking/ProgressDialog.vue";
 import {waitFor} from "@/utils/TimerUtils";
 import StakingDialog from "@/components/staking/StakingDialog.vue";
 import {nextTick} from "vue";
+import OptOutDialog from "@/components/staking/OptOutDialog.vue";
 
 /*
     Bookmarks
@@ -66,7 +67,7 @@ HMSF.forceUTC = true
 
 describe("Staking.vue", () => {
 
-    test.skip("no props", async () => {
+    test("no props", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -120,12 +121,14 @@ describe("Staking.vue", () => {
         await wrapper.get("#connectWalletButton").trigger("click")
         await flushPromises()
         const walletChooser = wrapper.getComponent(WalletChooser)
-        // expect(walletChooser.element.classList.contains("is-active")).toBeTruthy()
+        expect(walletChooser.get(".modal").element.classList.contains("is-active")).toBeTruthy()
 
         // 1.2) Chooses wallet "DriverMock"
         await walletChooser.get("#" + testDriver.name).trigger("click")
+        await nextTick()
+        await walletChooser.get("#connectButton").trigger("click")
         await flushPromises()
-        expect(walletManager.getActiveDriver()).toBe(testDriver)
+        expect(walletManager.getActiveDriver()).toStrictEqual(testDriver)
         expect(testDriver.isConnected()).toBeTruthy()
         expect(testDriver.getAccountId()).toBe(TARGET_ACCOUNT_ID)
 
@@ -355,7 +358,7 @@ describe("Staking.vue", () => {
         // 6.1) Clicks "DISCONNECT WALLET"
         await wrapper.get("#disconnectWalletButton").trigger("click")
         await flushPromises()
-        expect(walletManager.getActiveDriver()).toBe(testDriver)
+        expect(walletManager.getActiveDriver()).toStrictEqual(testDriver)
         expect(testDriver.isConnected()).toBeFalsy()
         expect(testDriver.getAccountId()).toBe(null)
 

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -66,7 +66,7 @@ HMSF.forceUTC = true
 
 describe("Staking.vue", () => {
 
-    test("no props", async () => {
+    test.skip("no props", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -120,7 +120,7 @@ describe("Staking.vue", () => {
         await wrapper.get("#connectWalletButton").trigger("click")
         await flushPromises()
         const walletChooser = wrapper.getComponent(WalletChooser)
-        expect(walletChooser.element.classList.contains("is-active")).toBeTruthy()
+        // expect(walletChooser.element.classList.contains("is-active")).toBeTruthy()
 
         // 1.2) Chooses wallet "DriverMock"
         await walletChooser.get("#" + testDriver.name).trigger("click")


### PR DESCRIPTION
**Description**:

This PR mostly addresses modifications requested by legal team:

- Disclaimer popup shown before connecting a wallet. This is shown only when the envt variable VUE_APP_WALLET_CHOOSER_DISCLAIMER_POPUP (which contains the HTML content of the disclaimer message) is set.
- Display a mention on the Staking page related to the current phase of the staking deployment and the way it works
- Display a link to the static terms-of-use document in the footer, using the value of the envt variable VUE_APP_TERMS_OF_USE_URL (and only when it is set)

Also modifies the WalletChooser dialog to base it on selection + CANCEL/CONNECT buttons (double-click also works).

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Currently deployed on staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
