### PR TITLE
00197 reward rate is wrong

### DIFF
--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -342,6 +342,17 @@ a.button.is-ghost.is-last {
 }
 
 //
+// TOOLTIPS
+//
+
+.h-tooltip {
+    --oruga-tooltip-background-color:var(--h-theme-highlight-color);
+    --oruga-tooltip-arrow-margin:5px;
+    --oruga-tooltip-content-font-size:0.75rem;
+    --oruga-tooltip-content-weight-normal:300;
+}
+
+//
 // ORUGA TABLES
 //
 

--- a/src/components/node/NodeLoader.ts
+++ b/src/components/node/NodeLoader.ts
@@ -64,8 +64,8 @@ export class NodeLoader extends EntityLoader<NetworkNodesResponse> {
     //
 
     public readonly rewardRate = computed(() =>
-        this.node.value?.reward_rate_start && this.node.value?.stake_rewarded
-            ? this.node.value.reward_rate_start / this.node.value?.stake_rewarded
+        this.node.value?.reward_rate_start
+            ? this.node.value.reward_rate_start / 100000000
             : 0)
 
     public readonly approxYearlyRate = computed(() => {

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -173,7 +173,7 @@ export default defineComponent({
     }
 
     const rewardRate = (node: NetworkNode) => {
-      return node.reward_rate_start && node.stake_rewarded ? node.reward_rate_start / node.stake_rewarded : 0
+      return (node.reward_rate_start ?? 0) / 100000000
     }
     const makeApproxYearlyRate = (node: NetworkNode) => {
       const formatter = new Intl.NumberFormat("en-US", {

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -152,7 +152,7 @@ export default defineComponent({
   setup(props) {
     const tooltipDelay = 500
     const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight " +
-        "(absent when amount staked is below the minimum, and until stake-based consensus is activated)."
+        "(weight is absent when the amount staked is below minimum)."
     const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
         "to decline rewards (and all accounts staked to those accounts)."
     const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -248,12 +248,6 @@ export default defineComponent({
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style>
-.h-tooltip {
-  --oruga-tooltip-background-color:var(--h-theme-highlight-color);
-  --oruga-tooltip-arrow-margin:5px;
-  --oruga-tooltip-content-font-size:0.75rem;
-  --oruga-tooltip-content-weight-normal:300;
-}
 .min-offset {
   margin-left: v-bind(minStakePix);
 }

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -175,7 +175,7 @@ export default defineComponent({
                 maxStake.value = nodes.value[0].max_stake ?? 0
               }
               for (const n of result.data.nodes) {
-                totalRewarded.value += (n.reward_rate_start ?? 0)
+                totalRewarded.value += (n.reward_rate_start ?? 0) * (n.stake_rewarded ?? 0) / 100000000
                 unclampedStakeTotal.value += (n.stake_rewarded ?? 0) + (n.stake_not_rewarded ?? 0)
               }
             }

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1166,7 +1166,7 @@ export const SAMPLE_NETWORK_NODES = {
             "node_account_id": "0.0.3",
             "node_cert_hash": "0xffd6ada74a3a34a9",
             "public_key": "0x308201a2300d0609",
-            "reward_rate_start": 13698630137,
+            "reward_rate_start": 2740,
             "service_endpoints": [
                 {
                     "ip_address_v4": "3.211.248.172",
@@ -1209,7 +1209,7 @@ export const SAMPLE_NETWORK_NODES = {
             "node_account_id": "0.0.4",
             "node_cert_hash": "0xffd6ada74a3a34a9",
             "public_key": "0x308201a2300d0609",
-            "reward_rate_start": 38356164383,
+            "reward_rate_start": 5479,
             "service_endpoints": [
                 {
                     "ip_address_v4": "3.133.213.146",
@@ -1239,7 +1239,7 @@ export const SAMPLE_NETWORK_NODES = {
             "node_account_id": "0.0.5",
             "node_cert_hash": "0xffd6ada74a3a34a9",
             "public_key": "0x308201a2300d0609",
-            "reward_rate_start": 57534246575,
+            "reward_rate_start": 8219,
             "service_endpoints": [
                 {
                     "ip_address_v4": "3.133.213.146",

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -52,7 +52,7 @@ HMSF.forceUTC = true
 describe("NodeTable.vue", () => {
 
     const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight" +
-        " (absent when amount staked is below the minimum, and until stake-based consensus is activated)."
+        " (weight is absent when the amount staked is below minimum)."
     const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
         "to decline rewards (and all accounts staked to those accounts)."
     const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -56,7 +56,7 @@ HMSF.forceUTC = true
 describe("Nodes.vue", () => {
 
     const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight" +
-        " (absent when amount staked is below the minimum, and until stake-based consensus is activated)."
+        " (weight is absent when the amount staked is below minimum)."
     const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
         "to decline rewards (and all accounts staked to those accounts)."
     const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +


### PR DESCRIPTION
**Description**:

This PR changes the way we interpret the `reward_rate_start` field returned by `/api/v1/network/node` REST call.
It is currently interpreted as an amount served for 24h while it is in fact a rate served for 24h ( = number of tinybars rewarded per hbar staked).

Also fixes the tooltip for 'Stake' column in NodeTable.

**Related issue(s)**:

Fixes #197

**Notes for reviewer**:

Without fix: ` <url>/testnet/nodes` shows 0% last reward rates for all nodes.
With fix: ` <url>/testnet/nodes` shows 6.5% instead.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
