### PR TITLE
Code refactoring : replace fetchNodes() methods by NodesLoader class

### DIFF
--- a/src/components/node/NodesLoader.ts
+++ b/src/components/node/NodesLoader.ts
@@ -36,7 +36,7 @@ export class NodesLoader extends EntityBatchLoader<NetworkNodesResponse> {
     public readonly totalRewarded: ComputedRef<number> = computed(() => {
         let result = 0
         for (const n of this.nodes.value) {
-            result += (n.reward_rate_start ?? 0)
+            result += (n.reward_rate_start ?? 0) * (n.stake_rewarded ?? 0) / 100000000
         }
         return result
     })

--- a/src/components/node/NodesLoader.ts
+++ b/src/components/node/NodesLoader.ts
@@ -1,0 +1,75 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {NetworkNode, NetworkNodesResponse} from "@/schemas/HederaSchemas";
+import axios, {AxiosResponse} from "axios";
+import {computed, ComputedRef} from "vue";
+import {EntityBatchLoader} from "@/utils/EntityBatchLoader";
+
+export class NodesLoader extends EntityBatchLoader<NetworkNodesResponse> {
+
+    //
+    // Public
+    //
+
+    public readonly nodes: ComputedRef<NetworkNode[]> = computed(() => this.entity.value?.nodes ?? [])
+
+    public readonly nodeCount = computed(() => this.nodes.value?.length ?? 0)
+
+    public readonly totalRewarded: ComputedRef<number> = computed(() => {
+        let result = 0
+        for (const n of this.nodes.value) {
+            result += (n.reward_rate_start ?? 0)
+        }
+        return result
+    })
+
+    public readonly unclampedStakeTotal: ComputedRef<number> = computed(() => {
+        let result = 0
+        for (const n of this.nodes.value) {
+            result += (n.stake_rewarded ?? 0) + (n.stake_not_rewarded ?? 0)
+        }
+        return result
+    })
+
+    public readonly node0 = computed(() => this.nodes.value.length >= 1 ? this.nodes.value[0] : null)
+    public readonly stakeTotal = computed(() => this.node0.value?.stake_total ?? 0)
+    public readonly minStake = computed(() => this.node0.value?.min_stake ?? 0)
+    public readonly maxStake = computed(() => this.node0.value?.max_stake ?? 0)
+
+    //
+    // EntityBatchLoader
+    //
+
+    protected async loadNext(nextURL: string|null): Promise<AxiosResponse<NetworkNodesResponse>|null> {
+        return axios.get<NetworkNodesResponse>(nextURL ?? "api/v1/network/nodes")
+    }
+
+    protected nextURL(entity: NetworkNodesResponse): string | null {
+        return entity.links?.next ?? null
+    }
+
+    protected mergeResponses(last: AxiosResponse<NetworkNodesResponse>, next: AxiosResponse<NetworkNodesResponse>): AxiosResponse<NetworkNodesResponse> {
+        const lastNodes = last.data.nodes ?? []
+        const nextNodes = next.data.nodes ?? []
+        last.data.nodes = lastNodes.concat(nextNodes)
+        return last
+    }
+}

--- a/src/components/node/NodesLoader.ts
+++ b/src/components/node/NodesLoader.ts
@@ -54,6 +54,22 @@ export class NodesLoader extends EntityBatchLoader<NetworkNodesResponse> {
     public readonly minStake = computed(() => this.node0.value?.min_stake ?? 0)
     public readonly maxStake = computed(() => this.node0.value?.max_stake ?? 0)
 
+    public readonly stakeRewardedTotal: ComputedRef<number> = computed(() => {
+        let result = 0
+        for (const n of this.nodes.value) {
+            result += n.stake_rewarded ?? 0
+        }
+        return result
+    })
+
+    public readonly stakeUnrewardedTotal: ComputedRef<number> = computed(() => {
+        let result = 0
+        for (const n of this.nodes.value) {
+            result += n.stake_not_rewarded ?? 0
+        }
+        return result
+    })
+
     //
     // EntityBatchLoader
     //

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -135,7 +135,6 @@ export default defineComponent({
     // Nodes
     //
     const nodes = ref<Array<NetworkNode> | null>([])
-    const unclampedStakeTotal = ref(0)
 
     const fetchNodes = (nextUrl: string | null = null) => {
       const url = nextUrl ?? "api/v1/network/nodes"
@@ -144,9 +143,6 @@ export default defineComponent({
           .then(result => {
             if (result.data.nodes) {
               nodes.value = nodes.value ? nodes.value.concat(result.data.nodes) : result.data.nodes
-              for (const n of result.data.nodes) {
-                unclampedStakeTotal.value += ((n.stake_rewarded ?? 0) + (n.stake_not_rewarded ?? 0))/100000000
-              }
             }
             const next = result.data.links?.next
             if (next) {

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -203,8 +203,9 @@ import {WalletDriver} from "@/utils/wallet/WalletDriver";
 import {WalletDriverError} from "@/utils/wallet/WalletDriverError";
 import {RewardsTransactionCache} from '@/components/staking/RewardsTransactionCache';
 import {normalizeTransactionId} from "@/utils/TransactionID";
-import {NodeLoader} from "@/components/node/NodeLoader";
+import {NodeCursor} from "@/components/node/NodeCursor";
 import {AccountLoader} from "@/components/account/AccountLoader";
+import {NodesLoader} from "@/components/node/NodesLoader";
 
 export default defineComponent({
   name: 'Staking',
@@ -368,7 +369,9 @@ export default defineComponent({
     // stakedNode
     //
 
-    const stakedNodeLoader = new NodeLoader(accountLoader.stakedNodeId)
+    const nodesLoader = new NodesLoader()
+    onMounted(() => nodesLoader.requestLoad())
+    const stakedNodeLoader = new NodeCursor(accountLoader.stakedNodeId, nodesLoader)
 
     //
     // handleStopStaking / handleChangeStaking

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -474,7 +474,7 @@ export interface ContractResultStateChanges {
 // ---------------------------------------------------------------------------------------------------------------------
 
 export interface NetworkNodesResponse {
-    nodes: [NetworkNode] | undefined
+    nodes: NetworkNode[] | undefined
     links: Links | undefined
 }
 

--- a/src/utils/EntityBatchLoader.ts
+++ b/src/utils/EntityBatchLoader.ts
@@ -1,0 +1,82 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityLoader} from "@/utils/EntityLoader";
+import {AxiosResponse} from "axios";
+
+export abstract class EntityBatchLoader<E> extends EntityLoader<E> {
+
+    //
+    // Protected
+    //
+
+    protected async loadNext(nextURL: string|null): Promise<AxiosResponse<E>|null> {
+        throw "To be subclassed"
+    }
+
+    protected abstract nextURL(entity: E): string|null
+
+    protected abstract mergeResponses(last: AxiosResponse<E>, next: AxiosResponse<E>): AxiosResponse<E>
+
+    //
+    // EntityLoader
+    //
+
+    protected async load(): Promise<AxiosResponse<E>|null> {
+        return this.recurseLoad(null, null, 100)
+    }
+
+    //
+    // Private
+    //
+
+    private async recurseLoad(nextURL: string|null, previous: AxiosResponse<E>|null, recursionCount: number): Promise<AxiosResponse<E>|null> {
+        let result: Promise<AxiosResponse<E>|null>
+
+        if (recursionCount < 0) {
+            console.warn("EntityBatchLoader gave up after too many iterations…")
+            result = Promise.resolve(previous)
+        } else {
+            const executor = (
+                resolve: (response: AxiosResponse<E>|null|Promise<AxiosResponse<E>|null>) => void) => {
+
+                this.loadNext(nextURL).then(
+                    (response: AxiosResponse<E>|null) => {
+                        if (response !== null) {
+                            const next = previous != null ? this.mergeResponses(previous, response) : response
+                            const afterNextURL = this.nextURL(response.data)
+                            if (afterNextURL !== null) {
+                                console.log("next is " + afterNextURL)
+                                resolve(this.recurseLoad(afterNextURL, next, recursionCount - 1))
+                            } else {
+                                resolve(next)
+                            }
+                        } else {
+                            resolve(null)
+                        }
+                    })
+            }
+            result = new Promise<AxiosResponse<E>|null>(executor)
+        }
+
+        return result
+    }
+
+}


### PR DESCRIPTION
**Description**:

Changes below complete code refactoring of fetchNodes() methods.
All vues having a fetchNodes() method now re-uses NodesLoader class.

**Related issue(s)**:

Fixes #00196

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
