### PR TITLE
00204 show account deleted

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -155,7 +155,7 @@ export default defineComponent({
         "(weight is absent when the amount staked is below minimum)."
     const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
         "to decline rewards (and all accounts staked to those accounts)."
-    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +
+    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward earned during the " +
         "last 24h period."
 
     const isTouchDevice = inject('isTouchDevice', false)

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -291,6 +291,8 @@ export default defineComponent({
         result =  "Invalid account ID: " + props.accountId
       } else if (accountLoader.got404.value) {
         result =  "Account with ID " + accountLoader.accountLocator.value + " was not found"
+      } else if (accountLoader.entity.value?.deleted === true) {
+        result = "Account is deleted"
       } else {
         result = null
       }

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -843,6 +843,34 @@ export const SAMPLE_ACCOUNT_DUDE = {
     "stake_period_start" : null
 }
 
+export const SAMPLE_ACCOUNT_DELETED = {
+    "account": "0.0.730632",
+    "alias": null,
+    "auto_renew_period": 6666000,
+    "balance": {
+        "balance": 31669471,
+        "timestamp": "1648548001.410978000",
+        "tokens": [
+            {
+                "token_id": SAMPLE_TOKEN_DUDE,
+                "balance": 99000000
+            }
+        ]
+    },
+    "deleted": true,
+    "expiry_timestamp": "1649648001.410978000",
+    "key": {"_type": "ED25519", "key": "38f1ea460e95d97eea13aefac760eaf990154b80a3608ab01d4a264944d68746"},
+    "max_automatic_token_associations": 10,
+    "memo": "Account Dude Memo in clear",
+    "receiver_sig_required": true,
+    "evm_address": null,
+    "ethereum_nonce": null,
+    "decline_reward": null,
+    "staked_node_id": null,
+    "staked_account_id": null,
+    "stake_period_start" : null
+}
+
 export const SAMPLE_ACCOUNT_STAKING_NODE = {
     "account": "0.0.730632",
     "alias": null,

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -55,7 +55,7 @@ describe("NodeTable.vue", () => {
         " (weight is absent when the amount staked is below minimum)."
     const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
         "to decline rewards (and all accounts staked to those accounts)."
-    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +
+    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward earned during the " +
         "last 24h period."
 
     it("should list the 3 nodes in the table", async () => {

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -59,7 +59,7 @@ describe("Nodes.vue", () => {
         " (weight is absent when the amount staked is below minimum)."
     const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
         "to decline rewards (and all accounts staked to those accounts)."
-    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward payed for the " +
+    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward earned during the " +
         "last 24h period."
 
     it("should display the nodes pages containing the node table", async () => {


### PR DESCRIPTION
**Description**:

This simple PR uses the notification banner of the AccountDetails page to show when an account is deleted, identical to what is done in ContractDetails.
Also adds unit tests.

**Related issue(s)**:

Fixes #204 

**Notes for reviewer**:

Look at <url>/#/testnet/contract/0.0.48170264 for instance. It says that the contract is deleted.
Follow the link to "Show the associated account". It does not mention the account is deleted.
With the fix, a similar banner is shown is both cases.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
