### PR TITLE
00215 system contract name

### DIFF
--- a/src/schemas/SystemContractRegistry.ts
+++ b/src/schemas/SystemContractRegistry.ts
@@ -1,0 +1,43 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export class SystemContractRegistry {
+
+    private readonly entries = new Map<string, string>()
+
+    constructor() {
+        this.addEntry("0.0.359", "Hedera Token Service System Contract")
+        this.addEntry("0.0.360", "Exchange Rate System Contract")
+        this.addEntry("0.0.361", "PRNG Seed System Contract")
+    }
+
+    public lookup(contractId: string): string | null {
+        return this.entries.get(contractId) ?? null
+    }
+
+    private addEntry(contractId: string, description: string) {
+        if(!this.entries.get(contractId)) {
+            this.entries.set(contractId, description)
+        }
+    }
+}
+
+export const systemContractRegistry = new SystemContractRegistry()
+

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -438,6 +438,30 @@ export const SAMPLE_CONTRACTCALL_TRANSACTIONS = {
     ]
 }
 
+export const SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS = {
+    "transactions": [
+        {
+            "bytes": null,
+            "charged_tx_fee": 0,
+            "consensus_timestamp": "1662623752.949648610",
+            "entity_id": "0.0.359",
+            "max_fee": "0",
+            "memo_base64": "",
+            "name": "CONTRACTCALL",
+            "node": null,
+            "nonce": 2,
+            "parent_consensus_timestamp": "1662623752.949648608",
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "LC8tH/tqkOEndC3ERShZO7n6NSxhdhbkSZJX3hnbwKAWaQ2KLMsg1DgaXByxrUEY",
+            "transaction_id": "0.0.29511696-1662623740-379586211",
+            "transfers": [],
+            "valid_duration_seconds": null,
+            "valid_start_timestamp": "1662623740.379586211"
+        }
+    ]
+}
+
 // https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=2&transactiontype=CRYPTOTRANSFER
 
 export const SAMPLE_CRYPTO_TRANSACTIONS = {


### PR DESCRIPTION
**Description**:

In TransactionDetails, when the transaction is a CONTRACT CALL, we now check whether its entityID is one of the system contracts we know about (via SystemContractRegistry) and then display the system contract name instead of the ID with a (broken) link.

**Related issue(s)**:

Fixes #215 

**Notes for reviewer**:

See: <url>#/mainnet/transaction/0.0.1107000-1662624593-105662235?t=1662624607.129656008
(fix deployed on staging)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
