### PR TITLE
00173 search tx by hash

### DIFF
--- a/src/components/transaction/TransactionLoader.ts
+++ b/src/components/transaction/TransactionLoader.ts
@@ -1,0 +1,270 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityLoader} from "@/utils/EntityLoader";
+import {BlocksResponse, Transaction, TransactionByIdResponse, TransactionType} from "@/schemas/HederaSchemas";
+import {computed, ComputedRef, Ref, ref, watch} from "vue";
+import axios, {AxiosResponse} from "axios";
+import {computeNetAmount} from "@/utils/TransactionTools";
+import {EntityDescriptor} from "@/utils/EntityDescriptor";
+import {ContractLoader} from "@/components/contract/ContractLoader";
+import {AccountLoader} from "@/components/account/AccountLoader";
+import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
+import {normalizeTransactionId} from "@/utils/TransactionID";
+import {base64DecToArr, byteToHex} from "@/utils/B64Utils";
+import {BlocksResponseCollector} from "@/utils/BlocksResponseCollector";
+
+export class TransactionLoader extends EntityLoader<TransactionByIdResponse> {
+
+    public readonly transactionLocator: ComputedRef<string|null>
+    public readonly consensusTimestamp: ComputedRef<string|null>
+    private readonly contractLoader: ContractLoader
+    private readonly accountLoader: AccountLoader
+
+    //
+    // Public
+    //
+
+    public constructor(transactionLocator: ComputedRef<string|null>, consensusTimestamp: ComputedRef<string|null>) {
+        super()
+        this.transactionLocator = transactionLocator
+        this.consensusTimestamp = consensusTimestamp
+        this.contractLoader = new ContractLoader(this.ethereumContractId)
+        this.accountLoader = new AccountLoader(this.ethereumContractId)
+        this.watchAndReload([this.transactionLocator])
+        watch(this.transaction, () => this.updateBlockNumber())
+    }
+
+    public readonly transactions: ComputedRef<Transaction[]> = computed(
+        () => this.entity.value?.transactions ?? [])
+
+    public readonly transaction: ComputedRef<Transaction|null> = computed(
+        () => this.entity.value?.transactions ? filter(this.transactions.value, this.consensusTimestamp.value) : null)
+
+    public readonly normalizedTransactionId: ComputedRef<string> = computed(() => {
+        const transaction_id = this.transactionLocator.value
+        return normalizeTransactionId(transaction_id ?? "", true)
+    })
+
+    public readonly transactionType = computed(() => this.transaction.value?.name ?? null)
+
+    public readonly result: ComputedRef<string|null> = computed(
+        () => this.transaction.value?.result ?? null)
+
+    public readonly hasSucceeded: ComputedRef<boolean> = computed(() => this.result.value == "SUCCESS")
+
+    public readonly netAmount: ComputedRef<number> = computed(
+        () => this.transaction.value !== null ? computeNetAmount(this.transaction.value) : 0)
+
+    public readonly maxFee: ComputedRef<number> = computed(() => {
+        const result = this.transaction.value?.max_fee ? Number.parseFloat(this.transaction.value?.max_fee) : 0
+        return isNaN(result) ? -9999 : result
+    })
+
+    public readonly formattedHash: ComputedRef<string|null> = computed( () => {
+        const hash = this.transaction.value?.transaction_hash
+        return hash ? byteToHex(base64DecToArr(hash)) : null
+    })
+
+    public readonly entityDescriptor = computed(() => {
+        let result: EntityDescriptor|null
+        if (this.contractLoader.entity.value !== null) {
+            result = new EntityDescriptor("Contract ID", "ContractDetails")
+        } else if (this.accountLoader.entity.value !== null) {
+            result = new EntityDescriptor("Account ID", "AccountDetails")
+        } else if (this.transaction.value) {
+            result = EntityDescriptor.makeEntityDescriptor(this.transaction.value)
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly systemContract: ComputedRef<string|null> = computed(() => {
+        let result
+        if (this.transaction.value?.name === TransactionType.CONTRACTCALL && this.transaction.value.entity_id) {
+            result = systemContractRegistry.lookup(this.transaction.value.entity_id)
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly scheduledTransaction = computed(() => {
+        let result: Transaction|null
+        if (this.transactions.value.length >= 2) {
+            result = (this.transaction.value?.name === TransactionType.SCHEDULECREATE)
+                ? lookupScheduledTransaction(this.transactions.value)
+                : null
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly schedulingTransaction = computed(() => {
+        let result: Transaction|null
+        if (this.transactions.value.length >= 2) {
+            result = this.transaction.value?.scheduled
+                ? lookupSchedulingTransaction(this.transactions.value)
+                : null
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly parentTransaction = computed(() => {
+        let result: Transaction|null
+        const children = lookupChildTransactions(this.transactions.value)
+        if (children.length && this.transaction.value?.nonce && this.transaction.value.nonce > 0) {
+            result = lookupParentTransaction(this.transactions.value)
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly childTransactions = computed(() => {
+        let result: Transaction[]
+        const children = lookupChildTransactions(this.transactions.value)
+        if (children.length && this.transaction.value?.nonce && this.transaction.value.nonce > 0) {
+            result = []
+        } else {
+            result = children
+        }
+        return result
+    })
+
+    public readonly blockNumber: Ref<number|null> = ref(null)
+
+    //
+    // EntityLoader
+    //
+
+    protected async load(): Promise<AxiosResponse<TransactionByIdResponse>|null> {
+        let result: Promise<AxiosResponse<TransactionByIdResponse>|null>
+        if (this.transactionLocator.value != null) {
+            result = axios.get<TransactionByIdResponse>("api/v1/transactions/" + this.transactionLocator.value)
+        } else {
+            result = Promise.resolve(null)
+        }
+        return result
+    }
+
+    //
+    // Private
+    //
+
+    private readonly ethereumContractId = computed(() => {
+        const entityId = this.transaction.value?.entity_id
+        const name = this.transaction.value?.name
+        return entityId && name == TransactionType.ETHEREUMTRANSACTION ? entityId : null
+    })
+
+    private updateBlockNumber() {
+        const cts = this.transaction.value?.consensus_timestamp
+        if (cts) {
+            BlocksResponseCollector.instance.fetch(cts)
+                .then((r: AxiosResponse<BlocksResponse>) => {
+                        this.blockNumber.value = r.data?.blocks ? (r.data?.blocks[0].number ?? null) : null
+                    }
+                    , (reason: unknown) => {
+                        console.warn("BlocksResponseCollector failed to find block with reason: " + reason)
+                        this.blockNumber.value = null
+                    })
+        } else {
+            this.blockNumber.value = null
+        }
+    }
+}
+
+function filter(transactions: Transaction[], consensusTimestamp: string|null): Transaction|null {
+    let result: Transaction|null
+    if (transactions.length == 1) {
+        result = transactions[0]
+    } else if (transactions.length >= 2) {
+        if (consensusTimestamp) {
+            const t = lookupTransactionWithTimestamp(transactions, consensusTimestamp)
+            result = t !== null ? t : transactions[0]
+        } else {
+            const t = lookupScheduledTransaction(transactions)
+            result = t !== null ? t : transactions[0]
+        }
+    } else {
+        result = null
+    }
+    return result
+}
+
+function lookupTransactionWithTimestamp(transactions: Transaction[], consensusTimestamp: string): Transaction|null {
+    let result: Transaction | null = null
+    for (const t of transactions) {
+        if (t.consensus_timestamp == consensusTimestamp) {
+            result = t
+            break
+        }
+    }
+    return result
+}
+
+function lookupScheduledTransaction(transactions: Transaction[]): Transaction|null {
+    let result: Transaction | null = null
+    for (const t of transactions) {
+        if (t.scheduled) {
+            result = t
+            break
+        }
+    }
+    return result
+}
+
+function lookupSchedulingTransaction(transactions: Transaction[]): Transaction|null {
+    let result: Transaction | null = null
+    for (const t of transactions) {
+        if (t.name === TransactionType.SCHEDULECREATE) {
+            result = t
+            break
+        }
+    }
+    return result
+}
+
+function lookupParentTransaction(transactions: Transaction[]): Transaction|null {
+  let result: Transaction | null = null
+  for (const t of transactions) {
+    if (t.nonce === 0) {
+      result = t
+      break
+    }
+  }
+  return result
+}
+
+function lookupChildTransactions(transactions: Transaction[]): Transaction[] {
+  const result = new Array<Transaction>()
+  for (const t of transactions) {
+    if (t.nonce && t.nonce > 0) {
+      result.push(t)
+    }
+  }
+  return result
+}
+

--- a/src/components/transaction/TransactionLoader.ts
+++ b/src/components/transaction/TransactionLoader.ts
@@ -58,9 +58,9 @@ export class TransactionLoader extends EntityLoader<TransactionByIdResponse> {
     public readonly transaction: ComputedRef<Transaction|null> = computed(
         () => this.entity.value?.transactions ? filter(this.transactions.value, this.consensusTimestamp.value) : null)
 
-    public readonly normalizedTransactionId: ComputedRef<string> = computed(() => {
-        const transaction_id = this.transactionLocator.value
-        return normalizeTransactionId(transaction_id ?? "", true)
+    public readonly formattedTransactionId: ComputedRef<string|null> = computed(() => {
+        const transaction_id = this.transaction.value?.transaction_id
+        return transaction_id ? normalizeTransactionId(transaction_id, true) : null
     })
 
     public readonly transactionType = computed(() => this.transaction.value?.name ?? null)

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -30,15 +30,15 @@
       <template v-slot:title>
         <div class="is-flex is-align-items-center">
           <span class="h-is-primary-title">Transaction </span>
-          <span class="h-is-secondary-text mr-3">{{ transaction ? convertTransactionId(transactionId) : "" }}</span>
+          <span class="h-is-secondary-text mr-3">{{ normalizedTransactionId ?? "" }}</span>
           <div v-if="transaction">
-            <div v-if="transaction?.result === TRANSACTION_SUCCESS"
+            <div v-if="transactionSucceeded"
                  class="h-has-pill has-background-success mr-3 h-is-text-size-2 mt-3">SUCCESS
             </div>
             <div v-else class="h-has-pill has-background-danger mr-3 h-is-text-size-2 mt-3">FAILURE</div>
           </div>
           <span v-if="showAllTransactionVisible" class="is-inline-block mt-2" id="allTransactionsLink">
-          <router-link :to="{name: 'TransactionsById', params: {transactionId: transactionId}}">
+          <router-link :to="{name: 'TransactionsById', params: {transactionId: normalizedTransactionId}}">
             <span class="h-is-property-text has-text-grey">See all transactions with the same ID</span>
           </router-link>
         </span>
@@ -53,7 +53,7 @@
         <Property id="transactionType">
           <template v-slot:name>Type</template>
           <template v-slot:value>
-            <StringValue :string-value="transaction ? makeTypeLabel(transaction.name) : undefined"/>
+            <StringValue :string-value="transactionType ? makeTypeLabel(transactionType) : undefined"/>
           </template>
         </Property>
         <Property id="consensusAt">
@@ -65,7 +65,7 @@
         <Property id="transactionHash">
           <template v-slot:name>Transaction Hash</template>
           <template v-slot:value>
-            <HexaValue v-bind:byteString="transaction ? formatHash(transaction?.transaction_hash): undefined" v-bind:show-none="true"/>
+            <HexaValue v-bind:byteString="formattedHash ?? undefined" v-bind:show-none="true"/>
           </template>
         </Property>
         <Property id="blockNumber">
@@ -122,13 +122,13 @@
         <Property id="maxFee">
           <template v-slot:name>Max fee</template>
           <template v-slot:value>
-            <HbarAmount v-if="transaction" v-bind:amount="computeMaxFee(transaction)" v-bind:show-extra="true"/>
+            <HbarAmount v-if="transaction" v-bind:amount="maxFee" v-bind:show-extra="true"/>
           </template>
         </Property>
         <Property id="netAmount" v-if="false">
           <template v-slot:name>Net Amount</template>
           <template v-slot:value>
-            <HbarAmount v-if="transaction" v-bind:amount="computeNetAmount(transaction)" v-bind:show-extra="true"/>
+            <HbarAmount v-if="transaction" v-bind:amount="netAmount" v-bind:show-extra="true"/>
           </template>
         </Property>
         <Property id="duration">
@@ -229,22 +229,11 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onBeforeMount, ref, watch} from 'vue';
-import axios, {AxiosResponse} from "axios";
-import {
-  AccountBalanceTransactions,
-  BlocksResponse,
-  ContractResponse,
-  Transaction,
-  TransactionByIdResponse,
-  TransactionType
-} from "@/schemas/HederaSchemas";
-import {EntityDescriptor} from "@/utils/EntityDescriptor"
-import {normalizeTransactionId, TransactionID} from "@/utils/TransactionID";
-import {computeNetAmount, makeOperatorAccountLabel, makeTypeLabel} from "@/utils/TransactionTools";
-import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
+import {computed, defineComponent, inject, onMounted, ref, watch} from 'vue';
+import {TransactionID} from "@/utils/TransactionID";
+import {makeOperatorAccountLabel, makeTypeLabel} from "@/utils/TransactionTools";
+import {TransactionLoader} from "@/components/transaction/TransactionLoader";
 import AccountLink from "@/components/values/AccountLink.vue";
-import {base64DecToArr, byteToHex} from "@/utils/B64Utils";
 import HexaValue from "@/components/values/HexaValue.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EntityLink from "@/components/values/EntityLink.vue";
@@ -257,7 +246,6 @@ import Footer from "@/components/Footer.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import Property from "@/components/Property.vue";
 import DurationValue from "@/components/values/DurationValue.vue";
-import {BlocksResponseCollector} from "@/utils/BlocksResponseCollector";
 import BlockLink from "@/components/values/BlockLink.vue";
 import ContractResultAndLogs from "@/components/transaction/ContractResultAndLogs.vue";
 
@@ -291,270 +279,73 @@ export default defineComponent({
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
-    const TRANSACTION_SUCCESS = 'SUCCESS'
-    const response = ref<AxiosResponse<TransactionByIdResponse>|null>(null)
-    const invalidId = ref(false)
-    const got404 = ref(false)
-    const transaction = ref<Transaction|null>(null)
-    const netAmount = ref(0)
-    const entity = ref<EntityDescriptor | null>(null)
-    const systemContract = computed(() => {
-      let result
-      if (transaction.value?.name === TransactionType.CONTRACTCALL && transaction.value.entity_id) {
-        result = systemContractRegistry.lookup(transaction.value.entity_id)
-      } else {
-        result = null
-      }
-      return result
-    })
-    const scheduledTransaction = ref<Transaction | null>(null)
-    const schedulingTransaction = ref<Transaction | null>(null)
-    const parentTransaction = ref<Transaction | null>(null)
-    const childTransactions = ref<Array<Transaction>>([])
-    const blockNumber = ref<number | null>(null)
+    const validId = computed(() => props.transactionId ? TransactionID.parse(props.transactionId) !== null : false)
+    const transactionLoader = new TransactionLoader(
+        computed(() => props.transactionId ?? null),
+        computed(() => props.consensusTimestamp ?? null))
+    onMounted(() => transactionLoader.requestLoad())
+
     const logCursor = ref(0)
     const nbLogLines = ref(NB_LOG_LINES)
     watch(nbLogLines, () => logCursor.value = 0)
 
     const showAllTransactionVisible = computed(() => {
-      const count = response.value?.data.transactions?.length ?? 0
+      const count = transactionLoader.transactions.value?.length ?? 0
       return count >= 2
     })
-    const displayAllChildrenLinks = computed(() => childTransactions.value.length > MAX_INLINE_CHILDREN )
+
+    const displayAllChildrenLinks = computed(
+        () => transactionLoader.childTransactions.value.length > MAX_INLINE_CHILDREN )
 
     const notification = computed(() => {
       let result
-      if (invalidId.value) {
+      if (!validId.value) {
         result = "Invalid transaction ID: " + props.transactionId
-      } else if (got404.value) {
-        result = "Transaction with ID " + normalizeTransactionId(props.transactionId ?? "", true) + " was not found"
-      } else if (transaction.value && transaction.value.result !== TRANSACTION_SUCCESS) {
-        result = transaction.value?.result
-      } else {
+      } else if (transactionLoader.got404.value) {
+        result = "Transaction with ID " + transactionLoader.normalizedTransactionId.value + " was not found"
+      } else if (transactionLoader.hasSucceeded.value) {
         result = null
+      } else {
+        result = transactionLoader.result.value
       }
       return result
     })
 
     const routeName = computed(() => {
-      return entity?.value?.routeName
+      return transactionLoader.entityDescriptor.value?.routeName
     })
-
-    onBeforeMount(() => {
-      fetchTransaction()
-    })
-
-    watch(() => props.transactionId, () => {
-      fetchTransaction()
-    });
-
-    watch(() => props.consensusTimestamp, () => {
-      fetchTransaction()
-    });
-
-    watch(transaction, () => {
-        if (transaction.value?.consensus_timestamp) {
-          BlocksResponseCollector.instance.fetch(transaction.value.consensus_timestamp)
-              .then((r: AxiosResponse<BlocksResponse>) => {
-                    blockNumber.value = r.data?.blocks ? (r.data?.blocks[0].number ?? null) : null
-                  }
-              , (reason: unknown) => {
-                console.warn("BlocksResponseCollector failed to find block with reason: " + reason)
-                    blockNumber.value = null
-              })
-        } else {
-          blockNumber.value = null
-        }
-    })
-
-    const fetchTransaction = () => {
-      got404.value = false
-      invalidId.value = false
-      response.value = null
-      transaction.value = null
-
-      if (props.transactionId && TransactionID.parse(props.transactionId)) {
-        axios
-            .get<TransactionByIdResponse>("api/v1/transactions/" + props.transactionId)
-            .then(r => {
-              response.value = r
-              transaction.value = null
-              scheduledTransaction.value = null
-              schedulingTransaction.value = null
-              parentTransaction.value = null
-              childTransactions.value = []
-              if (r.data.transactions) {
-                transaction.value = filter(r.data.transactions, props.consensusTimestamp)
-                if (transaction.value != null) {
-                  netAmount.value = computeNetAmount(transaction.value)
-
-                  if (transaction.value.entity_id && transaction.value.name === TransactionType.ETHEREUMTRANSACTION) {
-                    axios.get<ContractResponse>("api/v1/contracts/" + transaction.value.entity_id)
-                        .then(() => entity.value = new EntityDescriptor("Contract ID", "ContractDetails"))
-                        .catch(() => {
-                          axios.get<AccountBalanceTransactions>("api/v1/accounts/" + transaction.value?.entity_id)
-                              .then(() => entity.value = new EntityDescriptor("Account ID", "AccountDetails"))
-                              .catch(() => entity.value = new EntityDescriptor("Entity ID", ""))
-
-                        })
-                  } else if(
-                      transaction.value.name !== TransactionType.CONTRACTCALL
-                      || !systemContract.value
-                  ) {
-                    entity.value = EntityDescriptor.makeEntityDescriptor(transaction.value)
-                  } else {
-                    entity.value = null
-                  }
-
-                  if (r.data.transactions.length >= 2) {
-                    scheduledTransaction.value = (transaction.value.name === TransactionType.SCHEDULECREATE)
-                        ? lookupScheduledTransaction(r.data.transactions)
-                        : null
-                    schedulingTransaction.value = transaction.value.scheduled
-                        ? lookupSchedulingTransaction(r.data.transactions)
-                        : null
-                    const children = lookupChildTransactions(r.data.transactions)
-                    if (children.length && transaction.value.nonce && transaction.value.nonce > 0) {
-                      parentTransaction.value = lookupParentTransaction(r.data.transactions)
-                    } else {
-                      childTransactions.value = children
-                    }
-                  }
-                }
-              }
-            })
-            .catch(reason => {
-              if(axios.isAxiosError(reason) && reason?.request?.status === 404) {
-                got404.value = true
-              }
-            })
-      } else {
-        invalidId.value = true
-      }
-    }
-
-    const convertTransactionId = (id: string) => {
-      let result: string
-      if (id != null) {
-        const tid = TransactionID.parse(id)
-        result = tid != null ? tid.toString() : id
-      } else {
-        result = "?"
-      }
-      return result
-    }
-
-    const formatHash = (hash: string | undefined) => {
-      return hash != undefined ? byteToHex(base64DecToArr(hash)) : ""
-    }
-
-    const computeMaxFee = (t: Transaction) => {
-      const result = t.max_fee ? Number.parseFloat(t.max_fee) : 0
-      return isNaN(result) ? -9999 : result
-    }
 
     return {
       NB_LOG_LINES,
       MAX_LOG_LINES,
       isSmallScreen,
       isTouchDevice,
-      transaction,
-      netAmount,
-      entity,
-      systemContract,
+      transaction: transactionLoader.transaction,
+      normalizedTransactionId: transactionLoader.normalizedTransactionId,
+      netAmount: transactionLoader.netAmount,
+      entity: transactionLoader.entityDescriptor,
+      systemContract: transactionLoader.systemContract,
+      maxFee: transactionLoader.maxFee,
+      formattedHash: transactionLoader.formattedHash,
+      transactionType: transactionLoader.transactionType,
+      transactionSucceeded: transactionLoader.hasSucceeded,
+      scheduledTransaction: transactionLoader.scheduledTransaction,
+      schedulingTransaction: transactionLoader.schedulingTransaction,
+      parentTransaction: transactionLoader.parentTransaction,
+      childTransactions: transactionLoader.childTransactions,
+      blockNumber: transactionLoader.blockNumber,
       notification,
       routeName,
-      TRANSACTION_SUCCESS,
-      convertTransactionId,
-      formatHash,
-      computeMaxFee,
-      blockNumber,
       logCursor,
       nbLogLines,
       makeTypeLabel,
-      computeNetAmount,
+      // computeNetAmount,
       makeOperatorAccountLabel,
       showAllTransactionVisible,
       displayAllChildrenLinks,
-      scheduledTransaction,
-      schedulingTransaction,
-      parentTransaction,
-      childTransactions,
     }
   },
-});
-
-function filter(transactions: Transaction[], consensusTimestamp: string|undefined): Transaction|null {
-  let result: Transaction|null
-  if (transactions.length == 1) {
-    result = transactions[0]
-  } else if (transactions.length >= 2) {
-    if (consensusTimestamp) {
-      const t = lookupTransactionWithTimestamp(transactions, consensusTimestamp)
-      result = t !== null ? t : transactions[0]
-    } else {
-      const t = lookupScheduledTransaction(transactions)
-      result = t !== null ? t : transactions[0]
-    }
-  } else {
-    result = null
-  }
-  return result
-}
-
-function lookupTransactionWithTimestamp(transactions: Transaction[], consensusTimestamp: string): Transaction|null {
-  let result: Transaction | null = null
-  for (let t of transactions) {
-    if (t.consensus_timestamp == consensusTimestamp) {
-      result = t
-      break
-    }
-  }
-  return result
-}
-
-function lookupScheduledTransaction(transactions: Transaction[]): Transaction|null {
-  let result: Transaction | null = null
-  for (let t of transactions) {
-    if (t.scheduled) {
-      result = t
-      break
-    }
-  }
-  return result
-}
-
-function lookupSchedulingTransaction(transactions: Transaction[]): Transaction|null {
-  let result: Transaction | null = null
-  for (let t of transactions) {
-    if (t.name === TransactionType.SCHEDULECREATE) {
-      result = t
-      break
-    }
-  }
-  return result
-}
-
-function lookupParentTransaction(transactions: Transaction[]): Transaction|null {
-  let result: Transaction | null = null
-  for (let t of transactions) {
-    if (t.nonce === 0) {
-      result = t
-      break
-    }
-  }
-  return result
-}
-
-function lookupChildTransactions(transactions: Transaction[]): Transaction[] {
-  let result = new Array<Transaction>()
-  for (let t of transactions) {
-    if (t.nonce && t.nonce > 0) {
-      result.push(t)
-    }
-  }
-  return result
-}
+})
 
 </script>
 

--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -20,6 +20,7 @@
 
 import {aliasToBase32, base32ToAlias, byteToHex, hexToByte} from "@/utils/B64Utils";
 import {EntityID} from "@/utils/EntityID";
+import {TransactionID} from "@/utils/TransactionID";
 
 export class PathParam { // Block Hash or Number
 
@@ -75,6 +76,24 @@ export class PathParam { // Block Hash or Number
         if (s) {
             const n = parseInt(s)
             result =  isNaN(n) || n < 0 ? null : n
+        } else {
+            result = null
+        }
+
+        return result
+    }
+
+    public static parseTransactionIdOrHash(s: string|undefined): string|null {
+        let result: string|null
+
+        if (s) {
+            const id = TransactionID.parse(s)
+            if (id !== null) {
+                result = id.toString()
+            } else {
+                const hash = hexToByte(s)
+                result = hash !== null && hash.length == 48 ? "0x" + byteToHex(hash) : null
+            }
         } else {
             result = null
         }

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -60,6 +60,7 @@ export class SearchRequest {
         const normTransactionID = transactionID != null ? transactionID.toString(false) : null
         const hexBytes = hexToByte(this.searchedId)
         const evmAddress = (hexBytes !== null && hexBytes.length == 20) ? byteToHex(hexBytes) : null
+        const transactionHash = (hexBytes !== null && hexBytes.length == 48) ? byteToHex(hexBytes) : null
         const hexByteString32 = (hexBytes !== null && hexBytes.length >= 15) ? aliasToBase32(hexBytes) : null
 
         // 1) Searches accounts
@@ -83,9 +84,10 @@ export class SearchRequest {
         }
 
         // 2) Searches transactions
-        if (normTransactionID !== null) {
+        if (normTransactionID !== null || transactionHash !== null) {
+            const transactionPathParam = transactionID !== null ? transactionID : transactionHash
             axios
-                .get("api/v1/transactions/" + normTransactionID)
+                .get("api/v1/transactions/" + transactionPathParam)
                 .then(response => {
                     this.transactions = response.data.transactions
                 })

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -85,7 +85,7 @@ export class SearchRequest {
 
         // 2) Searches transactions
         if (normTransactionID !== null || transactionHash !== null) {
-            const transactionPathParam = transactionID !== null ? transactionID : transactionHash
+            const transactionPathParam = normTransactionID !== null ? normTransactionID : transactionHash
             axios
                 .get("api/v1/transactions/" + transactionPathParam)
                 .then(response => {

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -98,6 +98,15 @@ describe('Search Bar', () => {
             .should('contain', 'Child')  // criteria to check
     })
 
+    it('should find the transaction by hash', () => {
+        const searchTransaction = "0x1dc948b993ec66c161f83d8c686b641152d5a6f49b79550db9a22dd0d44cb60cd814c50c3b8abdabb8bc3d457adbfc38"
+        testBody(
+            searchTransaction,
+            '/testnet/transaction/' + searchTransaction,
+            'Transaction '
+        )
+    })
+
     it('should find the NFT ID', () => {
         const searchNFT = "0.0.30961728"
         testBody(searchNFT, '/testnet/token/' + searchNFT, 'Token ', true)

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -98,14 +98,17 @@ describe('Search Bar', () => {
             .should('contain', 'Child')  // criteria to check
     })
 
-    it('should find the transaction by hash', () => {
-        const searchTransaction = "0x1dc948b993ec66c161f83d8c686b641152d5a6f49b79550db9a22dd0d44cb60cd814c50c3b8abdabb8bc3d457adbfc38"
-        testBody(
-            searchTransaction,
-            '/testnet/transaction/' + searchTransaction,
-            'Transaction '
-        )
-    })
+    //
+    // To be uncommented when api/v1/transactions accepts transaction hash
+    //
+    // it('should find the transaction by hash', () => {
+    //     const searchTransaction = "0x1dc948b993ec66c161f83d8c686b641152d5a6f49b79550db9a22dd0d44cb60cd814c50c3b8abdabb8bc3d457adbfc38"
+    //     testBody(
+    //         searchTransaction,
+    //         '/testnet/transaction/' + searchTransaction,
+    //         'Transaction '
+    //     )
+    // })
 
     it('should find the NFT ID', () => {
         const searchNFT = "0.0.30961728"

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -29,7 +29,7 @@ import {
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import {SearchRequest} from "@/utils/SearchRequest";
-import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
+import {base32ToAlias, base64DecToArr, byteToHex} from "@/utils/B64Utils";
 
 const mock = new MockAdapter(axios)
 
@@ -41,6 +41,10 @@ mock.onGet(matcher_account_with_alias).reply(200, SAMPLE_ACCOUNT)
 
 const matcher_transaction = "/api/v1/transactions/" + SAMPLE_TRANSACTION.transaction_id
 mock.onGet(matcher_transaction).reply(200, SAMPLE_TRANSACTIONS)
+
+const TRANSACTION_HASH = byteToHex(base64DecToArr(SAMPLE_TRANSACTION.transaction_hash))
+const matcher_transaction_with_hash = "/api/v1/transactions/" + TRANSACTION_HASH
+mock.onGet(matcher_transaction_with_hash).reply(200, SAMPLE_TRANSACTIONS)
 
 const matcher_token = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
 mock.onGet(matcher_token).reply(200, SAMPLE_TOKEN)
@@ -108,6 +112,20 @@ describe("SearchRequest.ts", () => {
         await r.run()
 
         expect(r.searchedId).toBe(SAMPLE_TRANSACTION.transaction_id)
+        expect(r.account).toBeNull()
+        expect(r.transactions).toStrictEqual([SAMPLE_TRANSACTION])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
+
+    })
+
+    test("transaction (with hash)", async () => {
+        const r = new SearchRequest(TRANSACTION_HASH)
+        await r.run()
+
+        expect(r.searchedId).toBe(TRANSACTION_HASH)
         expect(r.account).toBeNull()
         expect(r.transactions).toStrictEqual([SAMPLE_TRANSACTION])
         expect(r.tokenInfo).toBeNull()


### PR DESCRIPTION
**Description**:

Code changes below enables two features:

1) transaction hash can be used in search bar to display transaction details
2) transaction details page is now accessible using the following url:
`{url}/#/{network}/transaction/{transactionHash}`

Changes also include a refactoring : TransactionDetails.vue now delegates loading logic to TransactionLoader class.

**Related issue(s)**:

Fixes #173

**Notes for reviewer**:

These two features relies on mirror node capability to search transaction using its hash.
At time of writing, this only works on previewnet.

To test search bar:

1) Go to [hashscan latest](https://hashscan-latest.hedera-devops.com)
2) Select `previewnet`
3) Paste the following transaction hash in search bar and press return:
`0xad3e01d576a2aff7a709f3a1b3df8d8b2201d8b87f427851de8fbe4b32f48c72ead7a670dcf27c9d9251804977d006bd`
=> explorer displays details for transaction [0.0.1078@1662802748.993296800](https://hashscan-latest.hedera-devops.com/#/previewnet/transaction/0.0.1078-1662802748-993296800?t=1662802852.998651369)

To test url:

1) Open [https://hashscan-latest.hedera-devops.com/#/previewnet/transaction/0xad3e01d576a2aff7a709f3a1b3df8d8b2201d8b87f427851de8fbe4b32f48c72ead7a670dcf27c9d9251804977d006bd](https://hashscan-latest.hedera-devops.com/#/previewnet/transaction/0xad3e01d576a2aff7a709f3a1b3df8d8b2201d8b87f427851de8fbe4b32f48c72ead7a670dcf27c9d9251804977d006bd)
=> explorer displays details for transaction [0.0.1078@1662802748.993296800](https://hashscan-latest.hedera-devops.com/#/previewnet/transaction/0.0.1078-1662802748-993296800?t=1662802852.998651369)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
