### PR TITLE
#223 Display account details using {url}/#/{network}/account/{account-alias-in-hex}

### DIFF
--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -62,7 +62,7 @@ export class PathParam { // Block Hash or Number
                     const hex = hexToByte(s)
                     if (hex !== null) {
                         if (hex.length == 20) {
-                            result = byteToHex(hex) // EVM address
+                            result = "0x" + byteToHex(hex) // EVM address
                         } else {
                             result = aliasToBase32(hex) // Account alias expressed in hex and reconverted in base32
                         }

--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -59,8 +59,16 @@ export class PathParam { // Block Hash or Number
                 if (alias !== null) {
                     result = aliasToBase32(alias)
                 } else {
-                    const address = hexToByte(s)
-                    result = address !== null && address.length == 20 ? "0x" + byteToHex(address) : null
+                    const hex = hexToByte(s)
+                    if (hex !== null) {
+                        if (hex.length == 20) {
+                            result = byteToHex(hex) // EVM address
+                        } else {
+                            result = aliasToBase32(hex) // Account alias expressed in hex and reconverted in base32
+                        }
+                    } else {
+                        result = null
+                    }
                 }
             }
         } else {

--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -135,11 +135,19 @@ describe('Account Navigation', () => {
         cy.contains('Account ' + accountID)
     })
 
-    it ('should display account details using account alias', () => {
+    it ('should display account details using account base32 alias', () => {
         const accountID = "0.0.46022656"
         const accountAlias = "HIQQGOGHZGVM3E7KT47Z6VQYY2TTYY3USZUDJGVSRLYRUR5J72ZD6PI4"
         cy.visit('#/testnet/account/' + accountAlias)
         cy.url().should('include', '/testnet/account/' + accountAlias)
+        cy.contains('Account ' + accountID)
+    })
+
+    it ('should display account details using account hex alias', () => {
+        const accountID = "0.0.46022656"
+        const accountAliasInHex = "0x3a210338c7c9aacd93ea9f3f9f5618c6a73c63749668349ab28af11a47a9feb23f3d1c"
+        cy.visit('#/testnet/account/' + accountAliasInHex)
+        cy.url().should('include', '/testnet/account/' + accountAliasInHex)
         cy.contains('Account ' + accountID)
     })
 

--- a/tests/unit/utils/PathParam.spec.ts
+++ b/tests/unit/utils/PathParam.spec.ts
@@ -20,7 +20,6 @@
 
 
 import {PathParam} from "@/utils/PathParam";
-import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
 
 describe("PathParam", () => {
 

--- a/tests/unit/utils/PathParam.spec.ts
+++ b/tests/unit/utils/PathParam.spec.ts
@@ -20,6 +20,7 @@
 
 
 import {PathParam} from "@/utils/PathParam";
+import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
 
 describe("PathParam", () => {
 
@@ -80,11 +81,20 @@ describe("PathParam", () => {
         expect(pp).toBe(accountId)
     })
 
-    test("PathParam.parseAccountIdOrAliasOrEvmAddress() with alias", () => {
+    test("PathParam.parseAccountIdOrAliasOrEvmAddress() with alias in base32", () => {
 
         const alias = "HIQQGOSRIF3EM35ICXWUQH722CIRBIWTIT3MTN4MDUKK7Q2RYOSRXYZ5"
 
         const pp = PathParam.parseAccountIdOrAliasOrEvmAddress(alias)
+        expect(pp).toBe(alias)
+    })
+
+    test("PathParam.parseAccountIdOrAliasOrEvmAddress() with alias in hex", () => {
+
+        const alias = "HIQQGOSRIF3EM35ICXWUQH722CIRBIWTIT3MTN4MDUKK7Q2RYOSRXYZ5"
+        const aliasInHex = "0x3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d"
+
+        const pp = PathParam.parseAccountIdOrAliasOrEvmAddress(aliasInHex)
         expect(pp).toBe(alias)
     })
 


### PR DESCRIPTION
Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

With the changes below Explorer recognizes url with the following form:
`{url}/#/{network}/account/{account-alias-in-hex}`

Changes also include unit and e2e matching test cases.

**Related issue(s)**:

Fixes #223

**Notes for reviewer**:

Test account on mainnet

Account ID: `0.0.1133968`
Account alias in base32: `CIQEN25ORE2F73TRYSYMMBVPR2HU4PPFGTQENJTIGVLLELP4PZ2M76A`
Account alias in hex: `0x122046ebae89345fee71c4b0c606af8e8f4e3de534e046a6683556b22dfc7e74cff8`


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
