### PR TITLE
00225 display hex form of account alias

### DIFF
--- a/src/components/Property.vue
+++ b/src/components/Property.vue
@@ -36,7 +36,7 @@
   </div>
 
   <div v-else class="columns" :id="id" style="margin-bottom: -0.75rem;">
-    <div class="column is-one-third has-text-weight-light" :id="nameId">
+    <div :class="nbColClass" class="column has-text-weight-light" :id="nameId">
       <slot name="name"/>
     </div>
     <div class="column" :id="valueId">
@@ -52,12 +52,16 @@
 
 <script lang="ts">
 
-import {defineComponent, inject} from "vue";
+import {computed, defineComponent, inject} from "vue";
 
 export default defineComponent({
   name: "Property",
   props: {
     id: String,
+    fullWidth: {
+      type: Boolean,
+      default: false
+    }
   },
   setup(props){
     const nameId = props.id + 'Name'
@@ -65,12 +69,14 @@ export default defineComponent({
 
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
+    const nbColClass = computed(() => props.fullWidth ? 'is-2' : 'is-4')
 
     return {
       nameId,
       valueId,
       isSmallScreen,
-      isTouchDevice
+      isTouchDevice,
+      nbColClass
     }
   }
 })

--- a/src/components/values/AliasValue.vue
+++ b/src/components/values/AliasValue.vue
@@ -1,0 +1,78 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <div class="should-wrap">
+
+    <BlobValue :blob-value="aliasValue" :show-none="true"/>
+    <div v-if="hexValue" class="has-text-grey mt-1">
+      <BlobValue :blob-value="hexValue"/>
+    </div>
+
+  </div>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent} from "vue";
+import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
+import BlobValue from "@/components/values/BlobValue.vue";
+
+export default defineComponent({
+  name: "AliasValue",
+  components: {BlobValue},
+  props: {
+    aliasValue: String,
+  },
+  setup(props) {
+    const hexValue = computed(() => {
+      let result
+      if (props.aliasValue) {
+        const alias = base32ToAlias(props.aliasValue)
+        result = alias ? "0x" + byteToHex(alias) : null
+      } else {
+        result = null
+      }
+      return result
+    })
+    return {
+      hexValue
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+
+</style>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -75,14 +75,13 @@
         </div>
         <div class="columns h-is-property-text">
           <div class="column">
-            <Property id="alias">
+            <Property id="alias" :class="{'mb-0':account?.alias}" :full-width="true">
               <template v-slot:name>Alias</template>
               <template v-slot:value>
-                <StringValue :string-value="account?.alias"/>
+                <AliasValue :alias-value="account?.alias"/>
               </template>
             </Property>
           </div>
-          <div class="column"><!-- spacer--></div>
         </div>
       </template>
 
@@ -224,6 +223,7 @@ import AccountLink from "@/components/values/AccountLink.vue";
 import {AccountLoader} from "@/components/account/AccountLoader";
 import {ContractLoader} from "@/components/contract/ContractLoader";
 import {NodeLoader} from "@/components/node/NodeLoader";
+import AliasValue from "@/components/values/AliasValue.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -232,6 +232,7 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
+    AliasValue,
     AccountLink,
     NotificationBanner,
     Property,

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -67,6 +67,9 @@ HMSF.forceUTC = true
 
 describe("AccountDetails.vue", () => {
 
+    const ALIAS_B32 = "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ"
+    const ALIAS_HEX = "0x12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296"
+
     it("Should display account details", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
@@ -112,7 +115,7 @@ describe("AccountDetails.vue", () => {
             "Copy to Clipboard" +
             "ED25519")
         expect(wrapper.get("#memoValue").text()).toBe("None")
-        expect(wrapper.get("#aliasValue").text()).toBe("CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ")
+        expect(wrapper.get("#aliasValue").text()).toBe(ALIAS_B32 + ALIAS_HEX)
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")

--- a/tests/unit/values/AliasValue.spec.ts
+++ b/tests/unit/values/AliasValue.spec.ts
@@ -1,0 +1,59 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {flushPromises, mount} from "@vue/test-utils"
+import router from "@/router";
+import AliasValue from "@/components/values/AliasValue.vue";
+
+describe("AliasValue.vue", () => {
+
+    it("should display 'None' when no alias value is provided", async () => {
+
+        const wrapper = mount(AliasValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe("None")
+    })
+
+    const ALIAS_B32 = "CIQEN25ORE2F73TRYSYMMBVPR2HU4PPFGTQENJTIGVLLELP4PZ2M76A"
+    const ALIAS_HEX = "0x122046ebae89345fee71c4b0c606af8e8f4e3de534e046a6683556b22dfc7e74cff8"
+
+    it("should display both base32 and hexa forms of provided alias", async () => {
+
+        const wrapper = mount(AliasValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                aliasValue: ALIAS_B32
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(ALIAS_B32 + ALIAS_HEX)
+    })
+})
+


### PR DESCRIPTION
**Description**:

This PR adds a new AliasValue component, now used by AccountDetails, which displays both the base32 encoding and the hexadecimal forms of the alias value, on 2 successive lines.

The Property component is also enhanced to be used when there is a single column of properties taking the whole width.
This fixes the previous alias layout issue ("in the middle of the page")

**Related issue(s)**:

Fixes #225 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
