### PR TITLE
00132 merge node hostedby and location

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -46,15 +46,9 @@
         </div>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="hosted_by" label="Hosted By">
+      <o-table-column v-slot="props" field="description" label="Description">
         <div class="should-wrap regular-node-column">
-          <BlobValue v-bind:blob-value="makeHost(props.row)" v-bind:show-none="true"/>
-        </div>
-      </o-table-column>
-
-      <o-table-column v-slot="props" field="location" label="Location">
-        <div class="should-wrap regular-node-column">
-          <BlobValue v-bind:blob-value="makeLocation(props.row)" v-bind:show-none="true"/>
+          <BlobValue v-bind:blob-value="makeDescription(props.row)" v-bind:show-none="true"/>
         </div>
       </o-table-column>
 
@@ -161,8 +155,17 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
-    const makeHost = (node: NetworkNode) => node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.name : null
-    const makeLocation = (node: NetworkNode) => node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.location : null
+    const makeDescription = (node: NetworkNode) => {
+      let result
+      if (node.description) {
+        result = node.description
+      } else if (node.node_account_id) {
+        result = operatorRegistry.makeDescription(node.node_account_id)
+      } else {
+        result = null
+      }
+      return result
+    }
     const makeUnclampedStake = (node: NetworkNode) => (node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0)
     const makeWeightPercentage = (node: NetworkNode) => {
       const formatter = new Intl.NumberFormat("en-US", {
@@ -226,8 +229,7 @@ export default defineComponent({
       tooltipRewardRate,
       isTouchDevice,
       isMediumScreen,
-      makeHost,
-      makeLocation,
+      makeDescription,
       makeUnclampedStake,
       makeWeightPercentage,
       makeApproxYearlyRate,

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -150,7 +150,7 @@ export default defineComponent({
       if (node.description) {
         result = node.description
       } else {
-        result = node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.getDescription() : null
+        result = node.node_account_id ? operatorRegistry.makeDescription(node.node_account_id) : null
       }
       return result
     }

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -288,7 +288,7 @@ export default defineComponent({
       if (node.description) {
         result = node.description
       } else {
-        result = node.node_account_id ? operatorRegistry.lookup(node.node_account_id)?.getDescription() : null
+        result = node.node_account_id ? operatorRegistry.makeDescription(node.node_account_id) : null
       }
       return result
     }

--- a/src/schemas/OperatorRegistry.ts
+++ b/src/schemas/OperatorRegistry.ts
@@ -53,27 +53,14 @@ import {getNetworkEntryFromCurrentRoute} from "@/router";
 export class OperatorEntry {
     public readonly accountId: string
     public readonly network: string|null
-    public readonly name: string
-    public readonly location: string|null
+    public readonly description: string
     public readonly nodeId: number|null
 
-    constructor(accountId: string, network: string|null, name: string, location: string|null, nodeId: number|null) {
+    constructor(accountId: string, network: string|null, description: string, nodeId: number|null) {
         this.accountId = accountId
         this.network = network
-        this.name = name
-        this.location = location
+        this.description = description
         this.nodeId = nodeId
-    }
-
-    getDescription(): string {
-        let result = this.name
-        if (this.nodeId != null) {
-            result = "Node " + this.nodeId + " - " + result
-        }
-        if (this.location != null) {
-            result = result + " - " + this.location
-        }
-        return result
     }
 }
 
@@ -83,32 +70,32 @@ export class OperatorRegistry {
     private readonly networkEntries = new Map<string, Map<string, OperatorEntry>>()
 
     constructor() {
-        this.addEntry("0.0.3", "LG", "Seoul, South Korea", 0)
-        this.addEntry("0.0.4", "Swirlds", "North Carolina, USA", 1)
-        this.addEntry("0.0.5", "FIS", "Florida, USA", 2)
-        this.addEntry("0.0.6", "Wipro", "Mumbai, India", 3)
-        this.addEntry("0.0.7", "Nomura", "Tokyo, Japan", 4)
-        this.addEntry("0.0.8", "Google", "Helsinki, Finland", 5)
-        this.addEntry("0.0.9", "Zain Group", "Kuwait City, Kuwait", 6)
-        this.addEntry("0.0.10", "Magalu", "São Paulo, Brazil", 7)
-        this.addEntry("0.0.11", "Boeing", "Toronto, Canada", 8)
-        this.addEntry("0.0.12", "DLA Piper", "London, UK", 9)
-        this.addEntry("0.0.13", "Tata Communications", "California, USA", 10)
-        this.addEntry("0.0.14", "IBM", "Washington, USA", 11)
-        this.addEntry("0.0.15", "Deutsche Telekom", "Berlin, Germany", 12)
-        this.addEntry("0.0.16", "UCL", "Amsterdam, Netherlands", 13)
-        this.addEntry("0.0.17", "Avery Dennison", "Pennsylvania, USA", 14)
-        this.addEntry("0.0.18", "Dentons", "Frankfurt, DE", 15)
-        this.addEntry("0.0.19", "Standard Bank", "Warsaw, Poland", 16)
-        this.addEntry("0.0.20", "eftpos", "Oregon, USA", 17)
-        this.addEntry("0.0.21", "EDF", "Paris, France", 18)
-        this.addEntry("0.0.22", "Shinhan Bank", "Seoul, South Korea", 19)
-        this.addEntry("0.0.23", "Chainlink Labs", "Michigan, USA", 20)
-        this.addEntry("0.0.24", "LSE", "Virginia, USA", 21)
-        this.addEntry("0.0.25", "IIT Madras", "Georgia, USA", 22)
-        this.addEntry("0.0.26", "DBS", "Singapore, Republic of Singapore", 23)
-        this.addEntry("0.0.27", "ServiceNow", "Ogden, Utah", 24)
-        this.addEntry("0.0.28", "Ubisoft", "Singapore, Republic of Singapore", 25)
+        this.addEntry("0.0.3", "LG - Seoul, South Korea", 0)
+        this.addEntry("0.0.4", "Swirlds - North Carolina, USA", 1)
+        this.addEntry("0.0.5", "FIS - Florida, USA", 2)
+        this.addEntry("0.0.6", "Wipro - Mumbai, India", 3)
+        this.addEntry("0.0.7", "Nomura - Tokyo, Japan", 4)
+        this.addEntry("0.0.8", "Google - Helsinki, Finland", 5)
+        this.addEntry("0.0.9", "Zain Group - Kuwait City, Kuwait", 6)
+        this.addEntry("0.0.10", "Magalu - São Paulo, Brazil", 7)
+        this.addEntry("0.0.11", "Boeing - Toronto, Canada", 8)
+        this.addEntry("0.0.12", "DLA Piper - London, UK", 9)
+        this.addEntry("0.0.13", "Tata Communications - California, USA", 10)
+        this.addEntry("0.0.14", "IBM - Washington, USA", 11)
+        this.addEntry("0.0.15", "Deutsche Telekom - Berlin, Germany", 12)
+        this.addEntry("0.0.16", "UCL - Amsterdam, Netherlands", 13)
+        this.addEntry("0.0.17", "Avery Dennison - Pennsylvania, USA", 14)
+        this.addEntry("0.0.18", "Dentons - Frankfurt, DE", 15)
+        this.addEntry("0.0.19", "Standard Bank - Warsaw, Poland", 16)
+        this.addEntry("0.0.20", "eftpos - Oregon, USA", 17)
+        this.addEntry("0.0.21", "EDF - Paris, France", 18)
+        this.addEntry("0.0.22", "Shinhan Bank - Seoul, South Korea", 19)
+        this.addEntry("0.0.23", "Chainlink Labs - Michigan, USA", 20)
+        this.addEntry("0.0.24", "LSE - Virginia, USA", 21)
+        this.addEntry("0.0.25", "IIT Madras - Georgia, USA", 22)
+        this.addEntry("0.0.26", "DBS - Singapore, Republic of Singapore", 23)
+        this.addEntry("0.0.27", "ServiceNow - Ogden, Utah", 24)
+        this.addEntry("0.0.28", "Ubisoft - Singapore, Republic of Singapore", 25)
 
         this.addTestnetEntry("0.0.3", 0)
         this.addTestnetEntry("0.0.4", 1)
@@ -126,7 +113,7 @@ export class OperatorRegistry {
         this.addPreviewnetEntry("0.0.8", 5)
         this.addPreviewnetEntry("0.0.9", 6)
 
-        this.addEntry("0.0.98", "Hedera fee collection account", null, null, null)
+        this.addEntry("0.0.98", "Hedera fee collection account", null, null)
     }
 
     public lookup(accountId: string): OperatorEntry|null {
@@ -136,10 +123,10 @@ export class OperatorRegistry {
 
     public makeDescription(accountId: string): string | null {
         const registryEntry = operatorRegistry.lookup(accountId)
-        return registryEntry !== null ? registryEntry.getDescription() : null
+        return registryEntry !== null ? registryEntry.description : null
     }
 
-    private addEntry(accountId: string, name: string, location: string|null, nodeID: number|null, network: string|null = "mainnet") {
+    private addEntry(accountId: string, description: string, nodeID: number|null, network: string|null = "mainnet") {
         let targetEntries: Map<string, OperatorEntry>
         if (network != null) {
             const networkEntries = this.networkEntries.get(network);
@@ -152,15 +139,15 @@ export class OperatorRegistry {
         } else {
             targetEntries = this.entries
         }
-        targetEntries.set(accountId, new OperatorEntry(accountId, network, name, location, nodeID))
+        targetEntries.set(accountId, new OperatorEntry(accountId, network, description, nodeID))
     }
 
     private addTestnetEntry(accountId: string, nodeID: number|null) {
-        this.addEntry(accountId, "testnet", null, nodeID, "testnet")
+        this.addEntry(accountId, "Node " + nodeID + " - testnet", nodeID, "testnet")
     }
 
     private addPreviewnetEntry(accountId: string, nodeID: number|null) {
-        this.addEntry(accountId, "previewnet", null, nodeID, "previewnet")
+        this.addEntry(accountId, "Node " + nodeID + " - previewnet", nodeID, "previewnet")
     }
 
 }

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -85,12 +85,12 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
+        expect(wrapper.get('thead').text()).toBe("Node Account Description Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
-            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
-            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
+            "0" + "0.0.3" + "Node 0 - testnet" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
+            "1" + "0.0.4" + "Node 1 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
+            "2" + "0.0.5" + "Node 2 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -100,11 +100,11 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Account Hosted By Location Stake Stake Not Rewarded Last Reward Rate Stake Range")
+        expect(table.get('thead').text()).toBe("Node Account Description Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "testnet" + "None" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
-            "1" + "0.0.4" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
-            "2" + "0.0.5" + "testnet" + "None" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
+            "0" + "0.0.3" + "Node 0 - testnet" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
+            "1" + "0.0.4" + "Node 1 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
+            "2" + "0.0.5" + "Node 2 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
         )
     });
 


### PR DESCRIPTION
**Description**:

This merges the `Hosted By` and `Location` columns of the Node table into a single one name `Description`.
The `Description` column will eventually display raw content from NetworkNode.description field (obtained via `/api/v1/network/nodes` call) once that data is populated. The Node description is currently fetched from the local, static information provided by OperatorRegistry.

**Related issue(s)**:

Fixes #132

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
