### PR TITLE
00238 disable prev/next block buttons when block not loaded

### DIFF
--- a/src/pages/BlockDetails.vue
+++ b/src/pages/BlockDetails.vue
@@ -180,8 +180,8 @@ export default defineComponent({
     const disablePreviousButton = ref(true)
     const disableNextButton = ref(true)
     watch(blockLoader.entity, () => {
-      disablePreviousButton.value = blockLoader.entity.value?.previous_hash === nullHash
-      disableNextButton.value = false
+      disablePreviousButton.value = (notification.value != null) || (blockLoader.entity.value?.previous_hash === nullHash)
+      disableNextButton.value = notification.value != null
     })
     const handlePreviousBlock = () => {
       router.push({

--- a/src/pages/BlockDetails.vue
+++ b/src/pages/BlockDetails.vue
@@ -89,7 +89,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard>
+    <DashboardCard id="blockTransactions">
       <template v-slot:title>
         <span class="h-is-secondary-title">Block Transactions</span>
       </template>

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1651,22 +1651,36 @@ export const SAMPLE_NETWORK_SUPPLY = {
 }
 
 //
-// https://previewnet.mirrornode.hedera.com/api/v1/blocks?timestamp=gte:1662111646.528325857&limit=1
+// https://testnet.mirrornode.hedera.com/api/v1/blocks?timestamp=gte:1662111646.528325857&limit=2
 //
 
 export const SAMPLE_BLOCKSRESPONSE = {
-    "blocks": [{
-        "count": 1,
-        "hapi_version": "0.30.0",
-        "hash": "0xe4416a679dc2d757e4f179501bbf8ab0f90b4aa2a69c60366919606e4d5e447cb501e90e9224de836cfcedbc72c0c559",
-        "name": "2022-09-02T09_45_08.062537644Z.rcd.gz",
-        "number": 271027,
-        "previous_hash": "0xa3cf2030a81300c57f5f16ce90d2fb6aacef13cb1412b9c89f50792742544dc10460626ca8554e7a87e162c7d3218b2e",
-        "size": 840,
-        "timestamp": {"from": "1662111908.062537644", "to": "1662111908.062537644"},
-        "gas_used": 0,
-        "logs_bloom": "0x"
-    }]
+    "blocks": [
+        {
+            "count": 1,
+            "hapi_version": "0.29.1",
+            "hash": "0xe9630d7d8cc86d0e0d3de5316995bbdf9f2a584524cf18da233abdcff82df97da0a0ec38c6b4046101294896ff88a86b",
+            "name": "2022-09-23T06_58_31.328130742Z.rcd.gz",
+            "number": 25175998,
+            "previous_hash": "0x7ece042fa9369ac7d6a407ffd4d4b76b284b54077abf2f5212e969a9fcbe34676f9eaae9dc718e8ca9987a48f92aa7c6",
+            "size": 663,
+            "timestamp": {"from": "1663916311.328130742", "to": "1663916311.328130742"},
+            "gas_used": 0,
+            "logs_bloom": "0x"
+        },
+        {
+            "count": 5,
+            "hapi_version": "0.29.1",
+            "hash": "0x7ece042fa9369ac7d6a407ffd4d4b76b284b54077abf2f5212e969a9fcbe34676f9eaae9dc718e8ca9987a48f92aa7c6",
+            "name": "2022-09-23T06_58_28.211469425Z.rcd.gz",
+            "number": 25175997,
+            "previous_hash": "0x6128cfb804b9552cac0ddd98b847cbc8a5ef8f206cfcd0d191acca6eebe464b4be4713af794728cbfa20afe1b808bbfb",
+            "size": 2014,
+            "timestamp": {"from": "1663916308.211469425", "to": "1663916309.239784003"},
+            "gas_used": 0,
+            "logs_bloom": "0x"
+        }
+    ], "links": {"next": "/api/v1/blocks?timestamp=gte:1662111646.528325857&limit=2&block.number=lt:25175997"}
 }
 
 //

--- a/tests/unit/block/BlockDetails.spec.ts
+++ b/tests/unit/block/BlockDetails.spec.ts
@@ -1,0 +1,390 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {flushPromises, mount} from "@vue/test-utils"
+import router from "@/router";
+import axios from "axios";
+import {SAMPLE_BLOCKSRESPONSE, SAMPLE_CONTRACTCALL_TRANSACTIONS, SAMPLE_TOKEN, SAMPLE_TRANSACTIONS,} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import NotificationBanner from "@/components/NotificationBanner.vue";
+import BlockDetails from "@/pages/BlockDetails.vue";
+import BlockTransactionTable from "@/components/block/BlockTransactionTable.vue";
+import {PathParam} from "@/utils/PathParam";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});
+
+HMSF.forceUTC = true
+
+describe("BlockDetails.vue", () => {
+
+    const BLOCK = SAMPLE_BLOCKSRESPONSE.blocks[0]
+    const BLOCK_NUMBER = BLOCK.number.toString()
+    const BLOCK_HASH = BLOCK.hash
+    const NORMALIZED_BLOCK_HASH = PathParam.parseBlockHashOrNumber(BLOCK_HASH)
+
+    it("Should display block details from block number", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/blocks/" + BLOCK_NUMBER
+        mock.onGet(matcher1).reply(200, BLOCK);
+
+        const matcher2 = "/api/v1/transactions"
+        mock.onGet(matcher2).reply(200, SAMPLE_TRANSACTIONS);
+
+        const token = SAMPLE_TOKEN
+        const matcher3 = "/api/v1/tokens/" + token.token_id
+        mock.onGet(matcher3).reply(200, token);
+
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: BLOCK_NUMBER
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Block " + BLOCK_NUMBER))
+        expect(wrapper.findComponent(NotificationBanner).exists()).toBe(false)
+
+        expect(wrapper.get("#countValue").text()).toBe("1")
+        expect(wrapper.get("#blockHashValue").text()).toBe(
+            "e963 0d7d 8cc8 6d0e 0d3d e531 6995 bbdf 9f2a 5845 24cf 18da 233a bdcf f82d f97d a0a0 ec38 " +
+            "c6b4 0461 0129 4896 ff88 a86bCopy to ClipboardSHA384")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("6:58:31.3281 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("6:58:31.3281 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("2022-09-23T06_58_31.328130742Z.rcd.gz")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        const table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("0.0.29624024@1646025139.152901498CRYPTO TRANSFER0.0.29624024\n" + "\n" +
+            "1\n" + "\n" +
+            "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC")
+    });
+
+    it("Should display block details from block hash", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/blocks/" + NORMALIZED_BLOCK_HASH
+        mock.onGet(matcher1).reply(200, BLOCK);
+
+        const matcher2 = "/api/v1/transactions"
+        mock.onGet(matcher2).reply(200, SAMPLE_TRANSACTIONS);
+
+        const token = SAMPLE_TOKEN
+        const matcher3 = "/api/v1/tokens/" + token.token_id
+        mock.onGet(matcher3).reply(200, token);
+
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: BLOCK_HASH
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Block " + BLOCK_NUMBER))
+        expect(wrapper.findComponent(NotificationBanner).exists()).toBe(false)
+
+        expect(wrapper.get("#countValue").text()).toBe("1")
+        expect(wrapper.get("#blockHashValue").text()).toBe(
+            "e963 0d7d 8cc8 6d0e 0d3d e531 6995 bbdf 9f2a 5845 24cf 18da 233a bdcf f82d f97d a0a0 ec38 " +
+            "c6b4 0461 0129 4896 ff88 a86bCopy to ClipboardSHA384")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("6:58:31.3281 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("6:58:31.3281 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("2022-09-23T06_58_31.328130742Z.rcd.gz")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        const table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("0.0.29624024@1646025139.152901498CRYPTO TRANSFER0.0.29624024\n" + "\n" +
+            "1\n" + "\n" +
+            "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC")
+    });
+
+    it("Should update when block hash changes", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        let normalizedBlockHash = PathParam.parseBlockHashOrNumber(BLOCK_HASH)
+        let matcher1 = "/api/v1/blocks/" + normalizedBlockHash
+        mock.onGet(matcher1).reply(200, BLOCK);
+
+        let matcher2 = "/api/v1/transactions"
+        mock.onGet(matcher2).reply(200, SAMPLE_TRANSACTIONS);
+
+        const token = SAMPLE_TOKEN
+        const matcher3 = "/api/v1/tokens/" + token.token_id
+        mock.onGet(matcher3).reply(200, token);
+
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: BLOCK_HASH
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Block " + BLOCK_NUMBER))
+        expect(wrapper.findComponent(NotificationBanner).exists()).toBe(false)
+
+        expect(wrapper.get("#countValue").text()).toBe("1")
+        expect(wrapper.get("#blockHashValue").text()).toBe(
+            "e963 0d7d 8cc8 6d0e 0d3d e531 6995 bbdf 9f2a 5845 24cf 18da 233a bdcf f82d f97d a0a0 ec38 " +
+            "c6b4 0461 0129 4896 ff88 a86bCopy to ClipboardSHA384")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("6:58:31.3281 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("6:58:31.3281 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("2022-09-23T06_58_31.328130742Z.rcd.gz")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        let table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("0.0.29624024@1646025139.152901498CRYPTO TRANSFER0.0.29624024\n" + "\n" +
+            "1\n" + "\n" +
+            "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC")
+
+        // Change Block Number
+        const NEW_BLOCK = SAMPLE_BLOCKSRESPONSE.blocks[1]
+        const NEW_BLOCK_NUMBER = NEW_BLOCK.number.toString()
+        const NEW_BLOCK_HASH = NEW_BLOCK.hash
+
+        normalizedBlockHash = PathParam.parseBlockHashOrNumber(NEW_BLOCK_HASH)
+        matcher1 = "/api/v1/blocks/" + normalizedBlockHash
+        mock.onGet(matcher1).reply(200, NEW_BLOCK);
+        matcher2 = "/api/v1/transactions"
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS);
+
+        await wrapper.setProps({
+            blockHon: NEW_BLOCK_HASH
+        })
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Block " + NEW_BLOCK_NUMBER))
+        expect(wrapper.findComponent(NotificationBanner).exists()).toBe(false)
+
+        expect(wrapper.get("#countValue").text()).toBe("5")
+        expect(wrapper.get("#blockHashValue").text()).toBe(
+            "7ece 042f a936 9ac7 d6a4 07ff d4d4 b76b 284b 5407 7abf 2f52 12e9 69a9 fcbe 3467 6f9e aae9 " +
+            "dc71 8e8c a998 7a48 f92a a7c6Copy to ClipboardSHA384")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("6:58:28.2114 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("6:58:29.2397 AMSep 23, 2022, UTC")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("2022-09-23T06_58_28.211469425Z.rcd.gz")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe(
+            "0.0.950@1646665756.235554077" +
+            "CONTRACT CALL" +
+            "Contract ID: 0.0.749774" +
+            "3:09:26.5747 PMMar 7, 2022, UTC" +
+            "0.0.950@1646664143.028737238" +
+            "CONTRACT CALL" +
+            "Contract ID: 0.0.749723" +
+            "2:42:34.8669 PMMar 7, 2022, UTC")
+    });
+
+    it("Should detect invalid block number", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const INVALID_BLOCK_NUMBER = "-42"
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: INVALID_BLOCK_NUMBER
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        const banner = wrapper.findComponent(NotificationBanner)
+        expect(banner.text()).toBe("Invalid block number or hash: " + INVALID_BLOCK_NUMBER)
+
+        expect(wrapper.get("#countValue").text()).toBe("0")
+        expect(wrapper.get("#blockHashValue").text()).toBe("None")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("None")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        const table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("")
+    });
+
+    it("Should detect invalid block hash", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const INVALID_BLOCK_HASH = "0xABCDEF"
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: INVALID_BLOCK_HASH
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        const banner = wrapper.findComponent(NotificationBanner)
+        expect(banner.text()).toBe("Invalid block number or hash: " + INVALID_BLOCK_HASH)
+
+        expect(wrapper.get("#countValue").text()).toBe("0")
+        expect(wrapper.get("#blockHashValue").text()).toBe("None")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("None")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        const table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("")
+    });
+
+    it("Should detect non-existent block number", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+        const matcher1 = "/api/v1/blocks/" + BLOCK_NUMBER
+        mock.onGet(matcher1).reply(404);
+
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: BLOCK_NUMBER
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        const banner = wrapper.findComponent(NotificationBanner)
+        expect(banner.text()).toBe("Block " + BLOCK_NUMBER + " was not found")
+
+        expect(wrapper.get("#countValue").text()).toBe("0")
+        expect(wrapper.get("#blockHashValue").text()).toBe("None")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("None")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        const table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("")
+    });
+
+    it("Should detect non-existent block hash", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+        const matcher1 = "/api/v1/blocks/" + NORMALIZED_BLOCK_HASH
+        mock.onGet(matcher1).reply(404);
+
+        const wrapper = mount(BlockDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                blockHon: BLOCK_HASH
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        const banner = wrapper.findComponent(NotificationBanner)
+        expect(banner.text()).toBe("Block " + NORMALIZED_BLOCK_HASH + " was not found")
+
+        expect(wrapper.get("#countValue").text()).toBe("0")
+        expect(wrapper.get("#blockHashValue").text()).toBe("None")
+        expect(wrapper.get("#fromTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#toTimestampValue").text()).toBe("None")
+        expect(wrapper.get("#gasUsedValue").text()).toBe("0")
+        expect(wrapper.get("#recordFileNameValue").text()).toBe("None")
+        expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
+        const table = wrapper.findComponent(BlockTransactionTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("ID Type Content Time & Date")
+        expect(table.get('tbody').text()).toBe("")
+    });
+});

--- a/tests/unit/block/Blocks.spec.ts
+++ b/tests/unit/block/Blocks.spec.ts
@@ -1,0 +1,95 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {flushPromises, mount} from "@vue/test-utils"
+import router from "@/router";
+import axios from "axios";
+import {SAMPLE_BLOCKSRESPONSE} from "../Mocks";
+import DashboardCard from "@/components/DashboardCard.vue";
+import MockAdapter from "axios-mock-adapter";
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import Blocks from "@/pages/Blocks.vue";
+import BlockTable from "@/components/block/BlockTable.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});
+
+HMSF.forceUTC = true
+
+describe("Blocks.vue", () => {
+
+    it("Should display the BlockTable", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/blocks"
+        mock.onGet(matcher1).reply(200, SAMPLE_BLOCKSRESPONSE);
+
+        const wrapper = mount(Blocks, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {},
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.vm.blockTableController.mounted.value).toBe(true)
+        const card = wrapper.findComponent(DashboardCard)
+        expect(card.exists()).toBe(true)
+        expect(card.text()).toMatch(RegExp("^Blocks"))
+
+        const table = card.findComponent(BlockTable)
+        expect(table.exists()).toBe(true)
+        expect(table.get('thead').text()).toBe("Number Start Time No. Transactions Gas Used")
+        expect(table.get('tbody').text()).toBe(
+            "25175998" + "6:58:31.3281 AMSep 23, 2022, UTC" + "1" + "0" +
+            "25175997" + "6:58:28.2114 AMSep 23, 2022, UTC" + "5" + "0"
+        )
+
+        wrapper.unmount()
+        await flushPromises()
+
+        expect(wrapper.vm.blockTableController.mounted.value).toBe(false)
+    });
+});


### PR DESCRIPTION
**Description**:

- Disable the PREV.BLOCK and NEXT BLOCK buttons on the BlockDetails page when the block was not found or when the block locator is invalid
- Add unit tests for Blocks and BlockDetails components

**Related issue(s)**:

Fixes #238

**Notes for reviewer**:

Load "<url>/#/testnet/block/12"
then load "<url>/#/testnet/block/555555555555555"
with the fix, PREV/NEXT buttons should be disabled

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
