### PR TITLE
209 Publish checksum of addresses

### DIFF
--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -197,7 +197,7 @@ export default defineComponent({
               result = declineChoice.value ? "Do you want to decline rewards?" : "Do you want to accept rewards?"
             }
           } else {
-            result = "Do you want to stake to account " + selectedAccount.value
+            result = "Do you want to stake to account " + EntityID.normalize(selectedAccount.value ?? "", true) + " ?"
           }
           return result
         })

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -252,7 +252,7 @@ export default defineComponent({
 
     const enableChangeButton = computed(() => {
       return (
-          isAccountSelected.value && isSelectedAccountValid.value && props.account?.staked_account_id != selectedAccount.value)
+          isAccountSelected.value && isSelectedAccountValid.value && props.account?.staked_account_id != selectedAccountEntity.value)
           || (isNodeSelected.value  && selectedNode.value && props.account?.staked_node_id != selectedNode.value)
           || (props.account?.decline_reward != declineChoice.value)
     })
@@ -370,7 +370,9 @@ export default defineComponent({
                 const accounts = response.data.accounts
                 if (accounts && accounts.length > 0) {
                   isSelectedAccountValid.value = true
-                  inputFeedbackMessage.value = VALID_ACCOUNT_MESSAGE
+                  if (props.account?.staked_account_id != selectedAccountEntity.value) {
+                    inputFeedbackMessage.value = VALID_ACCOUNT_MESSAGE
+                  }
                 } else {
                   inputFeedbackMessage.value = UNKNOWN_ACCOUNT_MESSAGE
                 }

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -170,6 +170,7 @@ const VALID_ACCOUNT_MESSAGE = "Rewards will now be paid to that account"
 const UNKNOWN_ACCOUNT_MESSAGE = "This account does not exist"
 const INVALID_ACCOUNTID_MESSAGE = "Invalid account ID"
 const INVALID_CHECKSUM_MESSAGE = "Invalid checksum"
+const CANT_STAKE_SAME_ACCOUNT_MESSAGE = "Cannot stake to one's own account"
 
 export default defineComponent({
   name: "StakingDialog",
@@ -345,11 +346,13 @@ export default defineComponent({
       }
     }
 
-    const validateAccount = (accountId: string) => {
-      const entityID = EntityID.stripChecksum(accountId)
-      const checksum = EntityID.extractChecksum(accountId)
+    const validateAccount = (stakedAccountId: string) => {
+      const entityID = EntityID.stripChecksum(stakedAccountId)
+      const checksum = EntityID.extractChecksum(stakedAccountId)
 
-      if (EntityID.isValid(entityID ?? "", checksum)) {
+      if (entityID == accountId.value) {
+        inputFeedbackMessage.value = CANT_STAKE_SAME_ACCOUNT_MESSAGE
+      } else if (EntityID.isValid(entityID ?? "", checksum)) {
         const params = {} as {
           limit: 1
         }

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -156,7 +156,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, onMounted, PropType, ref, watch} from "vue";
-import {AccountBalanceTransactions, NetworkNode} from "@/schemas/HederaSchemas";
+import {AccountBalanceTransactions, AccountsResponse, NetworkNode} from "@/schemas/HederaSchemas";
 import {NodesLoader} from "@/components/node/NodesLoader";
 import Property from "@/components/Property.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
@@ -361,13 +361,24 @@ export default defineComponent({
         if (selectedAccountEntity.value == accountId.value) {
           inputFeedbackMessage.value = CANT_STAKE_SAME_ACCOUNT_MESSAGE
         } else {
+
+          const params = {
+            'account.id': selectedAccountEntity.value,
+            balance: false
+          }
           axios
-              .get<AccountBalanceTransactions>("api/v1/accounts/" + selectedAccountEntity.value)
-              .then(() => {
-                isSelectedAccountValid.value = true
-                inputFeedbackMessage.value = VALID_ACCOUNT_MESSAGE
+              .get<AccountsResponse>("api/v1/accounts", { params: params } )
+              .then((response) => {
+                const accounts = response.data.accounts
+                if (accounts && accounts.length > 0) {
+                  isSelectedAccountValid.value = true
+                  inputFeedbackMessage.value = VALID_ACCOUNT_MESSAGE
+                } else {
+                  inputFeedbackMessage.value = UNKNOWN_ACCOUNT_MESSAGE
+                }
               })
               .catch(() => inputFeedbackMessage.value = UNKNOWN_ACCOUNT_MESSAGE)
+
         }
       } else {
         inputFeedbackMessage.value = INVALID_CHECKSUM_MESSAGE

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -101,7 +101,7 @@
               </div>
               <div class="column pt-0">
                 <div class="is-flex is-align-items-center">
-                  <input class="input is-small has-text-right has-text-white" type="text" placeholder="0.0.1234-vwxyz"
+                  <input class="input is-small has-text-right has-text-white" type="text" placeholder="0.0.1234"
                          :class="{'has-text-grey': !isAccountSelected}"
                          :value="selectedAccount"
                          @focus="stakeChoice='account'"

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -312,26 +312,32 @@ export default defineComponent({
 
     const handleInput = (value: string) => {
       const previousValue = selectedAccount.value
-      let isValid = true
-      let pastDash = false
+      let isValidInput = true
+      let isValidID = false
+      let isPastDash = false
 
       for (const c of value) {
-        if ((c < '0' || c > '9') && c !== '.') {
-          if (c === '-') {
-            if (pastDash) {
-              isValid = false
-              break
-            } else {
-              pastDash = true
-            }
-          } else if (c < 'a' || c > 'z' || !pastDash) {
-            isValid = false
+        if ((c >= '0' && c <= '9') || c === '.') {
+          if (isPastDash) {
+            isValidInput = false
             break
+          } else {
+            isValidID = EntityID.isValid(EntityID.stripChecksum(value))
           }
+        } else if (c === '-') {
+          if (! isValidID || isPastDash) {
+            isValidInput = false
+            break
+          } else {
+            isPastDash = true
+          }
+        } else if (c < 'a' || c > 'z' || !isPastDash) {
+          isValidInput = false
+          break
         }
       }
 
-      if (isValid) {
+      if (isValidInput) {
         selectedAccount.value = value
       } else {
         selectedAccount.value = ""
@@ -342,9 +348,6 @@ export default defineComponent({
     const validateAccount = (accountId: string) => {
       const entityID = EntityID.stripChecksum(accountId)
       const checksum = EntityID.extractChecksum(accountId)
-
-      console.log("validateAccount - entityID: " + entityID)
-      console.log("validateAccount - checksum: " + checksum)
 
       if (EntityID.isValid(entityID ?? "", checksum)) {
         const params = {} as {

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -210,7 +210,6 @@ import TokenAmount from "@/components/values/TokenAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import {BalanceCache} from "@/components/account/BalanceCache";
 import Footer from "@/components/Footer.vue";
-import {useRoute, useRouter} from "vue-router";
 import {PathParam} from "@/utils/PathParam";
 import Property from "@/components/Property.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
@@ -223,7 +222,8 @@ import {ContractLoader} from "@/components/contract/ContractLoader";
 import {NodeLoader} from "@/components/node/NodeLoader";
 import AliasValue from "@/components/values/AliasValue.vue";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
-import {EntityID} from "@/utils/EntityID";
+import {networkRegistry} from "@/schemas/NetworkRegistry";
+import router from "@/router";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -261,8 +261,8 @@ export default defineComponent({
     const isMediumScreen = inject('isMediumScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
-    const router = useRouter()
-    const route = useRoute()
+    const route = router.currentRoute.value
+    const network = route.params.network as string
 
     //
     // account
@@ -273,7 +273,7 @@ export default defineComponent({
     onMounted(() => accountLoader.requestLoad())
 
     const accountChecksum = computed(() =>
-        accountLoader.accountId.value ? EntityID.parse(accountLoader.accountId.value)?.makeChecksum() : null)
+        accountLoader.accountId.value ? networkRegistry.computeChecksum(accountLoader.accountId.value, network) : null)
 
     const notification = computed(() => {
       let result

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -29,8 +29,9 @@
     <DashboardCard>
       <template v-slot:title>
         <span class="h-is-primary-title">Account </span>
-        <span class="h-is-secondary-text mr-3">{{ account?.account ?? "" }}</span>
-        <span v-if="showContractVisible" class="is-inline-block" id="showContractLink">
+        <span class="h-is-secondary-text">{{ account?.account ?? "" }}</span>
+<!--        <span v-if="accountChecksum" class="has-text-grey" style="font-size: 28px">-{{ accountChecksum }}</span>-->
+        <span v-if="showContractVisible" class="is-inline-block ml-3" id="showContractLink">
           <router-link :to="{name: 'ContractDetails', params: {contractId: accountId}}">
             <span class="h-is-property-text">Show associated contract</span>
           </router-link>
@@ -86,6 +87,13 @@
       </template>
 
       <template v-slot:leftContent>
+              <Property id="idAndChecksum">
+                <template v-slot:name>Account ID with checksum</template>
+                <template v-slot:value v-if="account?.account">
+                  <span>{{ account?.account }}</span>
+                  <span class="has-text-grey">-{{ accountChecksum }}</span>
+                </template>
+              </Property>
               <Property v-if="account?.staked_account_id" id="stakedAccount">
                 <template v-slot:name>Staked to Account</template>
                 <template v-slot:value>
@@ -222,6 +230,7 @@ import {ContractLoader} from "@/components/contract/ContractLoader";
 import {NodeLoader} from "@/components/node/NodeLoader";
 import AliasValue from "@/components/values/AliasValue.vue";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
+import {EntityID} from "@/utils/EntityID";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -269,6 +278,9 @@ export default defineComponent({
     const accountLocator = computed(() => PathParam.parseAccountIdOrAliasOrEvmAddress(props.accountId))
     const accountLoader = new AccountLoader(accountLocator)
     onMounted(() => accountLoader.requestLoad())
+
+    const accountChecksum = computed(() =>
+        accountLoader.accountId.value ? EntityID.parse(accountLoader.accountId.value)?.makeChecksum() : null)
 
     const notification = computed(() => {
       let result
@@ -365,6 +377,7 @@ export default defineComponent({
       notification,
       account: accountLoader.entity,
       normalizedAccountI: accountLoader.accountId,
+      accountChecksum,
       accountInfo: accountLoader.accountInfo,
       nodeId: accountLoader.nodeId,
       ethereumAddress: accountLoader.ethereumAddress,

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -261,9 +261,6 @@ export default defineComponent({
     const isMediumScreen = inject('isMediumScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
-    const route = router.currentRoute.value
-    const network = route.params.network as string
-
     //
     // account
     //
@@ -273,7 +270,10 @@ export default defineComponent({
     onMounted(() => accountLoader.requestLoad())
 
     const accountChecksum = computed(() =>
-        accountLoader.accountId.value ? networkRegistry.computeChecksum(accountLoader.accountId.value, network) : null)
+        accountLoader.accountId.value ? networkRegistry.computeChecksum(
+            accountLoader.accountId.value,
+            router.currentRoute.value.params.network as string
+        ) : null)
 
     const notification = computed(() => {
       let result
@@ -312,7 +312,7 @@ export default defineComponent({
       updateQuery()
     })
     const transactionFilterFromRoute = computed(() => {
-      return (route.query?.type as string ?? "").toUpperCase()
+      return (router.currentRoute.value.query?.type as string ?? "").toUpperCase()
     })
     watch(transactionFilterFromRoute, () => {
       transactionTableController.transactionType.value = transactionFilterFromRoute.value

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -30,7 +30,7 @@
       <template v-slot:title>
         <span class="h-is-primary-title">Account </span>
         <span class="h-is-secondary-text">{{ account?.account ?? "" }}</span>
-<!--        <span v-if="accountChecksum" class="has-text-grey" style="font-size: 28px">-{{ accountChecksum }}</span>-->
+        <span v-if="accountChecksum" class="has-text-grey" style="font-size: 28px">-{{ accountChecksum }}</span>
         <span v-if="showContractVisible" class="is-inline-block ml-3" id="showContractLink">
           <router-link :to="{name: 'ContractDetails', params: {contractId: accountId}}">
             <span class="h-is-property-text">Show associated contract</span>
@@ -87,13 +87,6 @@
       </template>
 
       <template v-slot:leftContent>
-              <Property id="idAndChecksum">
-                <template v-slot:name>Account ID with checksum</template>
-                <template v-slot:value v-if="account?.account">
-                  <span>{{ account?.account }}</span>
-                  <span class="has-text-grey">-{{ accountChecksum }}</span>
-                </template>
-              </Property>
               <Property v-if="account?.staked_account_id" id="stakedAccount">
                 <template v-slot:name>Staked to Account</template>
                 <template v-slot:value>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -191,8 +191,9 @@ import Property from "@/components/Property.vue";
 import {ContractLoader} from "@/components/contract/ContractLoader";
 import {AccountLoader} from "@/components/account/AccountLoader";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
-import {useRoute, useRouter} from "vue-router";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
+import {networkRegistry} from "@/schemas/NetworkRegistry";
+import router from "@/router";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -229,9 +230,8 @@ export default defineComponent({
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
-    const router = useRouter()
-    const route = useRoute()
-
+    const route = router.currentRoute.value
+    const network = route.params.network as string
 
     //
     // basic computed's
@@ -255,7 +255,7 @@ export default defineComponent({
     onMounted(() => accountLoader.requestLoad())
 
     const accountChecksum = computed(() =>
-        accountLoader.accountId.value ? EntityID.parse(accountLoader.accountId.value)?.makeChecksum() : null)
+        accountLoader.accountId.value ? networkRegistry.computeChecksum(accountLoader.accountId.value, network) : null)
 
     const displayAllTokenLinks = computed(() => accountLoader.tokens.value ? accountLoader.tokens.value.length > MAX_TOKEN_BALANCES : false)
 

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -29,8 +29,9 @@
     <DashboardCard>
       <template v-slot:title>
         <span class="h-is-primary-title">Contract </span>
-        <span class="h-is-secondary-text is-numeric mr-3">{{ contract ? normalizedContractId : "" }}</span>
-        <span v-if="contract" class="is-inline-block">
+        <span class="h-is-secondary-text">{{ contract ? normalizedContractId : "" }}</span>
+        <span v-if="accountChecksum" class="has-text-grey" style="font-size: 28px">-{{ accountChecksum }}</span>
+        <span v-if="contract" class="is-inline-block ml-3">
           <router-link :to="{name: 'AccountDetails', params: {accountId: normalizedContractId}}">
             <span class="h-is-property-text">Show associated account</span>
           </router-link>
@@ -253,6 +254,9 @@ export default defineComponent({
     const accountLoader = new AccountLoader(normalizedContractId)
     onMounted(() => accountLoader.requestLoad())
 
+    const accountChecksum = computed(() =>
+        accountLoader.accountId.value ? EntityID.parse(accountLoader.accountId.value)?.makeChecksum() : null)
+
     const displayAllTokenLinks = computed(() => accountLoader.tokens.value ? accountLoader.tokens.value.length > MAX_TOKEN_BALANCES : false)
 
     const notification = computed(() => {
@@ -311,6 +315,7 @@ export default defineComponent({
       account: accountLoader.entity,
       balance: accountLoader.balance,
       tokens: accountLoader.tokens,
+      accountChecksum,
       displayAllTokenLinks,
       transactionTableController,
       notification,

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -230,9 +230,6 @@ export default defineComponent({
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
-    const route = router.currentRoute.value
-    const network = route.params.network as string
-
     //
     // basic computed's
     //
@@ -255,7 +252,10 @@ export default defineComponent({
     onMounted(() => accountLoader.requestLoad())
 
     const accountChecksum = computed(() =>
-        accountLoader.accountId.value ? networkRegistry.computeChecksum(accountLoader.accountId.value, network) : null)
+        accountLoader.accountId.value ? networkRegistry.computeChecksum(
+            accountLoader.accountId.value,
+            router.currentRoute.value.params.network as string
+        ) : null)
 
     const displayAllTokenLinks = computed(() => accountLoader.tokens.value ? accountLoader.tokens.value.length > MAX_TOKEN_BALANCES : false)
 
@@ -301,7 +301,7 @@ export default defineComponent({
       updateQuery()
     })
     const transactionFilterFromRoute = computed(() => {
-      return (route.query?.type as string ?? "").toUpperCase()
+      return (router.currentRoute.value.query?.type as string ?? "").toUpperCase()
     })
     watch(transactionFilterFromRoute, () => {
       transactionTableController.transactionType.value = transactionFilterFromRoute.value

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -321,9 +321,11 @@ export default defineComponent({
     const tokenInfoLoader = new TokenInfoLoader(normalizedTokenId)
     onMounted(() => tokenInfoLoader.requestLoad())
 
-    const network = router.currentRoute.value.params.network as string
     const tokenChecksum = computed(() =>
-        tokenInfoLoader.tokenId.value ? networkRegistry.computeChecksum(tokenInfoLoader.tokenId.value, network) : null)
+        tokenInfoLoader.tokenId.value ? networkRegistry.computeChecksum(
+            tokenInfoLoader.tokenId.value,
+            router.currentRoute.value.params.network as string
+        ) : null)
 
     const notification = computed(() => {
       let result

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -34,7 +34,8 @@
           <span v-else>Fungible</span>
         </span>
         <span class="h-is-primary-title"> Token </span>
-        <span class="h-is-secondary-text mr-2">{{ normalizedTokenId }}</span>
+        <span class="h-is-secondary-text">{{ normalizedTokenId }}</span>
+        <span v-if="tokenChecksum" class="has-text-grey" style="font-size: 28px">-{{ tokenChecksum }}</span>
       </template>
 
       <template v-slot:content>
@@ -319,6 +320,9 @@ export default defineComponent({
     const tokenInfoLoader = new TokenInfoLoader(normalizedTokenId)
     onMounted(() => tokenInfoLoader.requestLoad())
 
+    const tokenChecksum = computed(() =>
+        tokenInfoLoader.tokenId.value ? EntityID.parse(tokenInfoLoader.tokenId.value)?.makeChecksum() : null)
+
     const notification = computed(() => {
       let result
       if (!validEntityId.value) {
@@ -361,6 +365,7 @@ export default defineComponent({
       tokenInfo: tokenInfoLoader.entity,
       isNft: tokenInfoLoader.isNft,
       isFungible: tokenInfoLoader.isFungible,
+      tokenChecksum,
       validEntityId,
       normalizedTokenId,
       notification,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -278,6 +278,7 @@ import {NftHolderTableController} from "@/components/token/NftHolderTableControl
 import {TokenBalanceTableController} from "@/components/token/TokenBalanceTableController";
 import AccountLink from "@/components/values/AccountLink.vue";
 import StringValue from "@/components/values/StringValue.vue";
+import {networkRegistry} from "@/schemas/NetworkRegistry";
 
 export default defineComponent({
 
@@ -320,8 +321,9 @@ export default defineComponent({
     const tokenInfoLoader = new TokenInfoLoader(normalizedTokenId)
     onMounted(() => tokenInfoLoader.requestLoad())
 
+    const network = router.currentRoute.value.params.network as string
     const tokenChecksum = computed(() =>
-        tokenInfoLoader.tokenId.value ? EntityID.parse(tokenInfoLoader.tokenId.value)?.makeChecksum() : null)
+        tokenInfoLoader.tokenId.value ? networkRegistry.computeChecksum(tokenInfoLoader.tokenId.value, network) : null)
 
     const notification = computed(() => {
       let result

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -31,6 +31,7 @@
       <template v-slot:title>
         <span class="h-is-primary-title">Messages for Topic </span>
         <span v-if="validEntityId" class="h-is-secondary-text">{{ normalizedTopicId }}</span>
+        <span v-if="topicChecksum" class="has-text-grey" style="font-size: 28px">-{{ topicChecksum }}</span>
       </template>
 
       <template v-slot:control>
@@ -97,6 +98,9 @@ export default defineComponent({
       return props.topicId ? EntityID.normalize(props.topicId) : props.topicId
     })
 
+    const topicChecksum = computed(() =>
+        normalizedTopicId.value ? EntityID.parse(normalizedTopicId.value)?.makeChecksum() : null)
+
     const notification = computed(() => {
       let result
       if (!validEntityId.value) {
@@ -122,6 +126,7 @@ export default defineComponent({
       messageTableController,
       validEntityId,
       normalizedTopicId,
+      topicChecksum,
       notification
     }
   }

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -100,9 +100,11 @@ export default defineComponent({
       return props.topicId ? EntityID.normalize(props.topicId) : props.topicId
     })
 
-    const network = router.currentRoute.value.params.network as string
     const topicChecksum = computed(() =>
-        normalizedTopicId.value ? networkRegistry.computeChecksum(normalizedTopicId.value, network) : null)
+        normalizedTopicId.value ? networkRegistry.computeChecksum(
+            normalizedTopicId.value,
+            router.currentRoute.value.params.network as string
+        ) : null)
 
     const notification = computed(() => {
       let result

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -65,6 +65,8 @@ import Footer from "@/components/Footer.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import {EntityID} from "@/utils/EntityID";
 import {TopicMessageTableController} from "@/components/topic/TopicMessageTableController";
+import {networkRegistry} from "@/schemas/NetworkRegistry";
+import router from "@/router";
 
 export default defineComponent({
 
@@ -98,8 +100,9 @@ export default defineComponent({
       return props.topicId ? EntityID.normalize(props.topicId) : props.topicId
     })
 
+    const network = router.currentRoute.value.params.network as string
     const topicChecksum = computed(() =>
-        normalizedTopicId.value ? EntityID.parse(normalizedTopicId.value)?.makeChecksum() : null)
+        normalizedTopicId.value ? networkRegistry.computeChecksum(normalizedTopicId.value, network) : null)
 
     const notification = computed(() => {
       let result

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -91,7 +91,7 @@ export class NetworkRegistry {
     }
 
     public isValidChecksum(id: string, checksum: string, network: string): boolean {
-        return checksum===null || this.computeChecksum(id, network) == checksum
+        return this.computeChecksum(id, network) == checksum
     }
 
     public computeChecksum(id: string, network: string): string {

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -23,11 +23,13 @@ export class NetworkEntry {
     public readonly name: string
     public readonly displayName: string
     public readonly url: string
+    public readonly ledgerID: string
 
-    constructor(name: string, displayName: string, url: string) {
+    constructor(name: string, displayName: string, url: string, ledgerID: string) {
         this.name = name
         this.displayName = displayName
         this.url = url
+        this.ledgerID = ledgerID
     }
 }
 
@@ -44,17 +46,20 @@ export class NetworkRegistry {
         {
             name: 'mainnet',
             displayName: 'MAINNET',
-            url: "https://mainnet-public.mirrornode.hedera.com/"
+            url: "https://mainnet-public.mirrornode.hedera.com/",
+            ledgerID: '00'
         },
         {
             name: 'testnet',
             displayName: 'TESTNET',
-            url: "https://testnet.mirrornode.hedera.com/"
+            url: "https://testnet.mirrornode.hedera.com/",
+            ledgerID: '01'
         },
         {
             name: 'previewnet',
             displayName: 'PREVIEWNET',
-            url: "https://previewnet.mirrornode.hedera.com/"
+            url: "https://previewnet.mirrornode.hedera.com/",
+            ledgerID: '02'
         }
     ]
 
@@ -65,7 +70,8 @@ export class NetworkRegistry {
             this.entries.push(new NetworkEntry(
                 'devnet',
                 process.env.VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME ?? "DEVNET",
-                process.env.VUE_APP_LOCAL_MIRROR_NODE_URL
+                process.env.VUE_APP_LOCAL_MIRROR_NODE_URL,
+                'FF'
             ))
         }
     }
@@ -80,6 +86,82 @@ export class NetworkRegistry {
 
     public lookup(name: string): NetworkEntry | null {
         return this.entries.find(element => element.name === name) ?? null
+    }
+
+    public isValidChecksum(id: string, checksum: string, network: string): boolean {
+        return this.computeChecksum(id, network) == checksum
+    }
+
+    public computeChecksum(id: string, network: string): string {
+        const ledgerID = this.lookup(network)?.ledgerID
+        return NetworkRegistry.checksum(ledgerID ?? 'FF', id)
+    }
+
+    //
+    // From https://github.com/hashgraph/hedera-improvement-proposal/blob/master/assets/hip-15/HIP-15-javascript.html
+    //
+    // Given a ledger ID and an address like "0.0.123", return a checksum like "vfmkw" . The address must be in no-checksum
+    // format, with no extra characters (so not "0.0.00123" or "==0.0.123==" or "0.0.123-vfmkw"). The algorithm is defined
+    // by the HIP-15 standard to be:
+    //
+    // a = a valid no-checksum address string, such as 0.0.123
+    // d = int array for the digits of a (using 10 to represent "."), so 0.0.123 is [0,10,0,10,1,2,3]
+    // h = unsigned byte array containing the ledger ID followed by 6 zero bytes
+    // p3 = 26 * 26 * 26
+    // p5 = 26 * 26 * 26 * 26 * 26
+    // sd0 = (d[0] + d[2] + d[4] + d[6] + ...) mod 11
+    // sd1 = (d[1] + d[3] + d[5] + d[7] + ...) mod 11
+    // sd = (...((((d[0] * 31) + d[1]) * 31) + d[2]) * 31 + ... ) * 31 + d[d.length-1]) mod p3
+    // sh = (...(((h[0] * 31) + h[1]) * 31) + h[2]) * 31 + ... ) * 31 + h[h.length-1]) mod p5
+    // c = (((d.length mod 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh ) mod p5
+    // cp = (c * 1000003) mod p5
+    // checksum = cp, written as 5 digits in base 26, using a-z
+    //
+    //in ports to other languages, answer can be a string, digits an int32[] and the rest int32 (or uint32[] and uint32)
+
+    private static checksum(ledgerId: string, addr: string) {
+        let answer = "";
+        const d = [];      //digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3] *** FIX ***
+        let sd0 = 0;      //sum of even positions (mod 11)
+        let sd1 = 0;      //sum of odd positions (mod 11)
+        let sd = 0;       //weighted sum of all positions (mod p3)
+        let sh = 0;      //hash of the ledger ID
+        let cp: number;       //the checksum, as a single number
+        const p3 = 26 * 26 * 26;           //3 digits in base 26
+        const p5 = 26 * 26 * 26 * 26 * 26; //5 digits in base 26
+        const ascii_a = "a".charCodeAt(0);  //97  *** FIX ***
+        const m = 1_000_003; //min prime greater than a million. Used for the final permutation.
+        const w = 31; //sum s of digit values weights them by powers of w. Should be coprime to p5.
+
+        let id = ledgerId + "000000000000";
+        const h = []; // *** FIX ***
+        if (id.length % 2 == 1) id = "0" + id;
+        for (let i=0; i<id.length; i+=2) {  // *** FIX ***
+            h.push(parseInt(id.substr(i,2),16));
+        }
+        for (let i = 0; i < addr.length; i++) {
+            d.push(addr[i]=="." ? 10 : parseInt(addr[i],10));
+        }
+        for (let i=0; i<d.length; i++) {
+            sd = (w * sd + d[i]) % p3;
+            if (i % 2 == 0) {
+                sd0 = (sd0 + d[i]) % 11;
+            } else {
+                sd1 = (sd1 + d[i]) % 11;
+            }
+        }
+        for (let i=0; i<h.length; i++) {
+            sh = (w * sh + h[i]) % p5;
+        }
+        const c = ((((addr.length % 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh) % p5;  //the checksum, before the final permutation
+        cp = (c * m) % p5;
+
+        for (let i=0; i<5; i++) {
+            answer = String.fromCharCode(ascii_a + (cp % 26)) + answer;
+            cp /= 26;
+        }
+
+        return answer;
     }
 }
 

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -18,6 +18,8 @@
  *
  */
 
+import {EntityID} from "@/utils/EntityID";
+
 export class NetworkEntry {
 
     public readonly name: string
@@ -89,12 +91,27 @@ export class NetworkRegistry {
     }
 
     public isValidChecksum(id: string, checksum: string, network: string): boolean {
-        return this.computeChecksum(id, network) == checksum
+        return checksum===null || this.computeChecksum(id, network) == checksum
     }
 
     public computeChecksum(id: string, network: string): string {
         const ledgerID = this.lookup(network)?.ledgerID
         return NetworkRegistry.checksum(ledgerID ?? 'FF', id)
+    }
+
+    public stripChecksum(address: string): string {
+        const dash = address.indexOf('-')
+        return dash != -1 ? address.substring(0, dash) : address
+    }
+
+    public extractChecksum(address: string): string | null {
+        const dash = address.indexOf('-')
+        return dash != -1 ? address.substring(dash + 1) : null
+    }
+
+    public makeAddressWithChecksum(address: string, network: string): string | null {
+        const entity = EntityID.normalize(address)
+        return entity ? (entity + '-' + this.computeChecksum(entity, network)) : null
     }
 
     //

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -19,6 +19,8 @@
  */
 
 import {byteToHex} from "./B64Utils";
+import router from "@/router";
+import {NetworkRegistry} from "@/schemas/NetworkRegistry";
 
 export class EntityID {
 
@@ -65,6 +67,23 @@ export class EntityID {
     public static normalize(s: string): string|null {
         const id = EntityID.parse(s, true)
         return id !== null ? id.toString() : null
+    }
+
+    public static isValid(id: string, checksum: string | null = null): boolean {
+        const entityID = EntityID.parse(id, true)
+        return (entityID != null) && (checksum === null || entityID.isValidChecksum(checksum))
+    }
+
+    public isValidChecksum(checksum: string): boolean {
+        return this.makeChecksum() == checksum
+    }
+
+    public makeChecksum(): string {
+        const ledger = router.currentRoute.value.params.network
+        const ledgerId = (ledger === NetworkRegistry.MAIN_NETWORK) ? 0
+            : (ledger === NetworkRegistry.TEST_NETWORK) ? 1 : 2
+
+        return checksum(ledgerId, this.toString())
     }
 
     public toString(): string {
@@ -114,6 +133,15 @@ export class EntityID {
         return (isNaN(n) || Math.floor(n) != n || n < 0 || n >= EntityID.MAX_INT) ? null : n
     }
 
+    public static stripChecksum(address: string): string {
+        const dash = address.indexOf('-')
+        return dash != -1 ? address.substring(0, dash) : address
+    }
+
+    public static extractChecksum(address: string): string | null {
+        const dash = address.indexOf('-')
+        return dash != -1 ? address.substring(dash + 1) : null
+    }
 
     //
     // Private
@@ -124,7 +152,6 @@ export class EntityID {
         this.realm = realm
         this.num = num
     }
-
 }
 
 
@@ -138,4 +165,71 @@ function compareNumber(n1: number, n2: number): number {
         result = 0
     }
     return result
+}
+
+//
+// From https://github.com/hashgraph/hedera-improvement-proposal/blob/master/assets/hip-15/HIP-15-javascript.html
+//
+// Given a ledger ID and an address like "0.0.123", return a checksum like "vfmkw" . The address must be in no-checksum
+// format, with no extra characters (so not "0.0.00123" or "==0.0.123==" or "0.0.123-vfmkw"). The algorithm is defined
+// by the HIP-15 standard to be:
+//
+// a = a valid no-checksum address string, such as 0.0.123
+// d = int array for the digits of a (using 10 to represent "."), so 0.0.123 is [0,10,0,10,1,2,3]
+// h = unsigned byte array containing the ledger ID followed by 6 zero bytes
+// p3 = 26 * 26 * 26
+// p5 = 26 * 26 * 26 * 26 * 26
+// sd0 = (d[0] + d[2] + d[4] + d[6] + ...) mod 11
+// sd1 = (d[1] + d[3] + d[5] + d[7] + ...) mod 11
+// sd = (...((((d[0] * 31) + d[1]) * 31) + d[2]) * 31 + ... ) * 31 + d[d.length-1]) mod p3
+// sh = (...(((h[0] * 31) + h[1]) * 31) + h[2]) * 31 + ... ) * 31 + h[h.length-1]) mod p5
+// c = (((d.length mod 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh ) mod p5
+// cp = (c * 1000003) mod p5
+// checksum = cp, written as 5 digits in base 26, using a-z
+//
+//in ports to other languages, answer can be a string, digits an int32[] and the rest int32 (or uint32[] and uint32)
+
+function checksum(ledgerId: number, addr: string) {
+    let answer = "";
+    const d = [];      //digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3] *** FIX ***
+    let sd0 = 0;      //sum of even positions (mod 11)
+    let sd1 = 0;      //sum of odd positions (mod 11)
+    let sd = 0;       //weighted sum of all positions (mod p3)
+    let sh = 0;      //hash of the ledger ID
+    let cp: number;       //the checksum, as a single number
+    const p3 = 26 * 26 * 26;           //3 digits in base 26
+    const p5 = 26 * 26 * 26 * 26 * 26; //5 digits in base 26
+    const ascii_a = "a".charCodeAt(0);  //97  *** FIX ***
+    const m = 1_000_003; //min prime greater than a million. Used for the final permutation.
+    const w = 31; //sum s of digit values weights them by powers of w. Should be coprime to p5.
+
+    let id = ledgerId + "000000000000";
+    const h = []; // *** FIX ***
+    if (id.length % 2 == 1) id = "0" + id;
+    for (let i=0; i<id.length; i+=2) {  // *** FIX ***
+        h.push(parseInt(id.substr(i,2),16));
+    }
+    for (let i = 0; i < addr.length; i++) {
+        d.push(addr[i]=="." ? 10 : parseInt(addr[i],10));
+    }
+    for (let i=0; i<d.length; i++) {
+        sd = (w * sd + d[i]) % p3;
+        if (i % 2 == 0) {
+            sd0 = (sd0 + d[i]) % 11;
+        } else {
+            sd1 = (sd1 + d[i]) % 11;
+        }
+    }
+    for (let i=0; i<h.length; i++) {
+        sh = (w * sh + h[i]) % p5;
+    }
+    const c = ((((addr.length % 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh) % p5;  //the checksum, before the final permutation
+    cp = (c * m) % p5;
+
+    for (let i=0; i<5; i++) {
+        answer = String.fromCharCode(ascii_a + (cp % 26)) + answer;
+        cp /= 26;
+    }
+
+    return answer;
 }

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -19,8 +19,6 @@
  */
 
 import {byteToHex} from "./B64Utils";
-import router from "@/router";
-import {NetworkRegistry} from "@/schemas/NetworkRegistry";
 
 export class EntityID {
 
@@ -64,26 +62,9 @@ export class EntityID {
         return result
     }
 
-    public static normalize(s: string, withChecksum: boolean=false): string|null {
+    public static normalize(s: string, checksum: string|null = null): string|null {
         const id = EntityID.parse(s, true)
-        return id !== null ? id.toString() + (withChecksum ? "-" + id.makeChecksum() : "") : null
-    }
-
-    public static isValid(id: string, checksum: string | null = null): boolean {
-        const entityID = EntityID.parse(id, true)
-        return (entityID != null) && (checksum === null || entityID.isValidChecksum(checksum))
-    }
-
-    public isValidChecksum(checksum: string): boolean {
-        return this.makeChecksum() == checksum
-    }
-
-    public makeChecksum(): string {
-        const ledger = router.currentRoute.value.params.network
-        const ledgerId = (ledger === NetworkRegistry.MAIN_NETWORK) ? 0
-            : (ledger === NetworkRegistry.TEST_NETWORK) ? 1 : 2
-
-        return checksum(ledgerId, this.toString())
+        return id !== null ? id.toString() + (checksum ? "-" + checksum : "") : null
     }
 
     public toString(): string {
@@ -165,71 +146,4 @@ function compareNumber(n1: number, n2: number): number {
         result = 0
     }
     return result
-}
-
-//
-// From https://github.com/hashgraph/hedera-improvement-proposal/blob/master/assets/hip-15/HIP-15-javascript.html
-//
-// Given a ledger ID and an address like "0.0.123", return a checksum like "vfmkw" . The address must be in no-checksum
-// format, with no extra characters (so not "0.0.00123" or "==0.0.123==" or "0.0.123-vfmkw"). The algorithm is defined
-// by the HIP-15 standard to be:
-//
-// a = a valid no-checksum address string, such as 0.0.123
-// d = int array for the digits of a (using 10 to represent "."), so 0.0.123 is [0,10,0,10,1,2,3]
-// h = unsigned byte array containing the ledger ID followed by 6 zero bytes
-// p3 = 26 * 26 * 26
-// p5 = 26 * 26 * 26 * 26 * 26
-// sd0 = (d[0] + d[2] + d[4] + d[6] + ...) mod 11
-// sd1 = (d[1] + d[3] + d[5] + d[7] + ...) mod 11
-// sd = (...((((d[0] * 31) + d[1]) * 31) + d[2]) * 31 + ... ) * 31 + d[d.length-1]) mod p3
-// sh = (...(((h[0] * 31) + h[1]) * 31) + h[2]) * 31 + ... ) * 31 + h[h.length-1]) mod p5
-// c = (((d.length mod 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh ) mod p5
-// cp = (c * 1000003) mod p5
-// checksum = cp, written as 5 digits in base 26, using a-z
-//
-//in ports to other languages, answer can be a string, digits an int32[] and the rest int32 (or uint32[] and uint32)
-
-function checksum(ledgerId: number, addr: string) {
-    let answer = "";
-    const d = [];      //digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3] *** FIX ***
-    let sd0 = 0;      //sum of even positions (mod 11)
-    let sd1 = 0;      //sum of odd positions (mod 11)
-    let sd = 0;       //weighted sum of all positions (mod p3)
-    let sh = 0;      //hash of the ledger ID
-    let cp: number;       //the checksum, as a single number
-    const p3 = 26 * 26 * 26;           //3 digits in base 26
-    const p5 = 26 * 26 * 26 * 26 * 26; //5 digits in base 26
-    const ascii_a = "a".charCodeAt(0);  //97  *** FIX ***
-    const m = 1_000_003; //min prime greater than a million. Used for the final permutation.
-    const w = 31; //sum s of digit values weights them by powers of w. Should be coprime to p5.
-
-    let id = ledgerId + "000000000000";
-    const h = []; // *** FIX ***
-    if (id.length % 2 == 1) id = "0" + id;
-    for (let i=0; i<id.length; i+=2) {  // *** FIX ***
-        h.push(parseInt(id.substr(i,2),16));
-    }
-    for (let i = 0; i < addr.length; i++) {
-        d.push(addr[i]=="." ? 10 : parseInt(addr[i],10));
-    }
-    for (let i=0; i<d.length; i++) {
-        sd = (w * sd + d[i]) % p3;
-        if (i % 2 == 0) {
-            sd0 = (sd0 + d[i]) % 11;
-        } else {
-            sd1 = (sd1 + d[i]) % 11;
-        }
-    }
-    for (let i=0; i<h.length; i++) {
-        sh = (w * sh + h[i]) % p5;
-    }
-    const c = ((((addr.length % 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh) % p5;  //the checksum, before the final permutation
-    cp = (c * m) % p5;
-
-    for (let i=0; i<5; i++) {
-        answer = String.fromCharCode(ascii_a + (cp % 26)) + answer;
-        cp /= 26;
-    }
-
-    return answer;
 }

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -64,9 +64,9 @@ export class EntityID {
         return result
     }
 
-    public static normalize(s: string): string|null {
+    public static normalize(s: string, withChecksum: boolean=false): string|null {
         const id = EntityID.parse(s, true)
-        return id !== null ? id.toString() : null
+        return id !== null ? id.toString() + (withChecksum ? "-" + id.makeChecksum() : "") : null
     }
 
     public static isValid(id: string, checksum: string | null = null): boolean {

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -27,6 +27,8 @@ export class EntityID {
     public readonly num: number
 
 
+
+
     //
     // Public
     //
@@ -62,9 +64,9 @@ export class EntityID {
         return result
     }
 
-    public static normalize(s: string, checksum: string|null = null): string|null {
+    public static normalize(s: string): string|null {
         const id = EntityID.parse(s, true)
-        return id !== null ? id.toString() + (checksum ? "-" + checksum : "") : null
+        return id !== null ? id.toString() : null
     }
 
     public toString(): string {
@@ -112,16 +114,6 @@ export class EntityID {
     public static parsePositiveInt(s: string): number|null {
         const n = s.length >= 1 ? Number(s) : -1
         return (isNaN(n) || Math.floor(n) != n || n < 0 || n >= EntityID.MAX_INT) ? null : n
-    }
-
-    public static stripChecksum(address: string): string {
-        const dash = address.indexOf('-')
-        return dash != -1 ? address.substring(0, dash) : address
-    }
-
-    public static extractChecksum(address: string): string | null {
-        const dash = address.indexOf('-')
-        return dash != -1 ? address.substring(dash + 1) : null
     }
 
     //

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -192,7 +192,7 @@ describe("Staking.vue", () => {
             await changeConfirmButtons[1].trigger("click")
             await nextTick()
         }
-        await confirmChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to account 0.0.7FillerCANCELCONFIRM")
+        await confirmChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to account 0.0.7-lafyy ?FillerCANCELCONFIRM")
 
         // 2.7) Waits for progress dialog and closes ...
         const waitAndClose = async(busyText: string, completeText: string) => {

--- a/tests/unit/staking/StakingDialog.spec.ts
+++ b/tests/unit/staking/StakingDialog.spec.ts
@@ -25,7 +25,7 @@ import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {
     SAMPLE_ACCOUNT,
-    SAMPLE_ACCOUNT_STAKING_ACCOUNT,
+    SAMPLE_ACCOUNT_STAKING_ACCOUNT, SAMPLE_ACCOUNTS,
     SAMPLE_COINGECKO,
     SAMPLE_NETWORK_NODES,
 } from "../Mocks";
@@ -102,8 +102,9 @@ describe("StakingDialog.vue", () => {
         mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_NODES)
         const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-        const matcher4 = "/api/v1/accounts/0.0.7"
-        mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT)
+        const matcher4 = "/api/v1/accounts"
+        const body = {params: {"account.id": "0.0.7", balance: false}}
+        mock.onGet(matcher4, body).reply(200, SAMPLE_ACCOUNTS)
 
         const wrapper = mount(StakingDialog, {
             global: {
@@ -203,8 +204,9 @@ describe("StakingDialog.vue", () => {
         mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_NODES)
         const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-        const matcher4 = "/api/v1/accounts/0.0.7"
-        mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT)
+        const matcher4 = "/api/v1/accounts"
+        const body = {params: {"account.id": "0.0.7", balance: false}}
+        mock.onGet(matcher4, body).reply(200, SAMPLE_ACCOUNTS)
 
         const wrapper = mount(StakingDialog, {
             global: {

--- a/tests/unit/staking/StakingDialog.spec.ts
+++ b/tests/unit/staking/StakingDialog.spec.ts
@@ -1,0 +1,289 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {flushPromises, mount} from "@vue/test-utils"
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {
+    SAMPLE_ACCOUNT,
+    SAMPLE_ACCOUNT_STAKING_ACCOUNT,
+    SAMPLE_COINGECKO,
+    SAMPLE_NETWORK_NODES,
+} from "../Mocks";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
+import {waitFor} from "@/utils/TimerUtils";
+import StakingDialog from "@/components/staking/StakingDialog.vue";
+import {nextTick} from "vue";
+import router from "@/router";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});
+
+HMSF.forceUTC = true
+
+describe("StakingDialog.vue", () => {
+
+    it("provides valid account to stake to", async () => {
+
+        // Checks CONFIRM dialog
+        const confirmChangeStaking = async (expectedText: string) => {
+            const changeConfirmDialog = wrapper.getComponent(ConfirmDialog)
+            expect(changeConfirmDialog.text()).toBe(expectedText)
+            const changeConfirmButtons = changeConfirmDialog.findAll("button")
+            expect(changeConfirmButtons.length).toBe(2) // Cancel and Confirm
+            expect(changeConfirmButtons[1].text()).toBe("CONFIRM")
+            await changeConfirmButtons[1].trigger("click")
+            await nextTick()
+        }
+
+        // Checks CANCEL dialog
+        const cancelChangeStaking = async (expectedText: string) => {
+            const changeConfirmDialog = wrapper.getComponent(ConfirmDialog)
+            expect(changeConfirmDialog.text()).toBe(expectedText)
+            const changeConfirmButtons = changeConfirmDialog.findAll("button")
+            expect(changeConfirmButtons.length).toBe(2) // Cancel and Confirm
+            expect(changeConfirmButtons[0].text()).toBe("CANCEL")
+            await changeConfirmButtons[0].trigger("click")
+            await nextTick()
+        }
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Account for which we want to update staking
+        const TARGET_ACCOUNT = SAMPLE_ACCOUNT_STAKING_ACCOUNT
+
+        // Mocks axios
+        const mock = new MockAdapter(axios);
+        const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
+        mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT)
+        const matcher2 = "/api/v1/network/nodes"
+        for (const node of SAMPLE_NETWORK_NODES.nodes) {
+            const body = { params: { "node.id": node.node_id }}
+            const response = { nodes: [ node ]}
+            mock.onGet(matcher2, body).reply(200, response)
+        }
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_NODES)
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
+        const matcher4 = "/api/v1/accounts/0.0.7"
+        mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT)
+
+        const wrapper = mount(StakingDialog, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                showDialog: true,
+                account: TARGET_ACCOUNT,
+                currentlyStakedTo: "Account " + TARGET_ACCOUNT.staked_account_id,
+            },
+        });
+
+        await flushPromises()
+
+        const stakingModals = wrapper.findAll(".modal")
+        expect(stakingModals.length).toBeGreaterThanOrEqual(2)
+        const stakingModal = stakingModals[1]
+        // console.log(stakingModal.text())
+
+        expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Account 0.0.5")
+        const buttons = stakingModal.findAll("button")
+        expect(buttons.length).toBe(2) // Cancel and Change
+        const changeButton = buttons[1]
+        expect(changeButton.text()).toBe("CHANGE")
+
+        // Selects "Stake To Account" radio box
+        const stakingRadios = stakingModal.findAll<HTMLInputElement>("input[type='radio']")
+        expect(stakingRadios.length).toBe(2)
+        const stakingToAccountRadio = stakingRadios[1]
+        await stakingToAccountRadio.setValue(true)
+
+        const newStakeToAccountInput = stakingModal.get<HTMLInputElement>("input[type='text']")
+        const feedbackMessage = stakingModal.get('#feedbackMessage')
+
+        //
+        // Valid EntityID:  "7"
+        //
+        await newStakeToAccountInput.setValue("7")
+        expect(newStakeToAccountInput.element.value).toBe("7")
+        await waitFor(1000)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("Rewards will now be paid to that account")
+
+        // Clicks "CANCEL"
+        await changeButton.trigger("click")
+        await nextTick()
+        await cancelChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to account 0.0.7-lafyy ?FillerCANCELCONFIRM")
+
+        //
+        // Valid EntityID:  "0.0.7"
+        //
+        await newStakeToAccountInput.setValue("0.0.7")
+        expect(newStakeToAccountInput.element.value).toBe("0.0.7")
+        await waitFor(1000)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("Rewards will now be paid to that account")
+
+        // Clicks "CANCEL"
+        await changeButton.trigger("click")
+        await nextTick()
+        await cancelChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to account 0.0.7-lafyy ?FillerCANCELCONFIRM")
+
+        //
+        // Valid EntityID:  "0.0.7-lafyy"
+        //
+        await newStakeToAccountInput.setValue("0.0.7-lafyy")
+        expect(newStakeToAccountInput.element.value).toBe("0.0.7-lafyy")
+        await waitFor(1000)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("Rewards will now be paid to that account")
+
+        // Clicks "CHANGE"
+        await changeButton.trigger("click")
+        await nextTick()
+        await confirmChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to account 0.0.7-lafyy ?FillerCANCELCONFIRM")
+    })
+
+    it("provides invalid values for account to stake to", async () => {
+
+        await router.push("/testnet/")
+
+        // Account for which we want to update staking
+        const TARGET_ACCOUNT = SAMPLE_ACCOUNT_STAKING_ACCOUNT
+
+        // Mocks axios
+        const mock = new MockAdapter(axios);
+        const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
+        mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT)
+        const matcher2 = "/api/v1/network/nodes"
+        for (const node of SAMPLE_NETWORK_NODES.nodes) {
+            const body = { params: { "node.id": node.node_id }}
+            const response = { nodes: [ node ]}
+            mock.onGet(matcher2, body).reply(200, response)
+        }
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_NODES)
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
+        const matcher4 = "/api/v1/accounts/0.0.7"
+        mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT)
+
+        const wrapper = mount(StakingDialog, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                showDialog: true,
+                account: TARGET_ACCOUNT,
+                currentlyStakedTo: "Account " + TARGET_ACCOUNT.staked_account_id,
+            },
+        });
+
+        await flushPromises()
+
+        const stakingModals = wrapper.findAll(".modal")
+        expect(stakingModals.length).toBeGreaterThanOrEqual(2)
+        const stakingModal = stakingModals[1]
+        // console.log(stakingModal.text())
+
+        expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Account 0.0.5")
+        const buttons = stakingModal.findAll("button")
+        expect(buttons.length).toBe(2) // Cancel and Change
+        const changeButton = buttons[1]
+        expect(changeButton.text()).toBe("CHANGE")
+
+        // Selects "Stake To Account" radio box
+        const stakingRadios = stakingModal.findAll<HTMLInputElement>("input[type='radio']")
+        expect(stakingRadios.length).toBe(2)
+        const stakingToAccountRadio = stakingRadios[1]
+        await stakingToAccountRadio.setValue(true)
+
+        const newStakeToAccountInput = stakingModal.get<HTMLInputElement>("input[type='text']")
+        const feedbackMessage = stakingModal.get('#feedbackMessage')
+
+        //
+        // Invalid input:  "0.0.7abcde"
+        //
+        await newStakeToAccountInput.setValue("0.0.7abcde")
+        expect(newStakeToAccountInput.element.value).toBe("")
+        await waitFor(500)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("")
+
+        //
+        // Invalid account ID:  ".0.7"
+        //
+        await newStakeToAccountInput.setValue(".0.7")
+        expect(newStakeToAccountInput.element.value).toBe(".0.7")
+        await waitFor(500)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("Invalid account ID")
+
+        //
+        // Invalid checksum:  "0.0.7-"
+        //
+        await newStakeToAccountInput.setValue("0.0.7-")
+        expect(newStakeToAccountInput.element.value).toBe("0.0.7-")
+        await waitFor(500)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("Invalid checksum")
+
+        //
+        // Invalid checksum:  "0.0.7-abcde"
+        //
+        await newStakeToAccountInput.setValue("0.0.7-abcde")
+        expect(newStakeToAccountInput.element.value).toBe("0.0.7-abcde")
+        await waitFor(500)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("Invalid checksum")
+
+        //
+        // Account does not exist:  "7.0.0"
+        //
+        await newStakeToAccountInput.setValue("7.0.0")
+        expect(newStakeToAccountInput.element.value).toBe("7.0.0")
+        await waitFor(500)
+        await flushPromises()
+        expect(feedbackMessage.text()).toBe("This account does not exist")
+    })
+});

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -347,7 +347,8 @@ describe("TokenDetails.vue", () => {
 
         const mock = new MockAdapter(axios);
 
-        const testTokenId = SAMPLE_TOKEN_WITHOUT_KEYS.token_id
+        const testTokenId = "0.0.91961"
+        const testTokenIdWithChecksum = "0.0.91961-vxwbj"
         const matcher1 = "/api/v1/tokens/" + testTokenId
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_WITHOUT_KEYS);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
@@ -364,7 +365,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch(RegExp("^Non Fungible Token " + testTokenId + "Token is deleted"))
+        expect(wrapper.text()).toMatch(RegExp("^Non Fungible Token " + testTokenIdWithChecksum + "Token is deleted"))
 
         wrapper.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

With these changes:

- Details pages for Account/Contract/Token/Topic display a with-checksum form of the entity ID (per HIP-15).
- The StakingDialog will accept both with- and without-checksum forms of the stakedTo account ID.


**Related issue(s)**:

Fixes #209 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
