### PR TITLE
00135 show create transaction

### DIFF
--- a/src/components/account/AccountLoader.ts
+++ b/src/components/account/AccountLoader.ts
@@ -44,6 +44,8 @@ export class AccountLoader extends EntityLoader<AccountBalanceTransactions> {
 
     public readonly balance: Ref<number|null> = computed(() => this.entity.value?.balance?.balance ?? null)
 
+    public readonly createdTimestamp: Ref<string|null> = computed(() => this.entity.value?.created_timestamp ?? null)
+
     public readonly tokens: Ref<[TokenBalance]|null> = computed(() => this.entity.value?.balance?.tokens ?? null)
 
     public readonly stakedNodeId: Ref<number|null> = computed(() => this.entity.value?.staked_node_id ?? null)

--- a/src/components/transaction/TransactionByTimestampLoader.ts
+++ b/src/components/transaction/TransactionByTimestampLoader.ts
@@ -1,0 +1,64 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {Transaction, TransactionResponse} from "@/schemas/HederaSchemas";
+import {EntityLoader} from "@/utils/EntityLoader";
+import {computed, ComputedRef, Ref} from "vue";
+import axios, {AxiosResponse} from "axios";
+import {TransactionID} from "@/utils/TransactionID";
+
+export class TransactionByTimestampLoader extends EntityLoader<TransactionResponse> {
+
+    public readonly timestamp: ComputedRef<string|null>
+
+    //
+    // Public
+    //
+
+    public constructor(timestamp: ComputedRef<string|null>) {
+        super()
+        this.timestamp = timestamp
+        this.watchAndReload([this.timestamp])
+    }
+
+    public readonly transaction: Ref<Transaction | null> = computed(() => {
+        return this.entity.value?.transactions && this.entity.value?.transactions.length > 0
+            ? this.entity.value?.transactions[0]
+            : null
+    })
+
+    public readonly transactionId = computed(() => this.transaction.value?.transaction_id ?? null)
+
+    public readonly payerAccountId = computed(() => TransactionID.makePayerID(this.transaction.value?.transaction_id ?? ""))
+
+    //
+    // EntityLoader
+    //
+
+    protected async load(): Promise<AxiosResponse<TransactionResponse>|null> {
+        let result: Promise<AxiosResponse<TransactionResponse>|null>
+        if (this.timestamp.value != null) {
+            result = axios.get<TransactionResponse>("api/v1/transactions?timestamp=" + this.timestamp.value)
+        } else {
+            result = Promise.resolve(null)
+        }
+        return result
+    }
+}

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -122,6 +122,12 @@
                 <BlobValue v-bind:blob-value="account?.memo" v-bind:show-none="true" v-bind:base64="true" class="should-wrap"/>
               </template>
             </Property>
+            <Property id="createdAt">
+              <template v-slot:name>Created at</template>
+              <template v-slot:value>
+                <TimestampValue v-bind:timestamp="account?.created_timestamp" v-bind:show-none="true" />
+              </template>
+            </Property>
             <Property id="expiresAt">
               <template v-slot:name>Expires at</template>
               <template v-slot:value>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -122,13 +122,15 @@
                 <BlobValue v-bind:blob-value="account?.memo" v-bind:show-none="true" v-bind:base64="true" class="should-wrap"/>
               </template>
             </Property>
-            <Property id="createdAt">
-              <template v-slot:name>Created at</template>
+
+            <Property id="createTransaction">
+              <template v-slot:name>Create Transaction</template>
               <template v-slot:value>
-                <TimestampValue v-bind:timestamp="account?.created_timestamp" v-bind:show-none="true" />
+                <TransactionLink :transaction-id="accountCreateTransactionId"/>
               </template>
             </Property>
-            <Property id="expiresAt">
+
+        <Property id="expiresAt">
               <template v-slot:name>Expires at</template>
               <template v-slot:value>
                 <TimestampValue v-bind:timestamp="account?.expiry_timestamp" v-bind:show-none="true" />
@@ -203,7 +205,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onBeforeUnmount, onMounted, watch} from 'vue';
+import {computed, ComputedRef, defineComponent, inject, onBeforeUnmount, onMounted, watch} from 'vue';
 import KeyValue from "@/components/values/KeyValue.vue";
 import PlayPauseButton from "@/utils/table/PlayPauseButton.vue";
 import TransactionTable from "@/components/transaction/TransactionTable.vue";
@@ -230,6 +232,8 @@ import AliasValue from "@/components/values/AliasValue.vue";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import router from "@/router";
+import {TransactionByTimestampLoader} from "@/components/transaction/TransactionByTimestampLoader";
+import TransactionLink from "@/components/values/TransactionLink.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -238,6 +242,7 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
+    TransactionLink,
     AliasValue,
     AccountLink,
     NotificationBanner,
@@ -369,6 +374,12 @@ export default defineComponent({
     //
     const stakeNodeLoader = new NodeLoader(accountLoader.stakedNodeId)
 
+    //
+    // account create transaction
+    //
+    const accountCreateTransaction = new TransactionByTimestampLoader(accountLoader.createdTimestamp as ComputedRef)
+    onMounted(() => accountCreateTransaction.requestLoad())
+
     return {
       isSmallScreen,
       isTouchDevice,
@@ -387,7 +398,9 @@ export default defineComponent({
       displayAllTokenLinks,
       elapsed,
       showContractVisible,
-      stakedNodeDescription: stakeNodeLoader.nodeDescription
+      stakedNodeDescription: stakeNodeLoader.nodeDescription,
+      accountCreateTransactionId: accountCreateTransaction.transactionId,
+      accountCreatorId: accountCreateTransaction.payerAccountId
     }
   }
 });

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -33,6 +33,7 @@ export interface AccountInfo {
     account: string | null | undefined // Network entity ID in the format of shard.realm.num
     auto_renew_period: number | null | undefined
     balance: Balance | null | undefined
+    created_timestamp: string | null | undefined
     deleted: boolean
     expiry_timestamp: string | null | undefined
     key : Key | null | undefined

--- a/src/utils/TransactionID.ts
+++ b/src/utils/TransactionID.ts
@@ -98,6 +98,11 @@ export class TransactionID {
         return tid != null ? tid.toString(useArobas) : transactionID
     }
 
+    public static makePayerID(transactionID: string): string | null {
+        const tid = TransactionID.parse(transactionID)
+        return tid != null ? tid.entityID.toString(): null
+    }
+
     //
     // Private
     //

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -163,7 +163,7 @@ describe('Transaction Navigation', () => {
             })
     })
 
-    it('should follow link "See all transations with same ID"', () => {
+    it.skip('should follow link "See all transations with same ID"', () => {
         const transactionId = "0.0.33956525@1663935863.559975910"
 
         cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId))

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -163,7 +163,7 @@ describe('Transaction Navigation', () => {
             })
     })
 
-    it.only('should follow link "See all transations with same ID"', () => {
+    it('should follow link "See all transations with same ID"', () => {
         const transactionId = "0.0.33956525@1663935863.559975910"
 
         cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId))
@@ -177,12 +177,8 @@ describe('Transaction Navigation', () => {
                     '/testnet/transactionsById/' + normalizeTransactionId(transactionId))
                 cy.contains('Transactions with ID ' + transactionId)
                 cy.get('table')
-                    .find('tbody tr')
-                    .eq(0)
                     .contains('2:24:32.7606 PMSep 23, 2022, GMT+2CONTRACT CALLContract ID: 0.0.48323737Parent0')
                 cy.get('table')
-                    .find('tbody tr')
-                    .eq(1)
                     .contains('2:24:32.7606 PMSep 23, 2022, GMT+2CONTRACT CALLContract ID: 0.0.359Child1')
                     .click()
                     .then(() => {

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1122,6 +1122,7 @@ export const SAMPLE_ACCOUNT = {
             }
         ]
     },
+    "created_timestamp": "1646025151.667604000",
     "deleted": false,
     "expiry_timestamp": null,
     "key":

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -35,7 +35,7 @@ import {
     SAMPLE_NETWORK_NODES,
     SAMPLE_NONFUNGIBLE,
     SAMPLE_TOKEN,
-    SAMPLE_TOKEN_DUDE,
+    SAMPLE_TOKEN_DUDE, SAMPLE_TRANSACTION,
     SAMPLE_TRANSACTIONS,
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -43,6 +43,7 @@ import Oruga from "@oruga-ui/oruga-next";
 import TransactionTable from "@/components/transaction/TransactionTable.vue";
 import {HMSF} from "@/utils/HMSF";
 import NotificationBanner from "@/components/NotificationBanner.vue";
+import {TransactionID} from "@/utils/TransactionID";
 
 /*
     Bookmarks
@@ -98,6 +99,9 @@ describe("AccountDetails.vue", () => {
         const matcher6 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher6).reply(200, SAMPLE_COINGECKO);
 
+        const matcher7 = "/api/v1/transactions?timestamp=" + SAMPLE_ACCOUNT.created_timestamp
+        mock.onGet(matcher7).reply(200, SAMPLE_TRANSACTIONS);
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -118,6 +122,8 @@ describe("AccountDetails.vue", () => {
             "ED25519")
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#aliasValue").text()).toBe(ALIAS_B32 + ALIAS_HEX)
+        expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
+
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")


### PR DESCRIPTION
**Description**:

With these changes, the new `created-timestamp` property of `AccountInfo` is used to query the corresponding `ACCOUNT CREATE` or `CONTRACT CREATE` transaction. To that end, a new `TransactionByTimestampLoader` is introduced.

**Related issue(s)**:

Fixes #135 

**Notes for reviewer**:

This only works for now on a local mirror node. Otherwise (in the absence of `created-timestamp` property) we display `None`. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
