### PR TITLE
Use node descriptions from network

### DIFF
--- a/src/components/node/NodeLoader.ts
+++ b/src/components/node/NodeLoader.ts
@@ -67,7 +67,7 @@ export class NodeLoader extends EntityLoader<NetworkNodesResponse> {
         let result: Promise<AxiosResponse<NetworkNodesResponse>|null>
         if (this.nodeId.value != null) {
             const url = "api/v1/network/nodes"
-            const queryParams = {params: {'node.id': this.nodeId.value}}
+            const queryParams = {params: {'node.id': this.nodeId.value, 'file.id': '101'}}
             result = axios.get<NetworkNodesResponse>(url, queryParams)
         } else {
             result = Promise.resolve(null)

--- a/src/components/node/NodesLoader.ts
+++ b/src/components/node/NodesLoader.ts
@@ -72,7 +72,7 @@ export class NodesLoader extends EntityBatchLoader<NetworkNodesResponse> {
     //
 
     protected async loadNext(nextURL: string|null): Promise<AxiosResponse<NetworkNodesResponse>|null> {
-        return axios.get<NetworkNodesResponse>(nextURL ?? "api/v1/network/nodes")
+        return axios.get<NetworkNodesResponse>(nextURL ?? "api/v1/network/nodes?file.id=101")
     }
 
     protected nextURL(entity: NetworkNodesResponse): string | null {

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -353,6 +353,7 @@ export default defineComponent({
     // staking
     //
     const stakeNodeLoader = new NodeLoader(accountLoader.stakedNodeId)
+    onMounted(() => stakeNodeLoader.requestLoad())
 
     //
     // account create transaction

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1617,7 +1617,7 @@ export const SAMPLE_TOPIC_DUDE_MESSAGES = {
 export const SAMPLE_NETWORK_NODES = {
     "nodes": [
         {
-            "description": "",
+            "description": "Sample Network Node ID:0",
             "file_id": "0.0.102",
             "memo": "0.0.3",
             "node_id": 0,
@@ -1659,7 +1659,7 @@ export const SAMPLE_NETWORK_NODES = {
             "staking_period": null
         },
         {
-            "description": "",
+            "description": "Sample Network Node ID:1",
             "file_id": "0.0.102",
             "memo": "0.0.4",
             "node_id": 1,
@@ -1688,7 +1688,7 @@ export const SAMPLE_NETWORK_NODES = {
             "staking_period": null
         },
         {
-            "description": "",
+            "description": "Sample Network Node ID:2",
             "file_id": "0.0.102",
             "memo": "0.0.5",
             "node_id": 2,

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -292,7 +292,12 @@ describe("AccountDetails.vue", () => {
 
         const stakedNodeID = SAMPLE_ACCOUNT_STAKING_NODE.staked_node_id
         const matcher3 = "/api/v1/network/nodes"
-        const body = { params: { "node.id": stakedNodeID }}
+        const body = {
+            params: {
+                "node.id": stakedNodeID,
+                "file.id": "101",
+            }
+        }
         const response = { nodes: [ SAMPLE_NETWORK_NODES.nodes[stakedNodeID] ]}
         mock.onGet(matcher3, body).reply(200, response);
 
@@ -314,7 +319,7 @@ describe("AccountDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.html())
 
-        expect(wrapper.get("#stakedNodeValue").text()).toBe("Node " + stakedNodeID + " - testnet")
+        expect(wrapper.get("#stakedNodeValue").text()).toBe("Sample Network Node ID:" + stakedNodeID)
         expect(wrapper.find("#stakedAccount").exists()).toBe(false)
         expect(wrapper.get("#stakePeriodStartValue").text()).toBe("6:45:00.3568 PMMar 3, 2022, UTC")
         expect(wrapper.get("#declineRewardValue").text()).toBe("Accepted")
@@ -332,6 +337,9 @@ describe("AccountDetails.vue", () => {
 
         const matcher2 = "/api/v1/transactions"
         mock.onGet(matcher2).reply(200, SAMPLE_FAILED_TRANSACTIONS);
+
+        const matcher3 = "/api/v1/network/nodes?file.id=101"
+        mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
 
         const matcher4 = "/api/v1/balances"
         mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT_HBAR_BALANCE);

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -290,8 +290,11 @@ describe("AccountDetails.vue", () => {
         const matcher2 = "/api/v1/transactions"
         mock.onGet(matcher2).reply(200, SAMPLE_FAILED_TRANSACTIONS);
 
+        const stakedNodeID = SAMPLE_ACCOUNT_STAKING_NODE.staked_node_id
         const matcher3 = "/api/v1/network/nodes"
-        mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
+        const body = { params: { "node.id": stakedNodeID }}
+        const response = { nodes: [ SAMPLE_NETWORK_NODES.nodes[stakedNodeID] ]}
+        mock.onGet(matcher3, body).reply(200, response);
 
         const matcher4 = "/api/v1/balances"
         mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT_HBAR_BALANCE);
@@ -311,7 +314,7 @@ describe("AccountDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.html())
 
-        expect(wrapper.get("#stakedNodeValue").text()).toBe("Node 0 - testnet")
+        expect(wrapper.get("#stakedNodeValue").text()).toBe("Node " + stakedNodeID + " - testnet")
         expect(wrapper.find("#stakedAccount").exists()).toBe(false)
         expect(wrapper.get("#stakePeriodStartValue").text()).toBe("6:45:00.3568 PMMar 3, 2022, UTC")
         expect(wrapper.get("#declineRewardValue").text()).toBe("Accepted")
@@ -329,9 +332,6 @@ describe("AccountDetails.vue", () => {
 
         const matcher2 = "/api/v1/transactions"
         mock.onGet(matcher2).reply(200, SAMPLE_FAILED_TRANSACTIONS);
-
-        const matcher3 = "/api/v1/network/nodes"
-        mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
 
         const matcher4 = "/api/v1/balances"
         mock.onGet(matcher4).reply(200, SAMPLE_ACCOUNT_HBAR_BALANCE);

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -67,7 +67,7 @@ describe("NodeDetails.vue", () => {
         const mock = new MockAdapter(axios);
 
         const node = 0
-        const matcher1 = "api/v1/network/nodes"
+        const matcher1 = "api/v1/network/nodes?file.id=101"
         mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
         const matcher2 = "api/v1/network/stake"
         mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
@@ -87,7 +87,7 @@ describe("NodeDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Node " + node))
         expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.3")
-        expect(wrapper.get("#descriptionValue").text()).toBe("Node 0 - testnet")
+        expect(wrapper.get("#descriptionValue").text()).toBe("Sample Network Node ID:0")
         expect(wrapper.get("#publicKeyValue").text()).toBe("3082 01a2 300d 0609Copy to ClipboardRSA")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.102")
         expect(wrapper.get("#rangeFromValue").text()).toBe("4:10:06.0411 PMJun 6, 2022, UTC")

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -86,9 +86,9 @@ describe("NodeTable.vue", () => {
         expect(wrapper.get('thead').text()).toBe("Node Account Description Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "Node 0 - testnet" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
-            "1" + "0.0.4" + "Node 1 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
-            "2" + "0.0.5" + "Node 2 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
+            "0" + "0.0.3" + "Sample Network Node ID:0" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
+            "1" + "0.0.4" + "Sample Network Node ID:1" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
+            "2" + "0.0.5" + "Sample Network Node ID:2" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -70,7 +70,7 @@ describe("Nodes.vue", () => {
 
         const mock = new MockAdapter(axios);
 
-        const matcher1 = "/api/v1/network/nodes"
+        const matcher1 = "/api/v1/network/nodes?file.id=101"
         mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
         const matcher2 = "/api/v1/network/stake"
         mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
@@ -102,9 +102,9 @@ describe("Nodes.vue", () => {
         expect(table.exists()).toBe(true)
         expect(table.get('thead').text()).toBe("Node Account Description Stake Stake Not Rewarded Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "Node 0 - testnet" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
-            "1" + "0.0.4" + "Node 1 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
-            "2" + "0.0.5" + "Node 2 - testnet" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
+            "0" + "0.0.3" + "Sample Network Node ID:0" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
+            "1" + "0.0.4" + "Sample Network Node ID:1" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
+            "2" + "0.0.5" + "Sample Network Node ID:2" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
         )
     });
 

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -62,7 +62,7 @@ describe("Staking.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/accounts/" + TEST_ACCOUNT.account
         mock.onGet(matcher1).reply(200, TEST_ACCOUNT)
-        const matcher2 = "/api/v1/network/nodes"
+        const matcher2 = "/api/v1/network/nodes?file.id=101"
         for (const node of SAMPLE_NETWORK_NODES.nodes) {
             const body = {params: {"node.id": node.node_id}}
             const response = {nodes: [node]}
@@ -85,9 +85,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(3)
-        expect(options.at(0)?.element.text).toBe('Node 0 - testnet - 6,000,000ℏ staked (20% of Max)')
-        expect(options.at(1)?.element.text).toBe('Node 1 - testnet - 9,000,000ℏ staked (30% of Max)')
-        expect(options.at(2)?.element.text).toBe('Node 2 - testnet - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(0)?.element.text).toBe('Sample Network Node ID:0 - 6,000,000ℏ staked (20% of Max)')
+        expect(options.at(1)?.element.text).toBe('Sample Network Node ID:1 - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(2)?.element.text).toBe('Sample Network Node ID:2 - 9,000,000ℏ staked (30% of Max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)
@@ -109,7 +109,7 @@ describe("Staking.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/accounts/" + TEST_ACCOUNT.account
         mock.onGet(matcher1).reply(200, TEST_ACCOUNT)
-        const matcher2 = "/api/v1/network/nodes"
+        const matcher2 = "/api/v1/network/nodes?file.id=101"
         for (const node of SAMPLE_NETWORK_NODES.nodes) {
             const body = {params: {"node.id": node.node_id}}
             const response = {nodes: [node]}
@@ -135,9 +135,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(3)
-        expect(options.at(0)?.element.text).toBe('Node 0 - testnet - 6,000,000ℏ staked (20% of Max)')
-        expect(options.at(1)?.element.text).toBe('Node 1 - testnet - 9,000,000ℏ staked (30% of Max)')
-        expect(options.at(2)?.element.text).toBe('Node 2 - testnet - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(0)?.element.text).toBe('Sample Network Node ID:0 - 6,000,000ℏ staked (20% of Max)')
+        expect(options.at(1)?.element.text).toBe('Sample Network Node ID:1 - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(2)?.element.text).toBe('Sample Network Node ID:2 - 9,000,000ℏ staked (30% of Max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(true)
@@ -159,7 +159,7 @@ describe("Staking.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/accounts/" + TEST_ACCOUNT.account
         mock.onGet(matcher1).reply(200, TEST_ACCOUNT)
-        const matcher2 = "/api/v1/network/nodes"
+        const matcher2 = "/api/v1/network/nodes?file.id=101"
         for (const node of SAMPLE_NETWORK_NODES.nodes) {
             const body = {params: {"node.id": node.node_id}}
             const response = {nodes: [node]}
@@ -182,9 +182,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(3)
-        expect(options.at(0)?.element.text).toBe('Node 0 - testnet - 6,000,000ℏ staked (20% of Max)')
-        expect(options.at(1)?.element.text).toBe('Node 1 - testnet - 9,000,000ℏ staked (30% of Max)')
-        expect(options.at(2)?.element.text).toBe('Node 2 - testnet - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(0)?.element.text).toBe('Sample Network Node ID:0 - 6,000,000ℏ staked (20% of Max)')
+        expect(options.at(1)?.element.text).toBe('Sample Network Node ID:1 - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(2)?.element.text).toBe('Sample Network Node ID:2 - 9,000,000ℏ staked (30% of Max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -90,7 +90,7 @@ describe("Staking.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/accounts/" + testDriver.account.account
         mock.onGet(matcher1).reply(200, testDriver.account)
-        const matcher2 = "/api/v1/network/nodes"
+        const matcher2 = "/api/v1/network/nodes?file.id=101"
         for (const node of SAMPLE_NETWORK_NODES.nodes) {
             const body = { params: { "node.id": node.node_id }}
             const response = { nodes: [ node ]}
@@ -256,7 +256,7 @@ describe("Staking.vue", () => {
         await nextTick()
 
         // 3.6) Confirms
-        await confirmChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to Node 2 - testnet?FillerCANCELCONFIRM")
+        await confirmChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to Sample Network Node ID:2?FillerCANCELCONFIRM")
 
         // 3.7) Waits for progress dialog and closes ...
         await waitAndClose("Updating stakingConnecting to Hedera Network using your wallet…Check your wallet for any approval requestCLOSE",
@@ -269,7 +269,7 @@ describe("Staking.vue", () => {
         expect(testDriver.account.decline_reward).toBeTruthy()
 
         // 3.8) Checks staking information
-        expect(ndis[0].text()).toBe("Staked toNode 2 - testnetsince Mar 3, 2022")
+        expect(ndis[0].text()).toBe("Staked toSample Network Node ID:2since Mar 3, 2022")
         expect(ndis[1].text()).toBe("My Stake0.31669471HBAR")
         expect(ndis[2].text()).toBe("RewardsDeclined")
 
@@ -285,7 +285,7 @@ describe("Staking.vue", () => {
         // 4.2) Checks StakingDialog content
         expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
         expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
-        expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Node 2 - testnet")
+        expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Sample Network Node ID:2")
         expect(changeButton.text()).toBe("CHANGE")
         // expect(changeButton.attributes("disabled")).toBeDefined()
 
@@ -313,7 +313,7 @@ describe("Staking.vue", () => {
         expect(testDriver.account.decline_reward).toBeFalsy()
 
         // 4.8) Checks staking information
-        expect(ndis[0].text()).toBe("Staked toNode 2 - testnetsince Mar 3, 2022")
+        expect(ndis[0].text()).toBe("Staked toSample Network Node ID:2since Mar 3, 2022")
         expect(ndis[1].text()).toBe("My Stake0.31669471HBAR")
         expect(ndis[2].text()).toBe("RewardsAccepted")
 
@@ -335,7 +335,7 @@ describe("Staking.vue", () => {
             await confirmButtons[1].trigger("click")
             await flushPromises()
         }
-        await confirm("My Staking  for account 0.0.730632Do you want to stop staking to Node 2 - testnet?FillerCANCELCONFIRM")
+        await confirm("My Staking  for account 0.0.730632Do you want to stop staking to Sample Network Node ID:2?FillerCANCELCONFIRM")
 
         // 5.3) Waits for progress dialog and closes ...
         await waitAndClose("Stopping stakingCompleting operation…This may take a few secondsCLOSE",

--- a/tests/unit/staking/StakingDialog.spec.ts
+++ b/tests/unit/staking/StakingDialog.spec.ts
@@ -93,7 +93,7 @@ describe("StakingDialog.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
         mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT)
-        const matcher2 = "/api/v1/network/nodes"
+        const matcher2 = "/api/v1/network/nodes?file.id=101"
         for (const node of SAMPLE_NETWORK_NODES.nodes) {
             const body = { params: { "node.id": node.node_id }}
             const response = { nodes: [ node ]}
@@ -195,7 +195,7 @@ describe("StakingDialog.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
         mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT)
-        const matcher2 = "/api/v1/network/nodes"
+        const matcher2 = "/api/v1/network/nodes?file.id=101"
         for (const node of SAMPLE_NETWORK_NODES.nodes) {
             const body = { params: { "node.id": node.node_id }}
             const response = { nodes: [ node ]}


### PR DESCRIPTION
**Description**:

Use file.id 101 (instead of 102 by default) such that the REST API /api/v1/network/nodes actually returns the node descriptions now.
Modify mocks and unit tests accordingly.

**Related issue(s)**:

None.

**Notes for reviewer**:

This does not address yet the refactoring around NodeLoader, NodesLoader, OperatorRegistry... which is going to be needed at some point.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
