### PR TITLE
00260 Last Transactions table in Account details does not preserve selected page

### DIFF
--- a/src/components/transaction/TransactionTableControllerXL.ts
+++ b/src/components/transaction/TransactionTableControllerXL.ts
@@ -44,7 +44,15 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
             pageParamName, keyParamName);
         this.accountId = accountId
         this.accountIdMandatory = accountIdMandatory
-        this.watchAndReload([this.accountId, this.transactionType])
+        this.watchAndReload([this.transactionType])
+        // this.accountId cannot be treated as this.transactionType :
+        // when this.accountId changes, we don't want to move to auto-refresh mode.
+        watch(this.accountId, () => {
+            if (this.mounted.value) {
+                this.unmount()
+                this.mount()
+            }
+        })
     }
 
     public readonly transactionType: Ref<string> = ref("")

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -91,6 +91,13 @@ export abstract class TableController<R, K> {
         this.stopWatchingSources()
         this.subController?.unmount()
         this.subController = null
+        this.buffer.value = []
+        this.startIndex.value = 0
+        this.drained.value = false
+        this.autoUpdateCount.value = 0
+        this.shadowRowCount.value = 0
+        this.currentPage.value = 1
+
         this.mountedRef.value = false
         this.autoRefreshRef.value = false
     }

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -84,14 +84,11 @@ export abstract class TableController<R, K> {
         }
         this.autoRefreshRef.value = this.subController instanceof AutoRefreshController
         this.mountedRef.value = true
-        this.watchSourcesHandle = watch(this.sources, () => this.reset())
+        this.startWatchingSources()
     }
 
     public unmount(): void {
-        if (this.watchSourcesHandle !== null) {
-            this.watchSourcesHandle()
-            this.watchSourcesHandle = null
-        }
+        this.stopWatchingSources()
         this.subController?.unmount()
         this.subController = null
         this.mountedRef.value = false
@@ -233,10 +230,7 @@ export abstract class TableController<R, K> {
     protected watchAndReload(sources: WatchSource<unknown>[]): void {
         this.sources = sources
         if (this.mounted.value) {
-            if (this.watchSourcesHandle !== null) {
-                this.watchSourcesHandle()
-            }
-            this.watchSourcesHandle = watch(this.sources, () => this.reset())
+            this.startWatchingSources()
         }
     }
 
@@ -257,6 +251,17 @@ export abstract class TableController<R, K> {
     private readonly autoRefreshRef: Ref<boolean> = ref(false)
     private readonly mountedRef: Ref<boolean> = ref(false)
 
+    private startWatchingSources(): void {
+        this.stopWatchingSources()
+        this.watchSourcesHandle = watch(this.sources, () => this.reset())
+    }
+
+    private stopWatchingSources(): void {
+        if (this.watchSourcesHandle !== null) {
+            this.watchSourcesHandle()
+            this.watchSourcesHandle = null
+        }
+    }
 }
 
 export enum KeyOperator { gt= "gt", gte = "gte", lt= "lt", lte="lte" }

--- a/tests/unit/utils/TableController.spec.ts
+++ b/tests/unit/utils/TableController.spec.ts
@@ -125,7 +125,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loading.value).toBe(false)
         expect(tc.totalRowCount.value).toBe(TestTableController.PRESUMED_ROW_COUNT)
-        expect(tc.rows.value).toStrictEqual([49,48,47,46,45,44,43,42,41,40])
+        expect(tc.rows.value).toStrictEqual([])
         expect(tc.mounted.value).toBe(false)
 
     })
@@ -178,9 +178,9 @@ describe("TableController.ts", () => {
         tc.unmount()
         await flushPromises()
         expect(tc.autoRefresh.value).toBe(false)
-        expect(tc.autoStopped.value).toBe(true)
-        expect(tc.rows.value).toStrictEqual([49,48,47,46,45,44,43,42,41,40])
-        expect(tc.autoUpdateCount.value).toBe(5)
+        expect(tc.autoStopped.value).toBe(false)
+        expect(tc.rows.value).toStrictEqual([])
+        expect(tc.autoUpdateCount.value).toBe(0)
 
     })
 
@@ -231,8 +231,8 @@ describe("TableController.ts", () => {
         await flushPromises()
         expect(tc.autoRefresh.value).toBe(false)
         expect(tc.autoStopped.value).toBe(false)
-        expect(tc.rows.value).toStrictEqual([61,60,59,58,57,56,55,54,53,52])
-        expect(tc.autoUpdateCount.value).toBe(4)
+        expect(tc.rows.value).toStrictEqual([])
+        expect(tc.autoUpdateCount.value).toBe(0)
 
     })
 
@@ -270,8 +270,8 @@ describe("TableController.ts", () => {
         await flushPromises()
         expect(tc.autoRefresh.value).toBe(false)
         expect(tc.autoStopped.value).toBe(false)
-        expect(tc.rows.value).toStrictEqual([98,96,94,92,90,88,86,84,82,80])
-        expect(tc.autoUpdateCount.value).toBe(1)
+        expect(tc.rows.value).toStrictEqual([])
+        expect(tc.autoUpdateCount.value).toBe(0)
 
     })
 


### PR DESCRIPTION
**Description**:

AccountDetails calls TransactionTableController.mount() and then initializes TransactionTableController.accountId.
TransactionTableController does not handle this flow correctly.

Changes below:
- fix TransactionTableController logic in charge of watching accountId
- add a unit test for TransactionTableController

**Related issue(s)**:

Fixes #260

**Notes for reviewer**:

#260 provides instructions for reproducing the problem.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
