### PR TITLE
00264 router html5 history

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -18,7 +18,13 @@
  *
  */
 
-import {createRouter, createWebHashHistory, RouteLocationNormalized, Router, RouteRecordRaw} from 'vue-router'
+import {
+  createRouter,
+  createWebHistory,
+  RouteLocationNormalized,
+  Router,
+  RouteRecordRaw
+} from 'vue-router'
 import MainDashboard from "@/pages/MainDashboard.vue";
 import Transactions from "@/pages/Transactions.vue";
 import TransactionDetails from "@/pages/TransactionDetails.vue";
@@ -223,7 +229,7 @@ const routes: Array<RouteRecordRaw> = [
 
 export function makeRouter(): Router {
   return createRouter({
-    history: createWebHashHistory(process.env.BASE_URL),
+    history: createWebHistory(),
     routes
   })
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -251,48 +251,54 @@ router.beforeEach((to) => {
 router.beforeEach((to, from) => {
   let result: boolean | string
 
-  const toEntry = getNetworkEntryFromRoute(to)
-  const fromEntry = getNetworkEntryFromRoute(from)
-  if (toEntry !== null) {
-    // Network is valid
-    AppStorage.setLastNetwork(toEntry)
-    axios.defaults.baseURL = toEntry.url
-
-    if (toEntry.name == NetworkRegistry.TEST_NETWORK) {
-      document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-testnet-background-color)')
-      document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-testnet-highlight-color)')
-      document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-testnet-pagination-background-color)')
-      document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-testnet-box-shadow-color)')
-      document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-testnet-dropdown-arrow)')
-    } else if (toEntry.name == NetworkRegistry.PREVIEW_NETWORK) {
-      document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-previewnet-background-color)')
-      document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-previewnet-highlight-color)')
-      document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-previewnet-pagination-background-color)')
-      document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-previewnet-box-shadow-color)')
-      document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-previewnet-dropdown-arrow)')
-    } else {
-      document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-mainnet-background-color)')
-      document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-mainnet-highlight-color)')
-      document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-mainnet-pagination-background-color)')
-      document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-mainnet-box-shadow-color)')
-      document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-mainnet-dropdown-arrow)')
-    }
-
-    if (fromEntry != null && fromEntry != toEntry) {
-      // Network is changing => updates AppStorage and axios
-      if (to.name != "MainDashboard" && to.name != "PageNotFound") {
-        // We re-route on MainDashboard
-        result = "/" + toEntry.name + "/dashboard"
-      }
-      else {
-        result = true
-      }
-    } else (
-        result = true
-    )
+  const hash = window.location.hash
+  if (hash?.length > 1 && hash[0] === '#') {
+    result = hash.slice(1)
+    window.location.hash = ""
   } else {
-    // Network is invalid => page not found
-    result = '/page-not-found'
+
+    const toEntry = getNetworkEntryFromRoute(to)
+    const fromEntry = getNetworkEntryFromRoute(from)
+    if (toEntry !== null) {
+      // Network is valid
+      AppStorage.setLastNetwork(toEntry)
+      axios.defaults.baseURL = toEntry.url
+
+      if (toEntry.name == NetworkRegistry.TEST_NETWORK) {
+        document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-testnet-background-color)')
+        document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-testnet-highlight-color)')
+        document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-testnet-pagination-background-color)')
+        document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-testnet-box-shadow-color)')
+        document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-testnet-dropdown-arrow)')
+      } else if (toEntry.name == NetworkRegistry.PREVIEW_NETWORK) {
+        document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-previewnet-background-color)')
+        document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-previewnet-highlight-color)')
+        document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-previewnet-pagination-background-color)')
+        document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-previewnet-box-shadow-color)')
+        document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-previewnet-dropdown-arrow)')
+      } else {
+        document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-mainnet-background-color)')
+        document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-mainnet-highlight-color)')
+        document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-mainnet-pagination-background-color)')
+        document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-mainnet-box-shadow-color)')
+        document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-mainnet-dropdown-arrow)')
+      }
+
+      if (fromEntry != null && fromEntry != toEntry) {
+        // Network is changing => updates AppStorage and axios
+        if (to.name != "MainDashboard" && to.name != "PageNotFound") {
+          // We re-route on MainDashboard
+          result = "/" + toEntry.name + "/dashboard"
+        } else {
+          result = true
+        }
+      } else (
+          result = true
+      )
+    } else {
+      // Network is invalid => page not found
+      result = '/page-not-found'
+    }
   }
   return result
 })

--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -161,7 +161,7 @@ describe('Account Navigation', () => {
 
         // EIP 3091
         cy.visit('testnet/address/' + evmAddress)
-        cy.url().should('include', '/testnet/address/' + evmAddress)
+        cy.url().should('include', '/testnet/account/' + evmAddress)
         cy.contains('Account ' + accountID)
     })
 

--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -25,7 +25,7 @@ import {normalizeTransactionId} from "../../../src/utils/TransactionID";
 describe('Account Navigation', () => {
 
     it('should navigate from table to account details', () => {
-        cy.visit('#/testnet/accounts/')
+        cy.visit('testnet/accounts/')
         cy.url().should('include', '/testnet/accounts')
         cy.contains('Recent Accounts')
 
@@ -46,7 +46,7 @@ describe('Account Navigation', () => {
     it('should follow links from account with many tokens', () => {
         const accountId1 = "0.0.29627434"
 
-        cy.visit('#/testnet/account/' + accountId1)
+        cy.visit('testnet/account/' + accountId1)
         cy.url().should('include', '/testnet/account/')
         cy.contains('Account ' + accountId1)
 
@@ -92,7 +92,7 @@ describe('Account Navigation', () => {
     it('should follow links from account with few tokens', () => {
         const accountId2 = "0.0.30974874"
 
-        cy.visit('#/testnet/account/' + accountId2)
+        cy.visit('testnet/account/' + accountId2)
         cy.url().should('include', '/testnet/account/')
         cy.contains('Account ' + accountId2)
 
@@ -130,7 +130,7 @@ describe('Account Navigation', () => {
 
     it ('should display account details using account ID', () => {
         const accountID = "0.0.46022656"
-        cy.visit('#/testnet/account/' + accountID)
+        cy.visit('testnet/account/' + accountID)
         cy.url().should('include', '/testnet/account/' + accountID)
         cy.contains('Account ' + accountID)
     })
@@ -138,7 +138,7 @@ describe('Account Navigation', () => {
     it ('should display account details using account base32 alias', () => {
         const accountID = "0.0.46022656"
         const accountAlias = "HIQQGOGHZGVM3E7KT47Z6VQYY2TTYY3USZUDJGVSRLYRUR5J72ZD6PI4"
-        cy.visit('#/testnet/account/' + accountAlias)
+        cy.visit('testnet/account/' + accountAlias)
         cy.url().should('include', '/testnet/account/' + accountAlias)
         cy.contains('Account ' + accountID)
     })
@@ -146,7 +146,7 @@ describe('Account Navigation', () => {
     it ('should display account details using account hex alias', () => {
         const accountID = "0.0.46022656"
         const accountAliasInHex = "0x3a210338c7c9aacd93ea9f3f9f5618c6a73c63749668349ab28af11a47a9feb23f3d1c"
-        cy.visit('#/testnet/account/' + accountAliasInHex)
+        cy.visit('testnet/account/' + accountAliasInHex)
         cy.url().should('include', '/testnet/account/' + accountAliasInHex)
         cy.contains('Account ' + accountID)
     })
@@ -155,19 +155,19 @@ describe('Account Navigation', () => {
         const accountID = "0.0.46022656"
         const evmAddress = "0x43cb701defe8fc6ed04d7bddf949618e3c575fe1"
 
-        cy.visit('#/testnet/account/' + evmAddress)
+        cy.visit('testnet/account/' + evmAddress)
         cy.url().should('include', '/testnet/account/' + evmAddress)
         cy.contains('Account ' + accountID)
 
         // EIP 3091
-        cy.visit('#/testnet/address/' + evmAddress)
+        cy.visit('testnet/address/' + evmAddress)
         cy.url().should('include', '/testnet/address/' + evmAddress)
         cy.contains('Account ' + accountID)
     })
 
     it('should detect navigation to unknown account ID', () => {
         const unknownID = '9.9.9'
-        cy.visit('#/testnet/account/' + unknownID)
+        cy.visit('testnet/account/' + unknownID)
         cy.url().should('include', '/testnet/account/' + unknownID)
         cy.contains('Account')
 
@@ -178,7 +178,7 @@ describe('Account Navigation', () => {
 
     it('should follow link to associated contract and back', () => {
         const accountId = '0.0.47981544'
-        cy.visit('#/testnet/account/' + accountId)
+        cy.visit('testnet/account/' + accountId)
         cy.url().should('include', '/testnet/account/' + accountId)
         cy.contains('Account ' + accountId)
         cy.contains('a', "Show associated contract")
@@ -196,7 +196,7 @@ describe('Account Navigation', () => {
     it('should not show a link to associated contract', () => {
         const accountId = '0.0.47981544'
         const searchId = '0.0.3'
-        cy.visit('#/testnet/account/' + accountId)
+        cy.visit('testnet/account/' + accountId)
         cy.url().should('include', '/testnet/account/' + accountId)
         cy.contains('Account ' + accountId)
         cy.contains('a', "Show associated contract")

--- a/tests/e2e/specs/BlockNavigation.spec.ts
+++ b/tests/e2e/specs/BlockNavigation.spec.ts
@@ -23,7 +23,7 @@
 describe('Block Navigation', () => {
 
     it('should navigate from block table to block details', () => {
-        cy.visit('#/testnet/blocks/')
+        cy.visit('testnet/blocks/')
         cy.url().should('include', '/testnet/blocks')
         cy.contains('Blocks')
 
@@ -43,7 +43,7 @@ describe('Block Navigation', () => {
 
     it('should navigate from block details to previous block details', () => {
         const blockNumber = "24073523"
-        cy.visit('#/testnet/block/' + blockNumber)
+        cy.visit('testnet/block/' + blockNumber)
         cy.url().should('include', '/testnet/block/' + blockNumber)
         cy.contains('Block ' + blockNumber)
 
@@ -60,7 +60,7 @@ describe('Block Navigation', () => {
 
     it('should navigate from the list of Block Transactions to TransactionDetails and back', () => {
         const blockNumber = "24073523"
-        cy.visit('#/testnet/block/' + blockNumber)
+        cy.visit('testnet/block/' + blockNumber)
         cy.url().should('include', '/testnet/block/' + blockNumber)
         cy.contains('Block ' + blockNumber)
 

--- a/tests/e2e/specs/BlocksResponseCollector.spec.ts
+++ b/tests/e2e/specs/BlocksResponseCollector.spec.ts
@@ -26,14 +26,14 @@ describe('BlocksResponseCollector', () => {
     const lastTxnInBlock = "0.0.59-1598572589-275875990"
 
     it('should display block 12 for first transaction in block', () => {
-        cy.visit('#/testnet/transaction/' + firstTxnInBlock)
+        cy.visit('testnet/transaction/' + firstTxnInBlock)
         cy.url().should('include', '/testnet/transaction/' + firstTxnInBlock)
 
         cy.get('#blockNumberValue').contains("12")
     })
 
     it('should display block 12 for last transaction in block', () => {
-        cy.visit('#/testnet/transaction/' + lastTxnInBlock)
+        cy.visit('testnet/transaction/' + lastTxnInBlock)
         cy.url().should('include', '/testnet/transaction/' + lastTxnInBlock)
 
         cy.get('#blockNumberValue').contains("12")

--- a/tests/e2e/specs/ContractNavigation.spec.ts
+++ b/tests/e2e/specs/ContractNavigation.spec.ts
@@ -25,7 +25,7 @@ import {normalizeTransactionId} from "../../../src/utils/TransactionID";
 describe('Contract Navigation', () => {
 
     it('should navigate from table to contract details', () => {
-        cy.visit('#/testnet/contracts/')
+        cy.visit('testnet/contracts/')
         cy.url().should('include', '/testnet/contracts')
         cy.contains('Recent Contracts')
 
@@ -46,7 +46,7 @@ describe('Contract Navigation', () => {
     it('should follow links from contract details', () => {
         const contractId = "0.0.33958067"
 
-        cy.visit('#/testnet/contract/' + contractId)
+        cy.visit('testnet/contract/' + contractId)
         cy.url().should('include', '/testnet/contract/' + contractId)
         cy.contains('Contract ' + contractId)
 
@@ -64,7 +64,7 @@ describe('Contract Navigation', () => {
 
     it('should detect navigation to unknown contract ID', () => {
         const unknownID = '9.9.9'
-        cy.visit('#/testnet/contract/' + unknownID)
+        cy.visit('testnet/contract/' + unknownID)
         cy.url().should('include', '/testnet/contract/' + unknownID)
         cy.contains('Contract')
 

--- a/tests/e2e/specs/CopyHexaToClipboard.spec.ts
+++ b/tests/e2e/specs/CopyHexaToClipboard.spec.ts
@@ -35,7 +35,7 @@ describe('Copy HexaValue to Clipboard', () => {
     })
 
     it('should copy the last transaction hash', () => {
-        cy.visit('#/testnet/transactions')
+        cy.visit('testnet/transactions')
         cy.contains('Transactions')
 
         cy.get('table')

--- a/tests/e2e/specs/NodeNavigation.spec.ts
+++ b/tests/e2e/specs/NodeNavigation.spec.ts
@@ -23,7 +23,7 @@
 describe('Node Navigation', () => {
 
     it('should navigate from node table to node details', () => {
-        cy.visit('#/testnet/nodes/')
+        cy.visit('testnet/nodes/')
         cy.url().should('include', '/testnet/nodes')
         cy.contains('Network')
         cy.contains('Nodes')
@@ -46,7 +46,7 @@ describe('Node Navigation', () => {
         const nodeId = "3"
         const nodeAccount = "0.0.6"
 
-        cy.visit('#/testnet/node/' + nodeId)
+        cy.visit('testnet/node/' + nodeId)
         cy.url().should('include', '/testnet/node/')
         cy.contains('Node ' + nodeId)
 

--- a/tests/e2e/specs/PageNotFound.spec.ts
+++ b/tests/e2e/specs/PageNotFound.spec.ts
@@ -35,20 +35,20 @@ describe('Hedera Explorer page not found', () => {
   //
 
   it('/#/page-not-found (last used network is undefined)', () => {
-    cy.visit('/#/page-not-found')
-    cy.url().should('include', '/#/testnet/page-not-found')
+    cy.visit('page-not-found')
+    cy.url().should('include', '/testnet/page-not-found')
     cy.contains(target)
   })
 
   it('/#/testnet/page-not-found (last used network is undefined)', () => {
-    cy.visit('/#/testnet/page-not-found')
-    cy.url().should('include', '/#/testnet/page-not-found')
+    cy.visit('testnet/page-not-found')
+    cy.url().should('include', '/testnet/page-not-found')
     cy.contains(target)
   })
 
   it('/#/mainnet/page-not-found (last used network is undefined)', () => {
-    cy.visit('/#/mainnet/page-not-found')
-    cy.url().should('include', '/#/mainnet/page-not-found')
+    cy.visit('mainnet/page-not-found')
+    cy.url().should('include', '/mainnet/page-not-found')
     cy.contains(target)
   })
 
@@ -56,24 +56,24 @@ describe('Hedera Explorer page not found', () => {
   // last used network is testnet
   //
 
-  it('/#/page-not-found (last used network is tesnet)', () => {
-    localStorage.setItem("network", "tesnet")
-    cy.visit('/#/page-not-found')
-    cy.url().should('include', '/#/testnet/page-not-found')
+  it('/#/page-not-found (last used network is testnet)', () => {
+    localStorage.setItem("network", "testnet")
+    cy.visit('page-not-found')
+    cy.url().should('include', '/testnet/page-not-found')
     cy.contains(target)
   })
 
-  it('/#/testnet/page-not-found (last used network is tesnet)', () => {
-    localStorage.setItem("network", "tesnet")
-    cy.visit('/#/testnet/page-not-found')
-    cy.url().should('include', '/#/testnet/page-not-found')
+  it('/#/testnet/page-not-found (last used network is testnet)', () => {
+    localStorage.setItem("network", "testnet")
+    cy.visit('testnet/page-not-found')
+    cy.url().should('include', '/testnet/page-not-found')
     cy.contains(target)
   })
 
-  it('/#/mainnet/page-not-found (last used network is tesnet)', () => {
-    localStorage.setItem("network", "tesnet")
-    cy.visit('/#/mainnet/page-not-found')
-    cy.url().should('include', '/#/mainnet/page-not-found')
+  it('/#/mainnet/page-not-found (last used network is testnet)', () => {
+    localStorage.setItem("network", "testnet")
+    cy.visit('mainnet/page-not-found')
+    cy.url().should('include', '/mainnet/page-not-found')
     cy.contains(target)
   })
 
@@ -83,22 +83,22 @@ describe('Hedera Explorer page not found', () => {
 
   it('/#/page-not-found (last used network is mainnet)', () => {
     localStorage.setItem("network", "mainnet")
-    cy.visit('/#/page-not-found')
-    cy.url().should('include', '/#/testnet/page-not-found')
+    cy.visit('page-not-found')
+    cy.url().should('include', '/testnet/page-not-found')
     cy.contains(target)
   })
 
   it('/#/testnet/page-not-found (last used network is mainnet)', () => {
     localStorage.setItem("network", "mainnet")
-    cy.visit('/#/testnet/page-not-found')
-    cy.url().should('include', '/#/testnet/page-not-found')
+    cy.visit('testnet/page-not-found')
+    cy.url().should('include', '/testnet/page-not-found')
     cy.contains(target)
   })
 
   it('/#/testnet/page-not-found (last used network is mainnet)', () => {
     localStorage.setItem("network", "mainnet")
-    cy.visit('/#/mainnet/page-not-found')
-    cy.url().should('include', '/#/mainnet/page-not-found')
+    cy.visit('mainnet/page-not-found')
+    cy.url().should('include', '/mainnet/page-not-found')
     cy.contains(target)
   })
 

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -34,7 +34,7 @@ describe('Search Bar', () => {
         const searchAccount = "0.0.3"
         testBody(searchAccount, '/testnet/account/' + searchAccount, 'Account ', true)
 
-        cy.visit('#/testnet/account/0.0.4')
+        cy.visit('testnet/account/0.0.4')
         cy.url().should('include', '/testnet/account/0.0.4')
         testBody(searchAccount, '/testnet/account/' + searchAccount, 'Account ', true)
     })
@@ -114,7 +114,7 @@ describe('Search Bar', () => {
         const searchNFT = "0.0.30961728"
         testBody(searchNFT, '/testnet/token/' + searchNFT, 'Token ', true)
 
-        cy.visit('#/testnet/token/0.0.45960942')
+        cy.visit('testnet/token/0.0.45960942')
         cy.url().should('include', '/testnet/token/0.0.45960942')
         testBody(searchNFT, '/testnet/token/' + searchNFT, 'Token ', true)
     })
@@ -123,7 +123,7 @@ describe('Search Bar', () => {
         const searchToken = "0.0.45960539"
         testBody(searchToken, '/testnet/token/' + searchToken, 'Token ', true)
 
-        cy.visit('#/testnet/token/0.0.30960947')
+        cy.visit('testnet/token/0.0.30960947')
         cy.url().should('include', '/testnet/token/0.0.30960947')
         testBody(searchToken, '/testnet/token/' + searchToken, 'Token ', true)
     })
@@ -132,7 +132,7 @@ describe('Search Bar', () => {
         const searchTopic = "0.0.45960950"
         testBody(searchTopic, '/testnet/topic/' + searchTopic, 'Messages for Topic ', true)
 
-        cy.visit('#/testnet/topic/0.0.45960954')
+        cy.visit('testnet/topic/0.0.45960954')
         cy.url().should('include', '/testnet/topic/0.0.45960954')
         testBody(searchTopic, '/testnet/topic/' + searchTopic, 'Messages for Topic ', true)
     })
@@ -141,7 +141,7 @@ describe('Search Bar', () => {
         const searchContract = "0.0.45960092"
         testBody(searchContract, '/testnet/contract/' + searchContract, 'Contract ', true)
 
-        cy.visit('#/testnet/contract/0.0.30962023')
+        cy.visit('testnet/contract/0.0.30962023')
         cy.url().should('include', '/testnet/contract/0.0.30962023')
         testBody(searchContract, '/testnet/contract/' + searchContract, 'Contract ', true)
     })

--- a/tests/e2e/specs/TokenInfoCollector.spec.ts
+++ b/tests/e2e/specs/TokenInfoCollector.spec.ts
@@ -25,7 +25,7 @@ describe('TokenInfoCollector', () => {
     const transactionId = "0.0.88-1647364797-037128951"
 
     it('should display token name', () => {
-        cy.visit('#/testnet/transaction/' + transactionId)
+        cy.visit('testnet/transaction/' + transactionId)
         cy.url().should('include', '/testnet/transaction/')
 
         cy.get('#entityId')

--- a/tests/e2e/specs/TokenNavigation.spec.ts
+++ b/tests/e2e/specs/TokenNavigation.spec.ts
@@ -23,7 +23,7 @@
 describe('Token Navigation', () => {
 
     it('should navigate from table to token details', () => {
-        cy.visit('#/testnet/tokens/')
+        cy.visit('testnet/tokens/')
         cy.url().should('include', '/testnet/tokens')
 
         cy.get('.box.h-box-border')
@@ -63,7 +63,7 @@ describe('Token Navigation', () => {
 
     const nftId = "0.0.33957315"
     it('should follow links from NFT details', () => {
-        cy.visit('#/testnet/token/' + nftId)
+        cy.visit('testnet/token/' + nftId)
         cy.url().should('include', '/testnet/token/' + nftId)
         cy.contains('Non Fungible Token ' + nftId)
 
@@ -84,7 +84,7 @@ describe('Token Navigation', () => {
 
     const tokenId = "0.0.33958222"
     it('should follow links from token details', () => {
-        cy.visit('#/testnet/token/' + tokenId)
+        cy.visit('testnet/token/' + tokenId)
         cy.url().should('include', '/testnet/token/' + tokenId)
         cy.contains('Fungible Token ' + tokenId)
 
@@ -104,7 +104,7 @@ describe('Token Navigation', () => {
 
     it('should detect navigation to unknown token ID', () => {
         const unknownID = '9.9.9'
-        cy.visit('#/testnet/token/' + unknownID)
+        cy.visit('testnet/token/' + unknownID)
         cy.url().should('include', '/testnet/token/' + unknownID)
         cy.contains('Token')
 

--- a/tests/e2e/specs/TopicNavigation.spec.ts
+++ b/tests/e2e/specs/TopicNavigation.spec.ts
@@ -23,7 +23,7 @@
 describe('Topic Navigation', () => {
 
     it('should navigate from topic table to topic messages', () => {
-        cy.visit('#/testnet/topics/')
+        cy.visit('testnet/topics/')
         cy.url().should('include', '/testnet/topics')
         cy.contains('Recent Topics')
 

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -25,7 +25,7 @@ import {normalizeTransactionId} from "../../../src/utils/TransactionID";
 describe('Transaction Navigation', () => {
 
     it('should navigate from table to transaction details', () => {
-        cy.visit('#/testnet/transactions/')
+        cy.visit('testnet/transactions/')
         cy.url().should('include', '/testnet/transactions')
 
         cy.get('table')
@@ -45,7 +45,7 @@ describe('Transaction Navigation', () => {
     it('should filter table by transaction type', () => {
         const selectType = 'CONTRACTCALL'
 
-        cy.visit('#/testnet/transactions/')
+        cy.visit('testnet/transactions/')
         cy.url().should('include', '/testnet/transactions')
 
         cy.get('.box')
@@ -65,7 +65,7 @@ describe('Transaction Navigation', () => {
         const transactionId = "0.0.11495@1650446896.868427600"
         const consensusTimestamp = "1650446903.332120989"
 
-        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + consensusTimestamp)
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + consensusTimestamp)
         cy.url().should('include', '/testnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
@@ -104,7 +104,7 @@ describe('Transaction Navigation', () => {
         const schedulingConsensusTimestamp = "1650446903.332120989"
         const scheduledConsensusTimestamp = "1650446904.595635000"
 
-        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + schedulingConsensusTimestamp)
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + schedulingConsensusTimestamp)
         cy.url().should('include', '/testnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', schedulingConsensusTimestamp)
@@ -135,7 +135,7 @@ describe('Transaction Navigation', () => {
         const parentConsensusTimestamp = "1652787861.365127000"
         const childConsensusTimestamp = "1652787861.365127001"
 
-        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + parentConsensusTimestamp)
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + parentConsensusTimestamp)
         cy.url().should('include', '/testnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', parentConsensusTimestamp)
@@ -166,7 +166,7 @@ describe('Transaction Navigation', () => {
     it.skip('should follow link "See all transations with same ID"', () => {
         const transactionId = "0.0.33956525@1663935863.559975910"
 
-        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId))
         cy.url().should('include', '/testnet/transaction/' + normalizeTransactionId(transactionId))
 
         cy.get('#allTransactionsLink')
@@ -194,7 +194,7 @@ describe('Transaction Navigation', () => {
         const childConsensusTimestamp = "1653499919.290794747"
         const contractId = "0.0.34912638"
 
-        cy.visit('#/testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + parentConsensusTimestamp)
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + parentConsensusTimestamp)
         cy.url().should('include', '/testnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', parentConsensusTimestamp)
@@ -242,7 +242,7 @@ describe('Transaction Navigation', () => {
 
     it('should detect navigation to unknown transaction ID', () => {
         const unknownID = '9.9.9@1650446896.868427600'
-        cy.visit('#/testnet/transaction/' + normalizeTransactionId(unknownID))
+        cy.visit('testnet/transaction/' + normalizeTransactionId(unknownID))
         cy.url().should('include', '/testnet/transaction/' + normalizeTransactionId(unknownID))
         cy.contains('Transaction')
 

--- a/tests/e2e/specs/TransferGraphs.spec.ts
+++ b/tests/e2e/specs/TransferGraphs.spec.ts
@@ -27,8 +27,8 @@ describe('Transfer Graphs Navigation', () => {
     it('should follow links from Hbar transfer graph', () => {
         const transactionId = "0.0.690356@1645611941.817662784"
 
-        cy.visit('#/mainnet/transaction/' + normalizeTransactionId(transactionId))
-        cy.url().should('include', '#/mainnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.visit('mainnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/' + normalizeTransactionId(transactionId))
 
         cy.get('[data-cy=hbarTransfers]')
             .find('[data-cy=sourceAccount]')
@@ -36,7 +36,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 
@@ -49,7 +49,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 
@@ -62,7 +62,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 
@@ -71,8 +71,8 @@ describe('Transfer Graphs Navigation', () => {
     it('should follow links from NFT transfer graph', () => {
         const transactionId = "0.0.690356@1645611941.817662784"
 
-        cy.visit('#/mainnet/transaction/' + normalizeTransactionId(transactionId))
-        cy.url().should('include', '#/mainnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.visit('mainnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/' + normalizeTransactionId(transactionId))
 
         cy.get('[data-cy=nftTransfers]')
             .find('[data-cy=sourceAccount]')
@@ -80,7 +80,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 
@@ -92,7 +92,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap(nft)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/token/')
+                cy.url().should('include', '/mainnet/token/')
                 cy.contains('Token ')
             })
 
@@ -104,7 +104,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 
@@ -113,8 +113,8 @@ describe('Transfer Graphs Navigation', () => {
     it('should follow links from Token transfer graph', () => {
         const transactionId = "0.0.196756@1644275559.734822737"
 
-        cy.visit('#/mainnet/transaction/' + normalizeTransactionId(transactionId))
-        cy.url().should('include', '#/mainnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.visit('mainnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/' + normalizeTransactionId(transactionId))
 
         cy.get('[data-cy=tokenTransfers]')
             .find('[data-cy=sourceAccount]')
@@ -122,7 +122,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 
@@ -136,7 +136,7 @@ describe('Transfer Graphs Navigation', () => {
                     .find('a')
                     .click()
                     .then(($name) => {
-                        cy.url().should('include', '#/mainnet/token/')
+                        cy.url().should('include', '/mainnet/token/')
                         cy.contains('Token ')
                         cy.contains($name.text())
                     })
@@ -152,7 +152,7 @@ describe('Transfer Graphs Navigation', () => {
                     .find('a')
                     .click()
                     .then(($name) => {
-                        cy.url().should('include', '#/mainnet/token/')
+                        cy.url().should('include', '/mainnet/token/')
                         cy.contains('Token ')
                         cy.contains($name.text())
                     })
@@ -166,7 +166,7 @@ describe('Transfer Graphs Navigation', () => {
                 cy.wrap($account)
                     .find('a')
                     .click()
-                cy.url().should('include', '#/mainnet/account/' + $account.text())
+                cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ' + $account.text())
             })
 


### PR DESCRIPTION
**Description**:

With these changes:

- the 'history' mode of Vue Router is used instead of the 'hash' mode.
- a rewrite of the old hash-based routes is temporarily in place for compatibility
- the e2e tests are adjusted to the

**Related issue(s)**:

Fixes #264 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
