### PR TITLE
00062 Add EIP 3091 Support

### DIFF
--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -118,20 +118,20 @@
             <Property id="totalSupply">
               <template v-slot:name>Total Supply</template>
               <template v-slot:value v-if="validEntityId">
-                <TokenAmount :amount="parseIntString(tokenInfo?.total_supply)" :token-id="tokenId" :show-extra="false"/>
+                <TokenAmount :amount="parseIntString(tokenInfo?.total_supply)" :token-id="normalizedTokenId" :show-extra="false"/>
               </template>
             </Property>
             <Property id="initialSupply">
               <template v-slot:name>Initial Supply</template>
               <template v-slot:value v-if="validEntityId">
-                <TokenAmount :amount="parseIntString(tokenInfo?.initial_supply)" :token-id="tokenId" :show-extra="false"/>
+                <TokenAmount :amount="parseIntString(tokenInfo?.initial_supply)" :token-id="normalizedTokenId" :show-extra="false"/>
               </template>
             </Property>
             <Property id="maxSupply">
               <template v-slot:name>Max Supply</template>
               <template v-slot:value v-if="validEntityId">
                 <div v-if="tokenInfo?.supply_type === 'INFINITE'" class="has-text-grey">Infinite</div>
-                <TokenAmount v-else :amount="parseIntString(tokenInfo?.max_supply)" :show-extra="false" :token-id="tokenId"/>
+                <TokenAmount v-else :amount="parseIntString(tokenInfo?.max_supply)" :show-extra="false" :token-id="normalizedTokenId"/>
               </template>
             </Property>
             <Property id="ethereumAddress">

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {byteToHex} from "./B64Utils";
+import {byteToHex, hexToByte} from "./B64Utils";
 
 export class EntityID {
 
@@ -84,6 +84,26 @@ export class EntityID {
         return byteToHex(buffer)
     }
 
+    public static fromAddress(address: string|undefined): EntityID|null {
+        let result: EntityID|null
+
+        if (address) {
+            const buffer = hexToByte(address)
+            if (buffer !== null && buffer.length == 20) {
+                const view = new DataView(buffer.buffer)
+                const bigNum = view.getBigInt64(12)
+                const num = bigNum < EntityID.MAX_INT ? Number(bigNum) : null
+                result = num != null ? new EntityID(0, 0, num) : null
+            } else {
+                result = null
+            }
+        } else {
+            result = null
+        }
+
+        return result
+    }
+
     /*
      * Compare two account ID.
      * Accounts are sorted in ascending but account ids < 100 are put at the end.
@@ -109,7 +129,7 @@ export class EntityID {
 
     // Utility
 
-    private static readonly MAX_INT = Math.pow(2, 32) // Max supported by mirror node rest api on May 30, 2022
+    public static readonly MAX_INT = Math.pow(2, 32) // Max supported by mirror node rest api on May 30, 2022
 
     public static parsePositiveInt(s: string): number|null {
         const n = s.match(/^[0-9]+$/) !== null ? parseInt(s) : EntityID.MAX_INT

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -112,8 +112,8 @@ export class EntityID {
     private static readonly MAX_INT = Math.pow(2, 32) // Max supported by mirror node rest api on May 30, 2022
 
     public static parsePositiveInt(s: string): number|null {
-        const n = s.length >= 1 ? Number(s) : -1
-        return (isNaN(n) || Math.floor(n) != n || n < 0 || n >= EntityID.MAX_INT) ? null : n
+        const n = s.match(/^[0-9]+$/) !== null ? parseInt(s) : EntityID.MAX_INT
+        return (isNaN(n) || n >= EntityID.MAX_INT) ? null : n
     }
 
     //

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -128,6 +128,11 @@ describe("EntityID.ts", () => {
         expect(obj).toBeNull()
     })
 
+    test("0x000000444", () => {
+        const obj = EntityID.parse("0x000000444", true)
+        expect(obj).toBeNull()
+    })
+
     test("Too Big Number", () => {
         const tooBigNum = Math.pow(2, 32)
         const obj = EntityID.parse(tooBigNum.toString())

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -142,6 +142,44 @@ describe("EntityID.ts", () => {
     })
 
     //
+    // EntityID.fromAddress()
+    //
+
+    test("0x0000000000000000000000000000000000000000", () => {
+        const a = "0x0000000000000000000000000000000000000000"
+        const obj = EntityID.fromAddress(a)
+        expect(obj?.shard).toBe(0)
+        expect(obj?.realm).toBe(0)
+        expect(obj?.num).toBe(0)
+        expect(obj?.toString()).toBe("0.0.0")
+    })
+
+    test("0x00000000000000000000000000000000000000ff", () => {
+        const a = "0x00000000000000000000000000000000000000ff"
+        const obj = EntityID.fromAddress(a)
+        expect(obj?.shard).toBe(0)
+        expect(obj?.realm).toBe(0)
+        expect(obj?.num).toBe(255)
+        expect(obj?.toString()).toBe("0.0.255")
+    })
+
+    test("0x00000000000000000000000000000000ffffffff", () => {
+        const a = "0x00000000000000000000000000000000ffffffff"
+        const obj = EntityID.fromAddress(a)
+        expect(obj?.shard).toBe(0)
+        expect(obj?.realm).toBe(0)
+        expect(obj?.num).toBe(EntityID.MAX_INT -1)
+        expect(obj?.toString()).toBe("0.0.4294967295")
+    })
+
+    test("0x0000000000000000000000000000000100000000", () => {
+        const a = "0x0000000000000000000000000000000100000000"
+        const obj = EntityID.fromAddress(a)
+        expect(obj).toBeNull()
+    })
+
+
+    //
     // EntityID.compareAccountID()
     //
 


### PR DESCRIPTION
**Description**:

Changes below complete the work related to EIP 3090.

- http 400 reported when displaying token details using `{url}/token/{TOKEN_ADDRESS}` is fixed
- parsing of `TokenDetails.prop.tokenId` is now performed using `EntityID.parse()` and `EntityID.fromAddress()` methods
- new unit tests are available for `EntityID.fromAddress()`

**Related issue(s)**:

Fixes #62

**Notes for reviewer**:

Sample URL for testing:

https://localhost:8080/#/testnet/token/0x0000000000000000000000000000000002e615e7

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
