### PR TITLE
00188 + 00271 search account using base32 alias and token using eth. address

### DIFF
--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -47,7 +47,12 @@
           <span style="font-weight: 400">{{ this.searchedId }}</span>
           <span >".</span>
           <br/><br/>
-          Make sure you enter either an entity ID (0.0.x), a transaction ID (0.0.x@seconds.nanoseconds)<br/>or an account alias using hexadecimal notation.
+          Make sure you enter one of the expressions below:<br/><br/>
+          an entity ID (0.0.x),<br/>
+          a transaction ID (0.0.x@seconds.nanoseconds),<br/>
+          a transaction hash (48 bytes in hexadecimal notation),<br/>
+          an ethereum address (20 bytes in hexadecimal notation),<br/>
+          an account alias (string in base 32 notation).<br/>
         </template>
       </p>
     </div>

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -79,6 +79,13 @@ export function byteToHex(bytes: Uint8Array): string {
     return result
 }
 
+export function paddedBytes(bytes: Uint8Array, length: number): Uint8Array {
+    const result = new Uint8Array(length)
+    const paddingLength = Math.max(0, length - bytes.length)
+    result.set(bytes, paddingLength)
+    return result
+}
+
 const HEXSET = "0123456789ABCDEF"
 
 export function hexToByte(hex: string): Uint8Array|null {

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -132,7 +132,7 @@ export class SearchRequest {
 
         const accountParam = entityID ?? ethereumAddress ?? accountAlias
         const transactionParam = transactionID ?? transactionHash
-        const tokenParam = entityID ?? ethereumAddress
+        const tokenParam = entityID ?? EntityID.fromAddress(ethereumAddress ?? undefined)
         const contractParam = entityID ?? ethereumAddress
 
         // 1) Searches accounts

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -86,39 +86,6 @@ export class SearchRequest {
         base32                               | Account Alias    | api/v1/accounts/{searchId}
         -------------------------------------+------------------+------------------------------------------------------
 
-
-
-
-
-            searchId syntax                         | Tentative searches
-            ========================================+===============================================
-            shard.realm.num                         | api/v1/tokens/{searchId}
-            (ie EntityID)                           | api/v1/topics/{searchId}/messages
-                                                    | api/v1/contracts/{searchId}
-            ----------------------------------------+-----------------------------------------------
-            num                                     | api/v1/tokens/0.0.{searchId}
-            (ie incomplete EntityID)                | api/v1/topics/0.0.{searchId}/messages
-                                                    | api/v1/contracts/0.0.{searchId}
-            ========================================+===============================================
-            shard.realm.num@seconds.nanoseconds     | api/v1/transactions/{normalized-search-id}
-            (ie Transaction ID)                     |
-            ----------------------------------------+-----------------------------------------------
-            shard.realm.num-seconds-nanoseconds     | api/v1/transactions/{searchId}
-            (ie normalized Transaction ID)          |
-            ========================================+===============================================
-            hexadecimal 48 bytes                    | api/v1/transactions/{searchId}
-            (ie transaction hash)                   |
-            ----------------------------------------+-----------------------------------------------
-            hexadecimal 20 bytes                    | api/v1/accounts/{searchId}
-            (evm address)                           | api/v1/contracts/{searchId}
-            ----------------------------------------+-----------------------------------------------
-            hexadecimal >= 15 bytes                 | api/v1/accounts/{searchId-converted-to-base32}
-            (account alias)                         |
-            ========================================+===============================================
-            base32                                  | api/v1/accounts/{searchId}
-            (account alias)                         |
-            ----------------------------------------+-----------------------------------------------
-
          */
 
         const entityID = EntityID.parse(this.searchedId, true)?.toString() ?? null

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -61,10 +61,7 @@ mock.onGet(matcher_transaction_with_hash).reply(200, SAMPLE_TRANSACTIONS)
 
 const matcher_token = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
 mock.onGet(matcher_token).reply(200, SAMPLE_TOKEN)
-
 const SAMPLE_TOKEN_ADDRESS = EntityID.parse(SAMPLE_TOKEN.token_id)!.toAddress()
-const matcher_token_with_address = "/api/v1/tokens/" + SAMPLE_TOKEN_ADDRESS
-mock.onGet(matcher_token_with_address).reply(200, SAMPLE_TOKEN)
 
 const SAMPLE_TOPIC_ID = SAMPLE_TOPIC_MESSAGES.messages[0].topic_id
 const matcher_topic = "/api/v1/topics/" + SAMPLE_TOPIC_ID + "/messages"


### PR DESCRIPTION
**Description**:

Changes below extend search capability in explorer.
- accounts can now be searched using their base32 aliases
- tokens can now be search using their ethereum address

**Related issue(s)**:

Fixes #188 and #271

**Notes for reviewer**:

The following search examples are for `mainnet`.

Account `0.0.1133968` can be searched using its:
- id : `0.0.1133968`
- ethereum address: `0x0000000000000000000000000000000000114d90`
- alias: `CIQEN25ORE2F73TRYSYMMBVPR2HU4PPFGTQENJTIGVLLELP4PZ2M76A`

Transaction `0.0.41106@1666620946.600653709` can be searched using its:
- id: `0.0.41106@1666620946.600653709`
- normalized id: `0.0.41106-1666620946-600653709`
- hash: `0x510087e86d1654443c0c6c135f958cc8fe103a3d556131b89f99b4d22d18c8ca4812f0aebc28d4d773f3ec87ca1b7b7b`

Contract `0.0.1377616` can be searched using its:
- id: `0.0.1377616`
- ethereum address: `0x0000000000000000000000000000000000150550`

Token `0.0.1368126` can be searched using its:
- id: `0.0.1368126`
- ethereum address: `0x000000000000000000000000000000000014e03e`

Topic `0.0.1377521` can be searched using its:
- id: `0.0.1377521`


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
