### PR TITLE
00269 follow up

### DIFF
--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -73,10 +73,10 @@
               <NetworkDashboardItem :name="stakedAmount ? 'HBAR' : ''" title="My Stake" :value="stakedAmount"/>
 
               <NetworkDashboardItem v-if="!ignoreReward && declineReward && !pendingReward"
-                                    :title="'Rewards'"
-                                    :value="'Declined'"/>
+                                    title="Rewards"
+                                    value="Declined"/>
               <NetworkDashboardItem v-else
-                                    :title="'Pending Reward'"
+                                    title="Pending Reward"
                                     :name="pendingReward ? 'HBAR' : ''"
                                     :value="pendingReward"
                                     :class="{'h-has-opacity-40': ignoreReward && !pendingReward}"/>
@@ -104,11 +104,11 @@
               <div class="mt-4"/>
 
               <NetworkDashboardItem v-if="!ignoreReward && declineReward && !pendingReward"
-                                    :title="'Rewards'"
-                                    :value="'Declined'"/>
+                                    title="Rewards"
+                                    value="Declined"/>
               <NetworkDashboardItem v-else
-                                    :title="'Pending Reward'"
-                                    :name="'HBAR'"
+                                    title="Pending Reward"
+                                    name="HBAR"
                                     :value="null"
                                     :class="{'h-has-opacity-40': ignoreReward && !pendingReward}"/>
 

--- a/tests/e2e/specs/NodeNavigation.spec.ts
+++ b/tests/e2e/specs/NodeNavigation.spec.ts
@@ -56,7 +56,7 @@ describe('Node Navigation', () => {
 
         cy.url().should('include', '/testnet/account/' + nodeAccount)
         cy.contains('Account ' + nodeAccount)
-        cy.contains('Node ' + nodeId)
+        // cy.contains('Node ' + nodeId)
     })
 
 })


### PR DESCRIPTION
**Description**:

- Adjust e2e test following temporary removal of link allowing to navigate to NodeDetails from AccountDetails (when on a node's account).
- (unrelated:) Remove a couple bindings for static props.

**Related issue(s)**:

Follow-up for #269 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
