### PR TITLE
00275 indicate staked with no reward

### DIFF
--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -39,7 +39,7 @@
               <o-select v-model="selectedNodeId" class="h-is-text-size-1" style="border-radius: 4px">
                 <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
                         style="background-color: var(--h-theme-box-background-color)">
-                  {{ n.node_id }} - {{ makeNodeDescription(n) }} - {{ makeNodeStake(n) }}
+                  {{ n.node_id }} - {{ makeNodeDescription(n) }} - {{ makeNodeStakeDescription(n) }}
                 </option>
               </o-select>
             </o-field>
@@ -81,7 +81,7 @@
 import {computed, defineComponent, inject, onBeforeMount, onMounted, ref, watch} from 'vue';
 import NetworkDashboardItem from "@/components/node/NetworkDashboardItem.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
-import {makeShortNodeDescription, NetworkNode} from "@/schemas/HederaSchemas";
+import {makeNodeStakeDescription, makeShortNodeDescription, NetworkNode} from "@/schemas/HederaSchemas";
 import {operatorRegistry} from "@/schemas/OperatorRegistry";
 import {NodesLoader} from "@/components/node/NodesLoader";
 import {NodeCursor} from "@/components/node/NodeCursor";
@@ -139,27 +139,6 @@ export default defineComponent({
       return result
     }
 
-    const makeNodeStake = (node: NetworkNode) => {
-      const amountFormatter = new Intl.NumberFormat("en-US", {
-        maximumFractionDigits: 0
-      })
-      const percentFormatter = new Intl.NumberFormat("en-US", {
-        style: 'percent',
-        maximumFractionDigits: 1
-      })
-      const unclampedStakeAmount = ((node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0))/100000000
-      const percentMin = node.min_stake ? unclampedStakeAmount / (node.min_stake / 100000000) : 0
-      const percentMax = node.max_stake ? unclampedStakeAmount / (node.max_stake / 100000000) : 0
-
-      let result = amountFormatter.format(unclampedStakeAmount) + "ℏ staked"
-      if (percentMin != 0 && percentMin < 1) {
-        result += " (" + percentFormatter.format(percentMin) + " of Min)"
-      } else if (percentMax !== 0) {
-        result += " (" + percentFormatter.format(percentMax) + " of Max)"
-      }
-      return result
-    }
-
     const handleInput = (value: string) => {
       const previousAmount = amountStaked.value
       const newAmount = Number(value)
@@ -185,7 +164,7 @@ export default defineComponent({
       yearlyRate: nodeCursor.value.approxYearlyRate,
       nodes: nodesLoader.nodes,
       makeNodeDescription,
-      makeNodeStake,
+      makeNodeStakeDescription,
       handleInput
     }
   }

--- a/src/components/staking/RewardsTransactionTableController.ts
+++ b/src/components/staking/RewardsTransactionTableController.ts
@@ -34,7 +34,7 @@ export class RewardsTransactionTableController extends TableController<Transacti
     //
 
     public constructor(router: Router, accountId: Ref<string|null>, pageSize: ComputedRef<number>) {
-        super(router, pageSize, 10 * pageSize.value, 5000, 10, 100);
+        super(router, pageSize, 10 * pageSize.value, 5000, 0, 100);
         this.accountId = accountId
         this.watchAndReload([this.accountId])
     }

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -84,7 +84,7 @@
                           class="h-is-text-size-1" style="border-radius: 4px"  @focus="stakeChoice='node'">
                   <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
                           style="background-color: var(--h-theme-box-background-color)">
-                    {{ makeNodeDescription(n) }} - {{ makeNodeStake(n) }}
+                    {{ makeNodeDescription(n) }} - {{ makeNodeStakeDescription(n) }}
                   </option>
                 </o-select>
               </o-field>
@@ -158,7 +158,7 @@
 import {computed, defineComponent, onMounted, PropType, ref, watch} from "vue";
 import {
   AccountBalanceTransactions,
-  AccountsResponse,
+  AccountsResponse, makeNodeStakeDescription,
   makeShortNodeDescription,
   NetworkNode
 } from "@/schemas/HederaSchemas";
@@ -299,27 +299,6 @@ export default defineComponent({
       return result
     }
 
-    const makeNodeStake = (node: NetworkNode) => {
-      const amountFormatter = new Intl.NumberFormat("en-US", {
-        maximumFractionDigits: 0
-      })
-      const percentFormatter = new Intl.NumberFormat("en-US", {
-        style: 'percent',
-        maximumFractionDigits: 1
-      })
-      const unclampedStakeAmount = ((node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0))/100000000
-      const percentMin = node.min_stake ? unclampedStakeAmount / (node.min_stake / 100000000) : 0
-      const percentMax = node.max_stake ? unclampedStakeAmount / (node.max_stake / 100000000) : 0
-
-      let result = amountFormatter.format(unclampedStakeAmount) + "ℏ staked"
-      if (percentMin != 0 && percentMin < 1) {
-        result += " (" + percentFormatter.format(percentMin) + " of Min)"
-      } else if (percentMax !== 0) {
-        result += " (" + percentFormatter.format(percentMax) + " of Max)"
-      }
-      return result
-    }
-
     const handleInput = (value: string) => {
       const previousValue = selectedAccount.value
       let isValidInput = true
@@ -410,7 +389,7 @@ export default defineComponent({
       handleCancelChange,
       handleConfirmChange,
       makeNodeDescription,
-      makeNodeStake,
+      makeNodeStakeDescription,
       handleInput
     }
   }

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -131,7 +131,7 @@
           </div>
         </div>
 
-        <Property id="changeCost">
+        <Property v-if="false" id="changeCost">
           <template v-slot:name>Change Transaction Cost</template>
           <template v-slot:value>
             <HbarAmount v-if="account" :amount="10000000" :show-extra="true" :decimals="1"/>

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -244,7 +244,9 @@ export default defineComponent({
 
     const selectedNode = ref<number|null>(null)
     const selectedNodeDescription = computed(() => {
-      return (selectedNode.value && nodesLoader.nodes.value) ? makeNodeDescription(nodesLoader.nodes.value[selectedNode.value]) : null
+      return (selectedNode.value !== null && nodesLoader.nodes.value)
+          ? makeNodeDescription(nodesLoader.nodes.value[selectedNode.value])
+          : null
     })
     watch(accountId, () => {
       if ( isNodeSelected.value && selectedNode.value == null) {
@@ -256,9 +258,18 @@ export default defineComponent({
     watch(accountId, () => declineChoice.value = props.account?.decline_reward ?? false)
 
     const enableChangeButton = computed(() => {
+      console.log("isAccountSelected.value: " + isAccountSelected.value)
+      console.log("isSelectedAccountValid.value: " + isSelectedAccountValid.value)
+      console.log("props.account?.staked_account_id: " + props.account?.staked_account_id)
+      console.log("selectedAccountEntity.value: " + selectedAccountEntity.value)
+      console.log("isNodeSelected.value: " + isNodeSelected.value)
+      console.log("selectedNode.value: " + selectedNode.value)
+      console.log("props.account?.staked_node_id: " + props.account?.staked_node_id)
+      console.log("props.account?.decline_reward: " + props.account?.decline_reward)
+      console.log("declineChoice.value: " + declineChoice.value)
       return (
           isAccountSelected.value && isSelectedAccountValid.value && props.account?.staked_account_id != selectedAccountEntity.value)
-          || (isNodeSelected.value  && selectedNode.value && props.account?.staked_node_id != selectedNode.value)
+          || (isNodeSelected.value  && selectedNode.value !== null && props.account?.staked_node_id != selectedNode.value)
           || (props.account?.decline_reward != declineChoice.value)
     })
 
@@ -267,6 +278,15 @@ export default defineComponent({
     }
 
     const handleChange = () => {
+      console.log("handleChange - isAccountSelected.value: " + isAccountSelected.value)
+      console.log("isSelectedAccountValid.value: " + isSelectedAccountValid.value)
+      console.log("props.account?.staked_account_id: " + props.account?.staked_account_id)
+      console.log("selectedAccountEntity.value: " + selectedAccountEntity.value)
+      console.log("isNodeSelected.value: " + isNodeSelected.value)
+      console.log("selectedNode.value: " + selectedNode.value)
+      console.log("props.account?.staked_node_id: " + props.account?.staked_node_id)
+      console.log("props.account?.decline_reward: " + props.account?.decline_reward)
+      console.log("declineChoice.value: " + declineChoice.value)
       context.emit('update:showDialog', false)
       showConfirmDialog.value = true
     }

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -158,11 +158,6 @@
       <template v-slot:title>
         <span class="h-is-primary-title">Recent Staking Rewards Transactions</span>
       </template>
-      <template v-slot:control>
-        <div class="is-flex is-align-items-flex-end">
-          <PlayPauseButton v-bind:controller="transactionTableController"/>
-        </div>
-      </template>
       <template v-slot:content>
         <RewardsTransactionTable
             :narrowed="true"

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -196,7 +196,6 @@ import DashboardCard from "@/components/DashboardCard.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import ProgressDialog, {Mode} from "@/components/staking/ProgressDialog.vue";
 import AccountLink from "@/components/values/AccountLink.vue";
-import PlayPauseButton from "@/utils/table/PlayPauseButton.vue";
 import RewardsCalculator from "@/components/staking/RewardsCalculator.vue";
 import WalletChooser from "@/components/staking/WalletChooser.vue";
 import {WalletDriver} from "@/utils/wallet/WalletDriver";
@@ -221,7 +220,6 @@ export default defineComponent({
   components: {
     WalletChooser,
     RewardsCalculator,
-    PlayPauseButton,
     AccountLink,
     ConfirmDialog,
     ProgressDialog,

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -305,14 +305,14 @@ export default defineComponent({
     const accountLoader = new AccountLoader(walletManager.accountId)
     onMounted(() => accountLoader.requestLoad())
 
-    const isStaked = computed(() => accountLoader.stakedNodeId.value || accountLoader.stakedAccountId.value)
+    const isStaked = computed(() => accountLoader.stakedNodeId.value !== null || accountLoader.stakedAccountId.value)
     const isIndirectStaking = computed(() => accountLoader.stakedAccountId.value)
 
     const stakedTo = computed(() => {
       let result: string|null
       if (accountLoader.stakedAccountId.value) {
         result = "Account " + accountLoader.stakedAccountId.value
-      } else if (accountLoader.stakedNodeId.value) {
+      } else if (accountLoader.stakedNodeId.value !== null) {
         result = "Node " + accountLoader.stakedNodeId.value + " - " + stakedNodeLoader.shortNodeDescription.value
       } else {
         result = null

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -512,6 +512,29 @@ export function makeShortNodeDescription(description: string): string {
     return (separator !== -1) ? (description.slice(0, separator) ?? null) : description
 }
 
+export function makeNodeStakeDescription(node: NetworkNode): string {
+    const amountFormatter = new Intl.NumberFormat("en-US", {
+        maximumFractionDigits: 0
+    })
+    const percentFormatter = new Intl.NumberFormat("en-US", {
+        style: 'percent',
+        maximumFractionDigits: 1
+    })
+    const unclampedStakeAmount = ((node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0))/100000000
+    const unrewardedAmount = (node.stake_not_rewarded ?? 0)/100000000
+    const percentMin = node.min_stake ? unclampedStakeAmount / (node.min_stake / 100000000) : 0
+    const percentMax = node.max_stake ? unclampedStakeAmount / (node.max_stake / 100000000) : 0
+
+    let result = amountFormatter.format(unclampedStakeAmount) + "ℏ staked"
+    if (percentMin != 0 && percentMin < 1) {
+        result += " (" + percentFormatter.format(percentMin) + " of Min)"
+    } else if (percentMax !== 0) {
+        result += " (" + percentFormatter.format(percentMax) + " of Max)"
+    }
+    result += ", of which " + amountFormatter.format(unrewardedAmount) + "ℏ declined reward"
+    return result
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 //                                                      Network
 // ---------------------------------------------------------------------------------------------------------------------

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -85,9 +85,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(3)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max), of which 1,000,000ℏ declined reward')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)
@@ -135,9 +135,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(3)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max), of which 1,000,000ℏ declined reward')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(true)
@@ -182,9 +182,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(3)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max), of which 1,000,000ℏ declined reward')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)


### PR DESCRIPTION
**Description**:

With these changes, the description of the nodes provided in the node selectors (StakingDialog and RewardEstimator) now includes the number of hbars staked which have declined reward.

Also in this PR (and unrelated):

- Fix bug when staked to (or trying to stake to) Node 0
- Remove placeholder mention of transaction cost
- Disable auto-refresh of RewardsTransactionTable and remove related PlayPauseButton control. 

**Related issue(s)**:

Fixes #275 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
