### PR TITLE
Do not query contract results when not needed

### DIFF
--- a/src/components/transaction/TransactionLoader.ts
+++ b/src/components/transaction/TransactionLoader.ts
@@ -65,6 +65,11 @@ export class TransactionLoader extends EntityLoader<TransactionByIdResponse> {
 
     public readonly transactionType = computed(() => this.transaction.value?.name ?? null)
 
+    public readonly hasContractResult = computed(
+        () => this.transactionType.value === TransactionType.CONTRACTCREATEINSTANCE
+            || this.transactionType.value === TransactionType.CONTRACTCALL
+            || this.transactionType.value === TransactionType.ETHEREUMTRANSACTION)
+
     public readonly result: ComputedRef<string|null> = computed(
         () => this.transaction.value?.result ?? null)
 

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -215,7 +215,7 @@
       </template>
     </DashboardCard>
 
-    <ContractResultAndLogs :transaction-id-or-hash="transaction?.transaction_id"/>
+    <ContractResultAndLogs v-if="hasContractResult" :transaction-id-or-hash="transaction?.transaction_id"/>
 
   </section>
 
@@ -325,6 +325,7 @@ export default defineComponent({
       formattedTransactionId: transactionLoader.formattedTransactionId,
       netAmount: transactionLoader.netAmount,
       entity: transactionLoader.entityDescriptor,
+      hasContractResult: transactionLoader.hasContractResult,
       systemContract: transactionLoader.systemContract,
       maxFee: transactionLoader.maxFee,
       formattedHash: transactionLoader.formattedHash,


### PR DESCRIPTION
**Description**:

With this simple fix, we now try to get the contract result related to the currently displayed transaction **only when** the type of the transaction is one of { CONTRACT CREATE, CONTRACT CALL, ETHEREUM TRANSACTIOn }.

**Related issue(s)**:

None.

**Notes for reviewer**:

Without the fix, the following page:
   `<url>/mainnet/transaction/0.0.706113-1666377820-433121761?t=1666377870.801135355`
triggers an error 500 (which itself is likely an issue in mirror-node) caused by the unduly call to `api/v1/contracts/results/0.0.706113-1666377820-433121761`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
