### PR TITLE
00280 Explorer should enable to search an account using its public key

### DIFF
--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -52,6 +52,7 @@
           a transaction ID (0.0.x@seconds.nanoseconds),<br/>
           a transaction hash (48 bytes in hexadecimal notation),<br/>
           an ethereum address (20 bytes in hexadecimal notation),<br/>
+          an account public key (32 or 33 bytes in hexadecimal notation),<br/>
           an account alias (string in base 32 notation).<br/>
         </template>
       </p>

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -25,7 +25,7 @@
 import {EntityID} from "@/utils/EntityID";
 
 export interface AccountsResponse {
-    accounts: [AccountInfo] | undefined
+    accounts: AccountInfo[] | undefined
     links: Links | undefined
 }
 

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -19,12 +19,15 @@
  */
 
 import {
+    AccountBalanceTransactions,
     AccountInfo,
     AccountsResponse,
     ContractResponse,
     TokenInfo,
     TopicMessage,
-    Transaction
+    TopicMessagesResponse,
+    Transaction,
+    TransactionByIdResponse
 } from "@/schemas/HederaSchemas";
 import axios from "axios";
 import {TransactionID} from "@/utils/TransactionID";
@@ -109,7 +112,7 @@ export class SearchRequest {
         // 1) Searches accounts
         if (accountParam !== null) {
             axios
-                .get("api/v1/accounts/" + accountParam)
+                .get<AccountBalanceTransactions>("api/v1/accounts/" + accountParam)
                 .then(response => {
                     this.account = response.data
                 })
@@ -142,9 +145,9 @@ export class SearchRequest {
         // 2) Searches transactions
         if (transactionParam !== null) {
             axios
-                .get("api/v1/transactions/" + transactionParam)
+                .get<TransactionByIdResponse>("api/v1/transactions/" + transactionParam)
                 .then(response => {
-                    this.transactions = response.data.transactions
+                    this.transactions = response.data.transactions ?? []
                 })
                 .catch((reason: unknown) => {
                     this.updateErrorCount(reason)
@@ -161,7 +164,7 @@ export class SearchRequest {
         // 3) Searches tokens
         if (tokenParam !== null) {
             axios
-                .get("api/v1/tokens/" + tokenParam)
+                .get<TokenInfo>("api/v1/tokens/" + tokenParam)
                 .then(response => {
                     this.tokenInfo = response.data
                 })
@@ -184,9 +187,9 @@ export class SearchRequest {
                 limit: "1"
             }
             axios
-                .get("api/v1/topics/" + entityID + "/messages", {params})
+                .get<TopicMessagesResponse>("api/v1/topics/" + entityID + "/messages", {params})
                 .then(response => {
-                    this.topicMessages = response.data.messages
+                    this.topicMessages = response.data.messages ?? []
                 })
                 .catch((reason: unknown) => {
                     this.updateErrorCount(reason)

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -19,7 +19,8 @@
  */
 
 import {
-    AccountBalanceTransactions,
+    AccountInfo,
+    AccountsResponse,
     ContractResponse,
     TokenInfo,
     TopicMessage,
@@ -35,7 +36,7 @@ import {base32ToAlias, byteToHex, hexToByte, paddedBytes} from "@/utils/B64Utils
 export class SearchRequest {
 
     public readonly searchedId: string
-    public account: AccountBalanceTransactions|null = null
+    public account: AccountInfo|null = null
     public transactions = Array<Transaction>()
     public tokenInfo: TokenInfo|null = null
     public topicMessages = Array<TopicMessage>()
@@ -79,9 +80,11 @@ export class SearchRequest {
                                              |                  | api/v1/contracts/{searchId}
                                              |                  | api/v1/token/ethereumToEntityID({searchId})
         -------------------------------------+------------------+------------------------------------------------------
-        hexadecimal < 20 bytes               | Ethereum Address | api/v1/accounts/padded({searchId})
-                                             |                  | api/v1/contracts/padded({searchId})
+        hexadecimal < 20 bytes               | Incomplete       | api/v1/accounts/padded({searchId})
+                                             | Ethereum Address | api/v1/contracts/padded({searchId})
                                              |                  | api/v1/token/ethereumToEntityID(padded({searchId}))
+        -------------------------------------+------------------+------------------------------------------------------
+        hexadecimal 32/33 bytes              | Public Key       | api/v1/accounts/?account.publickey={searchId}
         -------------------------------------+------------------+------------------------------------------------------
         base32                               | Account Alias    | api/v1/accounts/{searchId}
         -------------------------------------+------------------+------------------------------------------------------
@@ -94,6 +97,7 @@ export class SearchRequest {
         const transactionHash = hexBytes !== null && hexBytes.length == 48 ? byteToHex(hexBytes) : null
         const ethereumAddress = hexBytes !== null && (1 <= hexBytes.length && hexBytes.length <= 20)
                                 ? byteToHex(paddedBytes(hexBytes, 20)) : null
+        const publicKey = hexBytes !== null && (hexBytes.length == 32 || hexBytes.length == 33) ? byteToHex(hexBytes) : null
         const accountAlias = base32ToAlias(this.searchedId) !== null ? this.searchedId : null
 
 
@@ -115,7 +119,21 @@ export class SearchRequest {
                 })
                 .finally(() => {
                     this.updatePromise()
-                });
+                })
+        } else if (publicKey !== null) {
+            axios
+                .get<AccountsResponse>("api/v1/accounts/?account.publickey=" + publicKey)
+                .then(response => {
+                    const accounts = response.data.accounts ?? []
+                    this.account = accounts.length >= 1 ? accounts[0] : null
+                })
+                .catch((reason: unknown) => {
+                    this.updateErrorCount(reason)
+                    return null // To avoid console pollution
+                })
+                .finally(() => {
+                    this.updatePromise()
+                })
         } else {
             // No account will match => no need to call server
             this.updatePromise()

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -24,6 +24,7 @@ import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {
     SAMPLE_ACCOUNT,
+    SAMPLE_ACCOUNTS,
     SAMPLE_CONTRACT,
     SAMPLE_TOKEN,
     SAMPLE_TOPIC_MESSAGES,
@@ -47,6 +48,10 @@ mock.onGet(matcher_account_with_alias).reply(200, SAMPLE_ACCOUNT)
 const SAMPLE_ACCOUNT_ADDRESS = EntityID.parse(SAMPLE_ACCOUNT.account)!.toAddress()
 const matcher_account_with_address = "/api/v1/accounts/" + SAMPLE_ACCOUNT_ADDRESS
 mock.onGet(matcher_account_with_address).reply(200, SAMPLE_ACCOUNT)
+
+const matcher_account_with_public_key = "/api/v1/accounts/?account.publickey=" + SAMPLE_ACCOUNTS.accounts[0].key.key
+mock.onGet(matcher_account_with_public_key).reply(200, SAMPLE_ACCOUNTS)
+
 
 // Transaction
 
@@ -103,6 +108,20 @@ describe("SearchRequest.ts", () => {
         await r.run()
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT_ADDRESS)
+        expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
+
+    })
+
+    test("account (with public key)", async () => {
+        const r = new SearchRequest(SAMPLE_ACCOUNT.key.key)
+        await r.run()
+
+        expect(r.searchedId).toBe(SAMPLE_ACCOUNT.key.key)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()


### PR DESCRIPTION
**Description**:

Changes below implement #280.

**Related issue(s)**:

Fixes #280 

**Notes for reviewer**:

Account `0.0.1133968` (on mainnet) can be searched using its:
id : `0.0.1133968`
ethereum address: `0x0000000000000000000000000000000000114d90`
alias: `CIQEN25ORE2F73TRYSYMMBVPR2HU4PPFGTQENJTIGVLLELP4PZ2M76A`
public key: `0x46ebae89345fee71c4b0c606af8e8f4e3de534e046a6683556b22dfc7e74cff8`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
