### PR TITLE
00279 clarify transaction relationships

### DIFF
--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -258,15 +258,6 @@ export default defineComponent({
     watch(accountId, () => declineChoice.value = props.account?.decline_reward ?? false)
 
     const enableChangeButton = computed(() => {
-      console.log("isAccountSelected.value: " + isAccountSelected.value)
-      console.log("isSelectedAccountValid.value: " + isSelectedAccountValid.value)
-      console.log("props.account?.staked_account_id: " + props.account?.staked_account_id)
-      console.log("selectedAccountEntity.value: " + selectedAccountEntity.value)
-      console.log("isNodeSelected.value: " + isNodeSelected.value)
-      console.log("selectedNode.value: " + selectedNode.value)
-      console.log("props.account?.staked_node_id: " + props.account?.staked_node_id)
-      console.log("props.account?.decline_reward: " + props.account?.decline_reward)
-      console.log("declineChoice.value: " + declineChoice.value)
       return (
           isAccountSelected.value && isSelectedAccountValid.value && props.account?.staked_account_id != selectedAccountEntity.value)
           || (isNodeSelected.value  && selectedNode.value !== null && props.account?.staked_node_id != selectedNode.value)
@@ -278,15 +269,6 @@ export default defineComponent({
     }
 
     const handleChange = () => {
-      console.log("handleChange - isAccountSelected.value: " + isAccountSelected.value)
-      console.log("isSelectedAccountValid.value: " + isSelectedAccountValid.value)
-      console.log("props.account?.staked_account_id: " + props.account?.staked_account_id)
-      console.log("selectedAccountEntity.value: " + selectedAccountEntity.value)
-      console.log("isNodeSelected.value: " + isNodeSelected.value)
-      console.log("selectedNode.value: " + selectedNode.value)
-      console.log("props.account?.staked_node_id: " + props.account?.staked_node_id)
-      console.log("props.account?.decline_reward: " + props.account?.decline_reward)
-      console.log("declineChoice.value: " + declineChoice.value)
       context.emit('update:showDialog', false)
       showConfirmDialog.value = true
     }

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -135,7 +135,7 @@ export default defineComponent({
     const makeRelationshipLabel = (row: Transaction): string => {
       let result: string
       if (row.name === TransactionType.SCHEDULECREATE) {
-        result = "Scheduling"
+        result = "Schedule Create"
       } else if (row.scheduled) {
         result = "Scheduled"
       } else if (hasChild.value) {

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -80,8 +80,8 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject, PropType, ref} from 'vue';
-import {Transaction} from '@/schemas/HederaSchemas';
-import {makeRelationshipLabel, makeTypeLabel} from "@/utils/TransactionTools";
+import {Transaction, TransactionType} from '@/schemas/HederaSchemas';
+import {makeTypeLabel} from "@/utils/TransactionTools";
 import router from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
@@ -113,15 +113,42 @@ export default defineComponent({
         }
     )
 
-    // 3) handleClick
     const handleClick = (t: Transaction) => {
       router.push({name: 'TransactionDetails',
         params: {transactionId: t.transaction_id},
         query: {t: t.consensus_timestamp}})
     }
 
-    // 4) currentPage
     let currentPage = ref(1)
+
+    const hasChild = computed(() => {
+      let result = false
+      for (const tx of props.transactions) {
+        if (tx.parent_consensus_timestamp) {
+          result = true
+          break
+        }
+      }
+      return result
+    })
+
+    const makeRelationshipLabel = (row: Transaction): string => {
+      let result: string
+      if (row.name === TransactionType.SCHEDULECREATE) {
+        result = "Scheduling"
+      } else if (row.scheduled) {
+        result = "Scheduled"
+      } else if (hasChild.value) {
+        if (row.nonce && row.nonce > 0) {
+          result = "Child"
+        } else {
+          result = "Parent"
+        }
+      } else {
+        result = ""
+      }
+      return result
+    }
 
     return {
       isTouchDevice,

--- a/src/components/transaction/TransactionLoader.ts
+++ b/src/components/transaction/TransactionLoader.ts
@@ -266,7 +266,7 @@ function lookupParentTransaction(transactions: Transaction[]): Transaction|null 
 function lookupChildTransactions(transactions: Transaction[]): Transaction[] {
   const result = new Array<Transaction>()
   for (const t of transactions) {
-    if (t.nonce && t.nonce > 0) {
+    if (t.parent_consensus_timestamp) {
       result.push(t)
     }
   }

--- a/src/components/values/TimestampValue.vue
+++ b/src/components/values/TimestampValue.vue
@@ -27,11 +27,11 @@
   <template v-if="timestamp">
     <template v-if="seconds != null">
       <span>
-        <span class="mr-3 is-numeric" style="white-space: nowrap">
+        <span class="mr-3 is-numeric">
           <span>{{ timePart.hour }}:{{ timePart.minute }}</span>
           <span class="h-is-text-size-3 has-text-grey">:{{ timePart.second }}.{{ timePart.fractionalSecond }}&nbsp;{{ timePart.dayPeriod }}</span>
         </span>
-        <span class="is-numeric" style="white-space: nowrap">{{ datePart }}</span>
+        <span class="is-numeric">{{ datePart }}</span>
       </span>
     </template>
     <template v-else>

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -52,6 +52,7 @@
           a transaction ID (0.0.x@seconds.nanoseconds),<br/>
           a transaction hash (48 bytes in hexadecimal notation),<br/>
           an ethereum address (20 bytes in hexadecimal notation),<br/>
+          an account public key (32 or 33 bytes in hexadecimal notation),<br/>
           an account alias (string in base 32 notation).<br/>
         </template>
       </p>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -172,7 +172,7 @@
           </template>
         </Property>
         <Property v-if="parentTransaction" id="parentTransaction">
-          <template v-slot:name>Parent</template>
+          <template v-slot:name>Parent Transaction</template>
           <template v-slot:value>
             <router-link :to="{
                   name: 'TransactionDetails',
@@ -183,11 +183,11 @@
           </template>
         </Property>
         <Property v-if="childTransactions.length" id="children">
-          <template v-slot:name>Children</template>
+          <template v-slot:name>Child Transactions</template>
           <template v-slot:value>
             <router-link v-if="displayAllChildrenLinks"
                          :to="{name: 'TransactionsById', params: {transactionId: transactionId}}">
-              {{ 'Show all ' + childTransactions.length + ' child transactions' }}
+              {{ 'Show all ' + childTransactions.length + ' transactions' }}
             </router-link>
             <div v-else>
               <router-link v-for="tx in childTransactions" :key="tx.nonce" :to="{
@@ -249,7 +249,7 @@ import DurationValue from "@/components/values/DurationValue.vue";
 import BlockLink from "@/components/values/BlockLink.vue";
 import ContractResultAndLogs from "@/components/transaction/ContractResultAndLogs.vue";
 
-const MAX_INLINE_CHILDREN = 3
+const MAX_INLINE_CHILDREN = 10
 const NB_LOG_LINES = 2
 const MAX_LOG_LINES = 10
 

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -37,12 +37,17 @@
             </div>
             <div v-else class="h-has-pill has-background-danger mr-3 h-is-text-size-2 mt-3">FAILURE</div>
           </div>
-          <span v-if="showAllTransactionVisible" class="is-inline-block mt-2" id="allTransactionsLink">
+          <span v-if="showAllTransactionVisible && isLargeScreen" class="is-inline-block mt-2" id="allTransactionsLink">
           <router-link :to="{name: 'TransactionsById', params: {transactionId: transaction?.transaction_id}}">
-            <span class="h-is-property-text has-text-grey">See all transactions with the same ID</span>
+            <span class="h-is-property-text has-text-grey">Show all transactions with the same ID</span>
           </router-link>
         </span>
         </div>
+        <span v-if="showAllTransactionVisible && !isLargeScreen">
+          <router-link :to="{name: 'TransactionsById', params: {transactionId: transaction?.transaction_id}}">
+            <span class="h-is-property-text has-text-grey">Show all transactions with the same ID</span>
+          </router-link>
+        </span>
       </template>
 
       <template v-slot:content>
@@ -278,6 +283,7 @@ export default defineComponent({
 
   setup(props) {
     const isSmallScreen = inject('isSmallScreen', true)
+    const isLargeScreen = inject('isLargeScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
 
     const transactionLocator = computed(() => PathParam.parseTransactionIdOrHash(props.transactionId))
@@ -321,6 +327,7 @@ export default defineComponent({
       NB_LOG_LINES,
       MAX_LOG_LINES,
       isSmallScreen,
+      isLargeScreen,
       isTouchDevice,
       transaction: transactionLoader.transaction,
       formattedTransactionId: transactionLoader.formattedTransactionId,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -147,7 +147,7 @@
           <template v-slot:name>Scheduled</template>
           <template v-if="transaction?.scheduled===true" v-slot:value>
             True
-            <div v-if="schedulingTransaction" class="h-is-extra-text h-is-text-size-2">
+            <div id="schedulingLink" v-if="schedulingTransaction" class="h-is-extra-text h-is-text-size-2">
               <router-link :to="{
                   name: 'TransactionDetails',
                   params: { transactionId: schedulingTransaction.transaction_id },
@@ -158,7 +158,7 @@
           </template>
           <template v-else-if="scheduledTransaction!==null" v-slot:value>
             False
-            <div class="h-is-extra-text h-is-text-size-2">
+            <div id="scheduledLink" class="h-is-extra-text h-is-text-size-2">
               <router-link :to="{
                   name: 'TransactionDetails',
                   params: { transactionId: scheduledTransaction.transaction_id },
@@ -182,7 +182,7 @@
             </router-link>
           </template>
         </Property>
-        <Property v-if="childTransactions.length" id="children">
+        <Property v-if="childTransactions.length" id="childTransactions">
           <template v-slot:name>Child Transactions</template>
           <template v-slot:value>
             <router-link v-if="displayAllChildrenLinks"

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -143,31 +143,31 @@
             {{ transaction?.nonce }}
           </template>
         </Property>
-        <Property v-if="schedulingTransaction" id="schedulingTransaction">
-          <template v-slot:name>Scheduling</template>
-          <template v-slot:value>
-            <router-link :to="{
+        <Property id="scheduled">
+          <template v-slot:name>Scheduled</template>
+          <template v-if="transaction?.scheduled===true" v-slot:value>
+            True
+            <div v-if="schedulingTransaction" class="h-is-extra-text h-is-text-size-2">
+              <router-link :to="{
                   name: 'TransactionDetails',
                   params: { transactionId: schedulingTransaction.transaction_id },
                   query: { t: schedulingTransaction.consensus_timestamp }
-                }">Show transaction
-            </router-link>
+                }">Show scheduling transaction
+              </router-link>
+            </div>
           </template>
-        </Property>
-        <Property v-else-if="scheduledTransaction" id="scheduledTransaction">
-          <template v-slot:name>Scheduled</template>
-          <template v-slot:value>
-            <router-link :to="{
+          <template v-else-if="scheduledTransaction!==null" v-slot:value>
+            False
+            <div class="h-is-extra-text h-is-text-size-2">
+              <router-link :to="{
                   name: 'TransactionDetails',
                   params: { transactionId: scheduledTransaction.transaction_id },
                   query: { t: scheduledTransaction.consensus_timestamp }
-                }">Show transaction
-            </router-link>
+                }">Show scheduled transaction
+              </router-link>
+            </div>
           </template>
-        </Property>
-        <Property v-else>
-          <template v-slot:name>Scheduled</template>
-          <template v-slot:value>
+          <template v-else v-slot:value>
             <span class="has-text-grey">False</span>
           </template>
         </Property>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -201,7 +201,7 @@
                     params: { transactionId: tx.transaction_id },
                     query: { t: tx.consensus_timestamp }
                   }">
-                <span class="mr-2">{{ '#' + tx.nonce }}</span>
+                <span class="mr-2 is-numeric">{{ '#' + tx.nonce }}</span>
                 <span>{{ makeTypeLabel(tx.name) }}</span>
                 <br/></router-link>
             </div>
@@ -235,7 +235,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onMounted, ref, watch} from 'vue';
+import {computed, defineComponent, inject, onMounted} from 'vue';
 import {PathParam} from "@/utils/PathParam";
 import {makeOperatorAccountLabel, makeTypeLabel} from "@/utils/TransactionTools";
 import {TransactionLoader} from "@/components/transaction/TransactionLoader";
@@ -255,9 +255,7 @@ import DurationValue from "@/components/values/DurationValue.vue";
 import BlockLink from "@/components/values/BlockLink.vue";
 import ContractResultAndLogs from "@/components/transaction/ContractResultAndLogs.vue";
 
-const MAX_INLINE_CHILDREN = 10
-const NB_LOG_LINES = 2
-const MAX_LOG_LINES = 10
+const MAX_INLINE_CHILDREN = 9
 
 export default defineComponent({
 
@@ -293,10 +291,6 @@ export default defineComponent({
         computed(() => props.consensusTimestamp ?? null))
     onMounted(() => transactionLoader.requestLoad())
 
-    const logCursor = ref(0)
-    const nbLogLines = ref(NB_LOG_LINES)
-    watch(nbLogLines, () => logCursor.value = 0)
-
     const showAllTransactionVisible = computed(() => {
       const count = transactionLoader.transactions.value?.length ?? 0
       return count >= 2
@@ -324,8 +318,6 @@ export default defineComponent({
     })
 
     return {
-      NB_LOG_LINES,
-      MAX_LOG_LINES,
       isSmallScreen,
       isLargeScreen,
       isTouchDevice,
@@ -346,8 +338,6 @@ export default defineComponent({
       blockNumber: transactionLoader.blockNumber,
       notification,
       routeName,
-      logCursor,
-      nbLogLines,
       makeTypeLabel,
       // computeNetAmount,
       makeOperatorAccountLabel,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -65,7 +65,7 @@
                   params: { transactionId: scheduledTransaction.transaction_id },
                   query: { t: scheduledTransaction.consensus_timestamp }
                 }">
-                <span class="h-is-text-size-2 has-text-grey">Show scheduled transaction</span>
+                <span class="h-is-text-size-3 has-text-grey">Show scheduled transaction</span>
               </router-link>
             </div>
           </template>
@@ -166,7 +166,7 @@
                   name: 'TransactionDetails',
                   params: { transactionId: schedulingTransaction.transaction_id },
                   query: { t: schedulingTransaction.consensus_timestamp }
-                }"><span class="has-text-grey h-is-text-size-2">Show schedule create transaction</span>
+                }"><span class="has-text-grey h-is-text-size-3">Show schedule create transaction</span>
               </router-link>
             </div>
           </template>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -54,6 +54,15 @@
           <template v-slot:name>Type</template>
           <template v-slot:value>
             <StringValue :string-value="transactionType ? makeTypeLabel(transactionType) : undefined"/>
+            <div v-if="scheduledTransaction" id="scheduledLink">
+              <router-link :to="{
+                  name: 'TransactionDetails',
+                  params: { transactionId: scheduledTransaction.transaction_id },
+                  query: { t: scheduledTransaction.consensus_timestamp }
+                }">
+                <span class="h-is-text-size-2 has-text-grey">Show scheduled transaction</span>
+              </router-link>
+            </div>
           </template>
         </Property>
         <Property id="consensusAt">
@@ -147,25 +156,17 @@
           <template v-slot:name>Scheduled</template>
           <template v-if="transaction?.scheduled===true" v-slot:value>
             True
-            <div id="schedulingLink" v-if="schedulingTransaction" class="h-is-extra-text h-is-text-size-2">
+            <div id="schedulingLink" v-if="schedulingTransaction">
               <router-link :to="{
                   name: 'TransactionDetails',
                   params: { transactionId: schedulingTransaction.transaction_id },
                   query: { t: schedulingTransaction.consensus_timestamp }
-                }">Show scheduling transaction
+                }"><span class="has-text-grey h-is-text-size-2">Show schedule create transaction</span>
               </router-link>
             </div>
           </template>
           <template v-else-if="scheduledTransaction!==null" v-slot:value>
             False
-            <div id="scheduledLink" class="h-is-extra-text h-is-text-size-2">
-              <router-link :to="{
-                  name: 'TransactionDetails',
-                  params: { transactionId: scheduledTransaction.transaction_id },
-                  query: { t: scheduledTransaction.consensus_timestamp }
-                }">Show scheduled transaction
-              </router-link>
-            </div>
           </template>
           <template v-else v-slot:value>
             <span class="has-text-grey">False</span>

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -25,7 +25,7 @@
 import {EntityID} from "@/utils/EntityID";
 
 export interface AccountsResponse {
-    accounts: [AccountInfo] | undefined
+    accounts: AccountInfo[] | undefined
     links: Links | undefined
 }
 

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -139,20 +139,6 @@ export function showPositiveNetAmount(row: Transaction): boolean {
     return result
 }
 
-export function makeRelationshipLabel(row: Transaction): string {
-    let result: string
-    if (row.name === TransactionType.SCHEDULECREATE) {
-        result = "Scheduling"
-    } else if (row.scheduled) {
-        result = "Scheduled"
-    } else if (row.nonce && row.nonce > 0) {
-        result = "Child"
-    } else {
-        result = "Parent"
-    }
-    return result
-}
-
 export function makeTypeLabel(type: TransactionType | undefined): string {
     let result: string
     switch (type) {

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -61,7 +61,7 @@ describe('Search Bar', () => {
             .eq(0)
             .find('td')
             .eq(3)
-            .should('contain', 'Scheduling')  // criteria to check
+            .should('contain', 'Schedule Create')  // criteria to check
         cy.get('table')
             .find('tbody tr')
             .eq(1)

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -140,7 +140,7 @@ describe('Transaction Navigation', () => {
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', parentConsensusTimestamp)
 
-        cy.get('#childrenValue')
+        cy.get('#childTransactionsValue')
             .find('a')
             .should('have.length', 2)
             .eq(0)
@@ -217,7 +217,7 @@ describe('Transaction Navigation', () => {
             })
         cy.go('back')
 
-        cy.get('#childrenValue')
+        cy.get('#childTransactionsValue')
             .find('a')
             .should('have.length', 1)
             .eq(0)

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -109,7 +109,7 @@ describe('Transaction Navigation', () => {
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', schedulingConsensusTimestamp)
 
-        cy.get('#scheduledValue')
+        cy.get('#transactionTypeValue')
             .find('a')
             .click()
             .then(() => {

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -109,7 +109,7 @@ describe('Transaction Navigation', () => {
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', schedulingConsensusTimestamp)
 
-        cy.get('#scheduledTransactionValue')
+        cy.get('#scheduledValue')
             .find('a')
             .click()
             .then(() => {
@@ -119,7 +119,7 @@ describe('Transaction Navigation', () => {
                 cy.contains('Transaction ' + transactionId)
             })
 
-        cy.get('#schedulingTransactionValue')
+        cy.get('#scheduledValue')
             .find('a')
             .click()
             .then(() => {

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1076,7 +1076,7 @@ export const SAMPLE_REWARDS_TRANSACTIONS = {
 }
 
 //
-// https://testnet.mirrornode.hedera.com/api/v1/transactions/0.0.48113503-1662470948-432078184
+// https://mainnet-public.mirrornode.hedera.com/api/v1/transactions/0.0.48113503-1662470948-432078184
 //
 
 export const SAMPLE_PARENT_CHILD_TRANSACTIONS = {
@@ -1202,6 +1202,130 @@ export const SAMPLE_PARENT_CHILD_TRANSACTIONS = {
             "valid_duration_seconds": null,
             "valid_start_timestamp": "1662470948.432078184"
         }]
+}
+
+//
+// https://mainnet-public.mirrornode.hedera.com/api/v1/transactions/0.0.503733-1666754898-238965661
+//
+
+export const SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS = {
+    "transactions": [{
+        "bytes": null,
+        "charged_tx_fee": 10222951,
+        "consensus_timestamp": "1666754908.576858590",
+        "entity_id": "0.0.1382775",
+        "max_fee": "500000000",
+        "memo_base64": "",
+        "name": "SCHEDULECREATE",
+        "node": "0.0.22",
+        "nonce": 0,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "kf0Uakt9YM0AztfHZanJXU9Rk5nmX0ZFjiyvGGHPPeZI/gdSTy+ThDAsLT1p7yfx",
+        "transaction_id": "0.0.503733-1666754898-238965661",
+        "transfers": [{"account": "0.0.22", "amount": 513563, "is_approval": false}, {
+            "account": "0.0.98",
+            "amount": 9709388,
+            "is_approval": false
+        }, {"account": "0.0.503733", "amount": -10222951, "is_approval": false}],
+        "valid_duration_seconds": "120",
+        "valid_start_timestamp": "1666754898.238965661"
+    }, {
+        "bytes": null,
+        "charged_tx_fee": 250757,
+        "consensus_timestamp": "1666754925.508764007",
+        "entity_id": "0.0.1304757",
+        "max_fee": "3000000000",
+        "memo_base64": "",
+        "name": "TOKENMINT",
+        "node": null,
+        "nonce": 0,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": true,
+        "token_transfers": [{
+            "token_id": "0.0.1304757",
+            "account": "0.0.540219",
+            "amount": 404955647,
+            "is_approval": false
+        }],
+        "transaction_hash": "88cs2fTZgAV2fh+n7zWhZjPs24NDyq6icaP/CR64SR5vruiiKoHB3Ip6oid5DMfa",
+        "transaction_id": "0.0.503733-1666754898-238965661",
+        "transfers": [{"account": "0.0.98", "amount": 250757, "is_approval": false}, {
+            "account": "0.0.540286",
+            "amount": -250757,
+            "is_approval": false
+        }],
+        "valid_duration_seconds": null,
+        "valid_start_timestamp": "1666754898.238965661"
+    }]
+}
+
+//
+// http://testnet.mirrornode.hedera.com/api/v1/transactions/0.0.2520793-1665085799-890453831
+//
+
+export const SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS = {
+    "transactions": [{
+        "bytes": null,
+        "charged_tx_fee": 141509235,
+        "consensus_timestamp": "1665085808.019403093",
+        "entity_id": null,
+        "max_fee": "10000000000",
+        "memo_base64": "",
+        "name": "CRYPTODELETEALLOWANCE",
+        "node": "0.0.4",
+        "nonce": 0,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "KuwQ5qibGSidcXJKP62s3aBPA+xIcN+EnH/GDXnN2+2hS5UlRRKtY+TlIurY9Vyo",
+        "transaction_id": "0.0.2520793-1665085799-890453831",
+        "transfers": [{"account": "0.0.4", "amount": 3630931, "is_approval": false}, {
+            "account": "0.0.98",
+            "amount": 137878304,
+            "is_approval": false
+        }, {"account": "0.0.2520793", "amount": -141509235, "is_approval": false}],
+        "valid_duration_seconds": "120",
+        "valid_start_timestamp": "1665085799.890453831"
+    }, {
+        "bytes": null,
+        "charged_tx_fee": 0,
+        "consensus_timestamp": "1665085808.019403094",
+        "entity_id": "0.0.534101",
+        "max_fee": "0",
+        "memo_base64": "",
+        "name": "CONTRACTDELETEINSTANCE",
+        "node": null,
+        "nonce": 1,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "QCcVBlDByJ9a+GbYmTwoSzBt8teJmS4r5j2IF0SidtfmkNAjDNnoIcWFnWm/wCQk",
+        "transaction_id": "0.0.2520793-1665085799-890453831",
+        "transfers": [],
+        "valid_duration_seconds": null,
+        "valid_start_timestamp": "1665085799.890453831"
+    }, {
+        "bytes": null,
+        "charged_tx_fee": 0,
+        "consensus_timestamp": "1665085808.019403095",
+        "entity_id": "0.0.534103",
+        "max_fee": "0",
+        "memo_base64": "",
+        "name": "CONTRACTDELETEINSTANCE",
+        "node": null,
+        "nonce": 2,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "tJWvi9tJwnT3Wnmi6wBj8qo8kItCzdBSdHnISaJfRxB+kyKmHa81Pak3VwjCxh8P",
+        "transaction_id": "0.0.2520793-1665085799-890453831",
+        "transfers": [],
+        "valid_duration_seconds": null,
+        "valid_start_timestamp": "1665085799.890453831"
+    }]
 }
 
 //

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -104,7 +104,7 @@ describe("TransactionByIdTable.vue", () => {
 
         let cells = rows[0].findAll('td')
         expect(cells[1].text()).toBe("SCHEDULE CREATE")
-        expect(cells[3].text()).toBe("Scheduling")
+        expect(cells[3].text()).toBe("Schedule Create")
         expect(cells[4].text()).toBe("0")
 
         cells = rows[1].findAll('td')

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -20,7 +20,11 @@
 
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
-import {SAMPLE_PARENT_CHILD_TRANSACTIONS} from "../Mocks";
+import {
+    SAMPLE_PARENT_CHILD_TRANSACTIONS,
+    SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS,
+    SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS
+} from "../Mocks";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import {Transaction} from "@/schemas/HederaSchemas";
@@ -51,7 +55,7 @@ HMSF.forceUTC = true
 
 describe("TransactionByIdTable.vue", () => {
 
-    test("all props", async () => {
+    it("Should list transactions as parent and child", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -77,4 +81,72 @@ describe("TransactionByIdTable.vue", () => {
         )
     });
 
+    it("Should list transactions as scheduling and scheduled", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(TransactionByIdTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                narrowed: true,
+                nbItems: 42,
+                transactions: SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions as Array<Transaction>,
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("Time Type Content Relationship Nonce")
+        const rows = wrapper.find('tbody').findAll('tr')
+
+        let cells = rows[0].findAll('td')
+        expect(cells[1].text()).toBe("SCHEDULE CREATE")
+        expect(cells[3].text()).toBe("Scheduling")
+        expect(cells[4].text()).toBe("0")
+
+        cells = rows[1].findAll('td')
+        expect(cells[1].text()).toBe("TOKEN MINT")
+        expect(cells[3].text()).toBe("Scheduled")
+        expect(cells[4].text()).toBe("0")
+    });
+
+    it("Should list transactions as unrelated", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(TransactionByIdTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                narrowed: true,
+                nbItems: 42,
+                transactions: SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS.transactions as Array<Transaction>,
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("Time Type Content Relationship Nonce")
+        const rows = wrapper.find('tbody').findAll('tr')
+
+        let cells = rows[0].findAll('td')
+        expect(cells[1].text()).toBe("CRYPTO DELETE ALLOWANCE")
+        expect(cells[3].text()).toBe("")
+        expect(cells[4].text()).toBe("0")
+
+        cells = rows[1].findAll('td')
+        expect(cells[1].text()).toBe("CONTRACT DELETE")
+        expect(cells[3].text()).toBe("")
+        expect(cells[4].text()).toBe("1")
+
+        cells = rows[2].findAll('td')
+        expect(cells[1].text()).toBe("CONTRACT DELETE")
+        expect(cells[3].text()).toBe("")
+        expect(cells[4].text()).toBe("2")
+    });
 });

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -457,7 +457,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(SCHEDULED.transaction_id, true)))
 
         const link = wrapper.get("#schedulingLink")
-        expect(link.text()).toBe("Show scheduling transaction")
+        expect(link.text()).toBe("Show schedule create transaction")
         expect(link.get('a').attributes("href")).toBe(
             "/testnet/transaction/" + SCHEDULING.transaction_id + "?t=" + SCHEDULING.consensus_timestamp
         )

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -29,13 +29,15 @@ import axios from "axios";
 import {
     SAMPLE_BLOCKSRESPONSE,
     SAMPLE_COINGECKO,
+    SAMPLE_CONTRACT_RESULT_DETAILS,
     SAMPLE_CONTRACTCALL_TRANSACTIONS,
-    SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS,
     SAMPLE_FAILED_TRANSACTION,
-    SAMPLE_FAILED_TRANSACTIONS,
+    SAMPLE_FAILED_TRANSACTIONS, SAMPLE_PARENT_CHILD_TRANSACTIONS,
+    SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
+    SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS,
     SAMPLE_TOKEN,
     SAMPLE_TRANSACTION,
-    SAMPLE_TRANSACTIONS, SAMPLE_CONTRACT_RESULT_DETAILS
+    SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import {HMSF} from "@/utils/HMSF";
@@ -375,5 +377,179 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(txnId, true)))
         expect(wrapper.get("#transactionTypeValue").text()).toBe("CONTRACT CALL")
         expect(wrapper.get("#entityId").text()).toBe("Contract IDHedera Token Service System Contract")
+    });
+
+    it("Should display a link to the scheduled transaction", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const SCHEDULING = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[0]
+        const SCHEDULED = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[1]
+        const matcher1 = "/api/v1/transactions/" + SCHEDULING.transaction_id
+        mock.onGet(matcher1).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
+
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
+
+        const matcher4 = "/api/v1/blocks"
+        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
+
+        const wrapper = mount(TransactionDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionId: SCHEDULING.transaction_id,
+                consensusTimestamp: SCHEDULING.consensus_timestamp
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(SCHEDULING.transaction_id, true)))
+
+        const link = wrapper.get("#scheduledLink")
+        expect(link.text()).toBe("Show scheduled transaction")
+        expect(link.get('a').attributes("href")).toBe(
+            "/testnet/transaction/" + SCHEDULED.transaction_id + "?t=" + SCHEDULED.consensus_timestamp
+        )
+    });
+
+    it("Should display a link to the scheduling transaction", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const SCHEDULING = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[0]
+        const SCHEDULED = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[1]
+        const TOKEN_ID = SCHEDULED.token_transfers ? SCHEDULED.token_transfers[0].token_id : "0.0.1304757"
+        const matcher1 = "/api/v1/transactions/" + SCHEDULED.transaction_id
+        mock.onGet(matcher1).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
+
+        const matcher2 = "/api/v1/tokens/" + TOKEN_ID
+        mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
+
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
+
+        const matcher4 = "/api/v1/blocks"
+        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
+
+        const wrapper = mount(TransactionDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionId: SCHEDULED.transaction_id,
+                consensusTimestamp: SCHEDULED.consensus_timestamp
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(SCHEDULED.transaction_id, true)))
+
+        const link = wrapper.get("#schedulingLink")
+        expect(link.text()).toBe("Show scheduling transaction")
+        expect(link.get('a').attributes("href")).toBe(
+            "/testnet/transaction/" + SCHEDULING.transaction_id + "?t=" + SCHEDULING.consensus_timestamp
+        )
+    });
+
+    it("Should display a link to the parent transaction", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const PARENT = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[0]
+        const CHILD = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[1]
+        const TOKEN_ID = CHILD.nft_transfers ? CHILD.nft_transfers[0].token_id : "0.0.48193741"
+        const matcher1 = "/api/v1/transactions/" + CHILD.transaction_id
+        mock.onGet(matcher1).reply(200, SAMPLE_PARENT_CHILD_TRANSACTIONS);
+
+        const matcher2 = "/api/v1/tokens/" + TOKEN_ID
+        mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
+
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
+
+        const matcher4 = "/api/v1/blocks"
+        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
+
+        const wrapper = mount(TransactionDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionId: CHILD.transaction_id,
+                consensusTimestamp: CHILD.consensus_timestamp
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(CHILD.transaction_id, true)))
+
+        const link = wrapper.get("#parentTransactionValue")
+        expect(link.text()).toBe("CONTRACT CALL")
+        expect(link.get('a').attributes("href")).toBe(
+            "/testnet/transaction/" + PARENT.transaction_id + "?t=" + PARENT.consensus_timestamp
+        )
+    });
+
+    it("Should display link to the child transactions", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const PARENT = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[0]
+        const CHILD1 = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[1]
+        const CHILD2 = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[2]
+        const matcher1 = "/api/v1/transactions/" + PARENT.transaction_id
+        mock.onGet(matcher1).reply(200, SAMPLE_PARENT_CHILD_TRANSACTIONS);
+
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
+
+        const matcher4 = "/api/v1/blocks"
+        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
+
+        const wrapper = mount(TransactionDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionId: PARENT.transaction_id,
+                consensusTimestamp: PARENT.consensus_timestamp
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(PARENT.transaction_id, true)))
+
+        const children = wrapper.get("#childTransactionsValue")
+        expect(children.text()).toBe("#1TOKEN MINT#2CRYPTO TRANSFER")
+
+        const links = children.findAll('a')
+        expect(links[0].attributes("href")).toBe(
+            "/testnet/transaction/" + CHILD1.transaction_id + "?t=" + CHILD1.consensus_timestamp
+        )
+        expect(links[1].attributes("href")).toBe(
+            "/testnet/transaction/" + CHILD2.transaction_id + "?t=" + CHILD2.consensus_timestamp
+        )
     });
 });

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -24,6 +24,7 @@ import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {
     SAMPLE_ACCOUNT,
+    SAMPLE_ACCOUNTS,
     SAMPLE_CONTRACT,
     SAMPLE_TOKEN,
     SAMPLE_TOPIC_MESSAGES,
@@ -47,6 +48,10 @@ mock.onGet(matcher_account_with_alias).reply(200, SAMPLE_ACCOUNT)
 const SAMPLE_ACCOUNT_ADDRESS = EntityID.parse(SAMPLE_ACCOUNT.account)!.toAddress()
 const matcher_account_with_address = "/api/v1/accounts/" + SAMPLE_ACCOUNT_ADDRESS
 mock.onGet(matcher_account_with_address).reply(200, SAMPLE_ACCOUNT)
+
+const matcher_account_with_public_key = "/api/v1/accounts/?account.publickey=" + SAMPLE_ACCOUNTS.accounts[0].key.key
+mock.onGet(matcher_account_with_public_key).reply(200, SAMPLE_ACCOUNTS)
+
 
 // Transaction
 
@@ -103,6 +108,20 @@ describe("SearchRequest.ts", () => {
         await r.run()
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT_ADDRESS)
+        expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
+
+    })
+
+    test("account (with public key)", async () => {
+        const r = new SearchRequest(SAMPLE_ACCOUNT.key.key)
+        await r.run()
+
+        expect(r.searchedId).toBe(SAMPLE_ACCOUNT.key.key)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()


### PR DESCRIPTION
**Description**:

With these changes, we clarify the way transaction relationship (parent/child, scheduling/scheduled) are presented.
In particular for parent/child, we come back to a traditional `Scheduled: True/False` property display, but with an underline link to navigate to the related transaction.

We also fix the detection of parent/child relationship: A transaction needs a `parent_consensus_timestamp` property to be considered a child.

**Related issue(s)**:

Fixes #279 #256 

**Notes for reviewer**:

This is deployed on the staging server.

Example of scheduling/scheduled transactions:
<url>/mainnet/transaction/0.0.503733-1666754898-238965661

Example of parent/child transactions:
<url>/mainnet/transaction/0.0.846260-1666766635-282429759

Example of unrelated transactions (but same ID)
<url>/testnet/transactionsById/0.0.2520793-1665085799-890453831

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
