### PR TITLE
00208 Transfer diagram with a strange (ugly) layout).

### DIFF
--- a/src/components/transfer_graphs/NftTransferGraph.vue
+++ b/src/components/transfer_graphs/NftTransferGraph.vue
@@ -29,7 +29,7 @@
 
     <div  v-if="nftTransferLayout.length >= 1">
 
-    <div class="graph-container" v-bind:class="{'graph-container-6': descriptionVisible}">
+    <div class="graph-container" v-bind:class="{'graph-container-6': !compact && descriptionVisible}">
 
       <template v-if="!compact">
 


### PR DESCRIPTION
Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Changes below fix layout issue reported in #208.
This bug affects NFT transfer diagrams displayed in « compact mode » (ie displayed in table, not in detail page).

**Related issue(s)**:

Fixes #208

**Notes for reviewer**:

Samples for testing:
- https://hashscan-latest.hedera-devops.com/mainnet/transactionsById/0.0.1112484-1666801627-219198139
- https://hashscan-latest.hedera-devops.com/testnet/transactionsById/0.0.11495-1662470792-231322900

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
