### PR TITLE
00288 fixed fee amount in hbar

### DIFF
--- a/src/components/token/FixedFeeTable.vue
+++ b/src/components/token/FixedFeeTable.vue
@@ -38,7 +38,8 @@
   >
 
     <o-table-column v-slot="props" field="amount" label="Amount">
-      <PlainAmount :amount="props.row.amount"/>
+      <PlainAmount v-if="props.row.denominating_token_id" :amount="props.row.amount"/>
+      <HbarAmount v-else :amount="props.row.amount" :show-extra="true"/>
     </o-table-column>
 
     <o-table-column v-slot="props" field="amount" label="Token">
@@ -61,18 +62,20 @@
 
 import {defineComponent, PropType} from 'vue';
 import AccountLink from "@/components/values/AccountLink.vue";
-import PlainAmount from "@/components/values/PlainAmount.vue";
 import TokenLink from "@/components/values/TokenLink.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
 import {TokenInfoLoader} from "@/components/token/TokenInfoLoader";
+import HbarAmount from "@/components/values/HbarAmount.vue";
+import PlainAmount from "@/components/values/PlainAmount.vue";
 
 export default defineComponent({
 
   name: 'FixedFeeTable',
 
   components: {
-    TokenLink,
     PlainAmount,
+    HbarAmount,
+    TokenLink,
     AccountLink,
   },
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -46,7 +46,12 @@ export const SAMPLE_TOKEN = {
                 "amount": 2,
                 "collector_account_id": "0.0.617890",
                 "denominating_token_id": "0.0.29662956"
-            }
+            },
+            {
+                "amount": 100000000,
+                "collector_account_id": "0.0.617888",
+                "denominating_token_id": null
+            },
         ],
         "fractional_fees": [
             {
@@ -249,7 +254,12 @@ export const SAMPLE_NONFUNGIBLE = {
                 "amount": 2,
                 "collector_account_id": "0.0.617890",
                 "denominating_token_id": "0.0.748383"
-            }
+            },
+            {
+                "amount": 100000000,
+                "collector_account_id": "0.0.617888",
+                "denominating_token_id": null
+            },
         ],
         "royalty_fees": [
             {

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -23,7 +23,7 @@ import router from "@/router";
 import TokenDetails from "@/pages/TokenDetails.vue";
 import axios from "axios";
 import {
-    SAMPLE_BALANCES,
+    SAMPLE_BALANCES, SAMPLE_COINGECKO,
     SAMPLE_NFTS, SAMPLE_NONFUNGIBLE,
     SAMPLE_NONFUNGIBLE_DUDE,
     SAMPLE_TOKEN,
@@ -386,6 +386,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/balances"
         mock.onGet(matcher2).reply(200, SAMPLE_BALANCES);
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -409,7 +411,8 @@ describe("TokenDetails.vue", () => {
         expect(fixedFee.get('tbody').text()).toBe(
             "5" + "0.0.2966295623423" + "0.0.617888" +
             "1" + "0.0.2966295623423" + "0.0.617889" +
-            "2" + "0.0.2966295623423" + "0.0.617890")
+            "2" + "0.0.2966295623423" + "0.0.617890" +
+            "1.00000000" + "$0.2460" + "0.0.617888")
 
         const fractionalFee = customFees.findComponent(FractionalFeeTable)
         expect(fractionalFee.exists()).toBe(true)
@@ -433,6 +436,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_NONFUNGIBLE);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -456,7 +461,8 @@ describe("TokenDetails.vue", () => {
         expect(fixedFee.get('tbody').text()).toBe(
             "5" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617888" +
             "1" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617889" +
-            "2" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617890")
+            "2" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617890" +
+            "1.00000000" + "$0.2460" + "0.0.617888")
 
         expect(customFees.findComponent(FractionalFeeTable).exists()).toBe(false)
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -76,6 +76,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/balances"
         mock.onGet(matcher2).reply(200, SAMPLE_BALANCES);
+        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
 
         const wrapper = mount(TokenDetails, {
             global: {

--- a/tests/unit/utils/Collector.spec.ts
+++ b/tests/unit/utils/Collector.spec.ts
@@ -19,8 +19,11 @@
  */
 
 import {Collector} from "@/utils/Collector";
-import {AxiosResponse} from "axios";
+import axios, {AxiosResponse} from "axios";
 import {flushPromises} from "@vue/test-utils";
+import {CoinGeckoCollector} from "@/utils/CoinGeckoCollector";
+import {SAMPLE_COINGECKO} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
 
 describe("Collector.ts", () => {
 
@@ -40,7 +43,18 @@ describe("Collector.ts", () => {
 
     })
 
+    test("CoinGeckoCollector", async () => {
 
+        const mock = new MockAdapter(axios);
+        const matcher = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+        mock.onGet(matcher).reply(200, SAMPLE_COINGECKO);
+
+        const r1 = await CoinGeckoCollector.instance.fetch(null)
+        const r2 = await CoinGeckoCollector.instance.fetch(null)
+        expect(r2.data).toBe(r1.data)
+        expect(mock.history.get.length).toBe(1)
+
+    })
 })
 
 class TestCollector extends Collector<TestData, number> {


### PR DESCRIPTION
**Description**:

Fix for the case where token custom fixed fees are collected in hbar instead of another fungible token. The amount has to be displayed as a number of hbars instead of a plain amount.

**Related issue(s)**:

Fixes #288 

**Notes for reviewer**:

Instructions to reproduce in issue #288 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
