### PR TITLE
00292 Setting a transaction type in Transactions table triggers duplicated api/v1/transactions requests

### DIFF
--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -251,6 +251,11 @@ export abstract class TableController<R, K> {
 
     private sourcesDidChange(): void {
         if (this.mountedRef.value) {
+            if (this.autoRefreshRef.value) {
+                this.abortRefreshBuffer()
+            } else {
+                this.abortMoveBufferToPage()
+            }
             this.buffer.clear()
             this.bufferDidChange().finally(() => {
                 if (this.autoRefreshRef.value) {


### PR DESCRIPTION
**Description**:

Changes below fix issue #292. See issue for details.

**Related issue(s)**:

Fixes #292.

**Notes for reviewer**:

See #292.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
