### PR TITLE
00290 Remove compatibility with previous hash-based URL structure

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -18,13 +18,7 @@
  *
  */
 
-import {
-  createRouter,
-  createWebHistory,
-  RouteLocationNormalized,
-  Router,
-  RouteRecordRaw
-} from 'vue-router'
+import {createRouter, createWebHistory, RouteLocationNormalized, Router, RouteRecordRaw} from 'vue-router'
 import MainDashboard from "@/pages/MainDashboard.vue";
 import Transactions from "@/pages/Transactions.vue";
 import TransactionDetails from "@/pages/TransactionDetails.vue";
@@ -251,54 +245,48 @@ router.beforeEach((to) => {
 router.beforeEach((to, from) => {
   let result: boolean | string
 
-  const hash = window.location.hash
-  if (hash?.length > 1 && hash[0] === '#') {
-    result = hash.slice(1)
-    window.location.hash = ""
-  } else {
+  const toEntry = getNetworkEntryFromRoute(to)
+  const fromEntry = getNetworkEntryFromRoute(from)
 
-    const toEntry = getNetworkEntryFromRoute(to)
-    const fromEntry = getNetworkEntryFromRoute(from)
-    if (toEntry !== null) {
-      // Network is valid
-      AppStorage.setLastNetwork(toEntry)
-      axios.defaults.baseURL = toEntry.url
+  if (toEntry !== null) {
+    // Network is valid
+    AppStorage.setLastNetwork(toEntry)
+    axios.defaults.baseURL = toEntry.url
 
-      if (toEntry.name == NetworkRegistry.TEST_NETWORK) {
-        document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-testnet-background-color)')
-        document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-testnet-highlight-color)')
-        document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-testnet-pagination-background-color)')
-        document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-testnet-box-shadow-color)')
-        document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-testnet-dropdown-arrow)')
-      } else if (toEntry.name == NetworkRegistry.PREVIEW_NETWORK) {
-        document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-previewnet-background-color)')
-        document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-previewnet-highlight-color)')
-        document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-previewnet-pagination-background-color)')
-        document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-previewnet-box-shadow-color)')
-        document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-previewnet-dropdown-arrow)')
-      } else {
-        document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-mainnet-background-color)')
-        document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-mainnet-highlight-color)')
-        document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-mainnet-pagination-background-color)')
-        document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-mainnet-box-shadow-color)')
-        document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-mainnet-dropdown-arrow)')
-      }
-
-      if (fromEntry != null && fromEntry != toEntry) {
-        // Network is changing => updates AppStorage and axios
-        if (to.name != "MainDashboard" && to.name != "PageNotFound") {
-          // We re-route on MainDashboard
-          result = "/" + toEntry.name + "/dashboard"
-        } else {
-          result = true
-        }
-      } else (
-          result = true
-      )
+    if (toEntry.name == NetworkRegistry.TEST_NETWORK) {
+      document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-testnet-background-color)')
+      document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-testnet-highlight-color)')
+      document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-testnet-pagination-background-color)')
+      document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-testnet-box-shadow-color)')
+      document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-testnet-dropdown-arrow)')
+    } else if (toEntry.name == NetworkRegistry.PREVIEW_NETWORK) {
+      document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-previewnet-background-color)')
+      document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-previewnet-highlight-color)')
+      document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-previewnet-pagination-background-color)')
+      document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-previewnet-box-shadow-color)')
+      document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-previewnet-dropdown-arrow)')
     } else {
-      // Network is invalid => page not found
-      result = '/page-not-found'
+      document.documentElement.style.setProperty('--h-theme-background-color', 'var(--h-mainnet-background-color)')
+      document.documentElement.style.setProperty('--h-theme-highlight-color', 'var(--h-mainnet-highlight-color)')
+      document.documentElement.style.setProperty('--h-theme-pagination-background-color', 'var(--h-mainnet-pagination-background-color)')
+      document.documentElement.style.setProperty('--h-theme-box-shadow-color', 'var(--h-mainnet-box-shadow-color)')
+      document.documentElement.style.setProperty('--h-theme-dropdown-arrow', 'var(--h-mainnet-dropdown-arrow)')
     }
+
+    if (fromEntry != null && fromEntry != toEntry) {
+      // Network is changing => updates AppStorage and axios
+      if (to.name != "MainDashboard" && to.name != "PageNotFound") {
+        // We re-route on MainDashboard
+        result = "/" + toEntry.name + "/dashboard"
+      } else {
+        result = true
+      }
+    } else (
+        result = true
+    )
+  } else {
+    // Network is invalid => page not found
+    result = '/page-not-found'
   }
   return result
 })

--- a/tests/e2e/specs/HomePage.spec.ts
+++ b/tests/e2e/specs/HomePage.spec.ts
@@ -21,8 +21,15 @@
 // https://docs.cypress.io/api/introduction/api.html
 
 describe('Hedera Explorer home page', () => {
-  it('Visits the app root url', () => {
+  it('Visits the app root URL', () => {
     cy.visit('/')
+    cy.url().should('include', '/testnet/dashboard')
+    cy.contains('Crypto Transfers')
+    cy.contains('Smart Contract Calls')
+    cy.contains('HCS Messages')
+  })
+  it('Visits an old hash-based URL', () => {
+    cy.visit('/#/testnet/token/0.0.48789573')
     cy.url().should('include', '/testnet/dashboard')
     cy.contains('Crypto Transfers')
     cy.contains('Smart Contract Calls')


### PR DESCRIPTION
**Description**:

All is said in the title...

**Related issue(s)**:

Fixes #290 

**Notes for reviewer**:

Try to navigate to `{url}/#/testnet/token/0.0.48789573` (or any other page).

- Before this change (with the compat. code) there is a redirect to: `{url}/testnet/token/0.0.48789573`

- With this change, (compat. code removed) the redirect is to:  `{url}/testnet/dashboard`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
