### PR TITLE
00131 HashScan should display the structure of complex keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-brands-svg-icons": "^6.1.2",
         "@fortawesome/free-solid-svg-icons": "^6.1.2",
         "@fortawesome/vue-fontawesome": "^3.0.0-5",
+        "@hashgraph/proto": "^2.11.0",
         "@hashgraph/sdk": "^2.18.0",
         "@metamask/detect-provider": "^1.2.0",
         "@metamask/providers": "^9.1.0",
@@ -5419,9 +5420,9 @@
       }
     },
     "node_modules/@hashgraph/cryptography": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.0.tgz",
-      "integrity": "sha512-NtDmeuwaWJKBDYZd+g/etAD56p/RPUuZGdT9jhXxiFW0YrKCaU1k4ramICbRaJg7E+RDSFJXJLarh0G72z5YDA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.1.tgz",
+      "integrity": "sha512-Qx7fl58Upyf1C4Xdqo2DdMaELYAni3RpAr6fVux3tpGUwp0Wo+zaWseW7k2Klg+FPlmjOjL8XBCXkOr1AbHYWQ==",
       "dependencies": {
         "bignumber.js": "^9.0.2",
         "crypto-js": "^4.1.1",
@@ -5437,6 +5438,17 @@
         "expo": "^45.0.3",
         "expo-crypto": "^10.1.2",
         "expo-random": "^12.1.2"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-crypto": {
+          "optional": true
+        },
+        "expo-random": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hashgraph/cryptography/node_modules/tweetnacl": {
@@ -5445,9 +5457,9 @@
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/@hashgraph/proto": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.9.0.tgz",
-      "integrity": "sha512-Ot0OVLCl9lNBpHZozN0BS4mvlpxgJ0Bkea4p+6MoQ/+sZtOCu+FMsidIVdvFZBvdNjgPXx8byYjkpmFaxiIOpQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.11.0.tgz",
+      "integrity": "sha512-JOom5ZIfmgPWfPMaCYg5pYBuNyMGb38F9lNFBxjA7cVbo2dnIOUQx4Zi98yyq0O4CrUSlKBhFaspDKXk+FfAhQ==",
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "^6.11.3"
@@ -5479,6 +5491,18 @@
       },
       "peerDependencies": {
         "expo": "^45.0.3"
+      }
+    },
+    "node_modules/@hashgraph/sdk/node_modules/@hashgraph/proto": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.9.0.tgz",
+      "integrity": "sha512-Ot0OVLCl9lNBpHZozN0BS4mvlpxgJ0Bkea4p+6MoQ/+sZtOCu+FMsidIVdvFZBvdNjgPXx8byYjkpmFaxiIOpQ==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@intervolga/optimize-cssnano-plugin": {
@@ -15899,6 +15923,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-10.2.0.tgz",
       "integrity": "sha512-YVFp+DJXBtt4t6oZXepnzb+xwpKzFbXn3B9Oma1Tfh6J0rIlm/I20UW/5apdvEdbj44fxJ5DsiZeyADI3bcZkQ==",
+      "optional": true,
       "peer": true,
       "peerDependencies": {
         "expo": "*"
@@ -16204,6 +16229,7 @@
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-12.3.0.tgz",
       "integrity": "sha512-q+AsTfGNT+Q+fb2sRrYtRkI3g5tV4H0kuYXM186aueILGO/vLn/YYFa7xFZj1IZ8LJZg2h96JDPDpsqHfRG2mQ==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0"
@@ -37416,9 +37442,9 @@
       }
     },
     "@hashgraph/cryptography": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.0.tgz",
-      "integrity": "sha512-NtDmeuwaWJKBDYZd+g/etAD56p/RPUuZGdT9jhXxiFW0YrKCaU1k4ramICbRaJg7E+RDSFJXJLarh0G72z5YDA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.1.tgz",
+      "integrity": "sha512-Qx7fl58Upyf1C4Xdqo2DdMaELYAni3RpAr6fVux3tpGUwp0Wo+zaWseW7k2Klg+FPlmjOjL8XBCXkOr1AbHYWQ==",
       "requires": {
         "bignumber.js": "^9.0.2",
         "crypto-js": "^4.1.1",
@@ -37436,9 +37462,9 @@
       }
     },
     "@hashgraph/proto": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.9.0.tgz",
-      "integrity": "sha512-Ot0OVLCl9lNBpHZozN0BS4mvlpxgJ0Bkea4p+6MoQ/+sZtOCu+FMsidIVdvFZBvdNjgPXx8byYjkpmFaxiIOpQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.11.0.tgz",
+      "integrity": "sha512-JOom5ZIfmgPWfPMaCYg5pYBuNyMGb38F9lNFBxjA7cVbo2dnIOUQx4Zi98yyq0O4CrUSlKBhFaspDKXk+FfAhQ==",
       "requires": {
         "long": "^4.0.0",
         "protobufjs": "^6.11.3"
@@ -37461,6 +37487,17 @@
         "long": "^4.0.0",
         "protobufjs": "^6.11.3",
         "utf8": "^3.0.0"
+      },
+      "dependencies": {
+        "@hashgraph/proto": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.9.0.tgz",
+          "integrity": "sha512-Ot0OVLCl9lNBpHZozN0BS4mvlpxgJ0Bkea4p+6MoQ/+sZtOCu+FMsidIVdvFZBvdNjgPXx8byYjkpmFaxiIOpQ==",
+          "requires": {
+            "long": "^4.0.0",
+            "protobufjs": "^6.11.3"
+          }
+        }
       }
     },
     "@intervolga/optimize-cssnano-plugin": {
@@ -46066,6 +46103,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-10.2.0.tgz",
       "integrity": "sha512-YVFp+DJXBtt4t6oZXepnzb+xwpKzFbXn3B9Oma1Tfh6J0rIlm/I20UW/5apdvEdbj44fxJ5DsiZeyADI3bcZkQ==",
+      "optional": true,
       "peer": true,
       "requires": {}
     },
@@ -46290,6 +46328,7 @@
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-12.3.0.tgz",
       "integrity": "sha512-q+AsTfGNT+Q+fb2sRrYtRkI3g5tV4H0kuYXM186aueILGO/vLn/YYFa7xFZj1IZ8LJZg2h96JDPDpsqHfRG2mQ==",
+      "optional": true,
       "peer": true,
       "requires": {
         "base64-js": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "vue-router": "^4.0.0-0",
     "hashconnect": "^0.1.9",
     "@bladelabs/blade-web3.js": "^0.9.11",
-    "@hashgraph/sdk": "^2.18.0"
+    "@hashgraph/sdk": "^2.18.0",
+    "@hashgraph/proto": "^2.11.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.12",

--- a/src/components/values/ComplexKeyValue.vue
+++ b/src/components/values/ComplexKeyValue.vue
@@ -1,0 +1,143 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <div :style="containerStyle()">
+    <template v-for="line in lines" :key="line.seqNb">
+      <div :style="lineStyle(line)">
+        <template v-if="line.innerKeyBytes() !== null">
+          <HexaValue :byte-string="line.innerKeyBytes()"/>
+          <div class="h-is-extra-text h-is-text-size-3">{{ line.innerKeyType() }}</div>
+        </template>
+        <template v-else>
+          <div>{{ lineText(line) }}</div>
+        </template>
+      </div>
+    </template>
+  </div>
+</template>
+
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent} from "vue";
+import {ComplexKeyLine} from "@/utils/ComplexKeyLine";
+import {hexToByte} from "@/utils/B64Utils";
+import hashgraph from "@hashgraph/proto/lib/proto";
+import HexaValue from "@/components/values/HexaValue.vue";
+
+export default defineComponent({
+  name: "ComplexKeyValue",
+  components: {HexaValue},
+  props: {
+    keyBytes: String,
+    showNone: {
+      type: Boolean,
+      default: false
+    },
+  },
+  setup(props) {
+
+    const key = computed(() => {
+      let result: hashgraph.proto.Key|null
+      if (props.keyBytes) {
+        const keyByteArray = hexToByte(props.keyBytes)
+        try {
+          result = keyByteArray !== null ? hashgraph.proto.Key.decode(keyByteArray) : null
+        } catch(reason) {
+          console.warn("Failed to decode key:" + reason)
+          result = null
+        }
+      } else {
+        result = null
+      }
+      return result
+    })
+
+    const lines = computed(() => {
+      return key.value !== null ? ComplexKeyLine.flattenComplexKey(key.value) : []
+    })
+
+    const maxLevel = computed(() => {
+      let result = 0
+      for (const line of lines.value) {
+        result = Math.max(result, line.level)
+      }
+      return result
+    })
+
+    const containerStyle = (): Record<string, string> => {
+      const n = maxLevel.value + 1
+      const offset = 20
+      return {
+        display: "grid",
+        gridTemplateColumns: "repeat(" + n + ", " + offset + "px) auto repeat(" + n + ", " + offset + "px)",
+        rowGap: "0.50rem"
+      }
+    }
+
+    const lineStyle = (line: ComplexKeyLine): Record<string, string> => {
+      const n = maxLevel.value + 1
+      const start = line.level + 1
+      const end = start + n + 1
+      return {
+        'grid-column-start': start.toString(),
+        'grid-column-end': end.toString(),
+      }
+    }
+
+    const lineText = (line: ComplexKeyLine): string => {
+      let result: string
+      if (line.key.thresholdKey) {
+        const childCount = line.key.thresholdKey.keys?.keys?.length ?? 0
+        result = line.key.key + "(" + line.key.thresholdKey.threshold + " of " + childCount + ")"
+      } else if (line.key.keyList) {
+        const childCount = line.key.keyList.keys?.length ?? 0
+        result = line.key.key + "(" + childCount + ")"
+      } else {
+        result = line.key.key ?? "?"
+      }
+      return result
+    }
+
+    return {
+      lines,
+      containerStyle,
+      lineStyle,
+      lineText
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped/>

--- a/src/components/values/ComplexKeyValue.vue
+++ b/src/components/values/ComplexKeyValue.vue
@@ -23,19 +23,26 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div :style="containerStyle()">
-    <template v-for="line in lines" :key="line.seqNb">
-      <div :style="lineStyle(line)">
-        <template v-if="line.innerKeyBytes() !== null">
-          <HexaValue :byte-string="line.innerKeyBytes()"/>
-          <div class="h-is-extra-text h-is-text-size-3">{{ line.innerKeyType() }}</div>
-        </template>
-        <template v-else>
-          <div>{{ lineText(line) }}</div>
-        </template>
-      </div>
-    </template>
+  <div v-if="key !== null">
+    <div :style="containerStyle()">
+      <template v-for="line in lines" :key="line.seqNb">
+        <div :style="lineStyle(line)">
+          <template v-if="line.innerKeyBytes() !== null">
+            <HexaValue :byte-string="line.innerKeyBytes()"/>
+            <div class="h-is-extra-text h-is-text-size-3">{{ line.innerKeyType() }}</div>
+          </template>
+          <template v-else>
+            <div>{{ lineText(line) }}</div>
+          </template>
+        </div>
+      </template>
+    </div>
   </div>
+  <div v-else-if="showNone && !initialLoading">
+    <div class="has-text-grey">None</div>
+  </div>
+  <div v-else/>
+
 </template>
 
 
@@ -45,11 +52,12 @@
 
 <script lang="ts">
 
-import {computed, defineComponent} from "vue";
+import {computed, defineComponent, inject, ref} from "vue";
 import {ComplexKeyLine} from "@/utils/ComplexKeyLine";
 import {hexToByte} from "@/utils/B64Utils";
 import hashgraph from "@hashgraph/proto/lib/proto";
 import HexaValue from "@/components/values/HexaValue.vue";
+import {initialLoadingKey} from "@/AppKeys";
 
 export default defineComponent({
   name: "ComplexKeyValue",
@@ -125,11 +133,15 @@ export default defineComponent({
       return result
     }
 
+    const initialLoading = inject(initialLoadingKey, ref(false))
+
     return {
+      key,
       lines,
       containerStyle,
       lineStyle,
-      lineText
+      lineText,
+      initialLoading
     }
   }
 })

--- a/src/components/values/KeyValue.vue
+++ b/src/components/values/KeyValue.vue
@@ -23,8 +23,15 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <HexaValue :byte-string="keyBytes" :show-none="showNone" :none-extra="noneExtra"/>
-  <div v-if="keyBytes" class="h-is-extra-text h-is-text-size-3">{{ this.keyType }}</div>
+  <template v-if="isComplexKey">
+    <ComplexKeyValue :key-bytes="keyBytes" :show-none="showNone"/>
+  </template>
+  <template v-else>
+    <div>
+      <HexaValue :byte-string="keyBytes" :show-none="showNone" :none-extra="noneExtra"/>
+      <div v-if="keyBytes" class="h-is-extra-text h-is-text-size-3">{{ this.keyType }}</div>
+    </div>
+  </template>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -33,12 +40,13 @@
 
 <script lang="ts">
 
-import {defineComponent} from "vue";
+import {computed, defineComponent} from "vue";
 import HexaValue from "@/components/values/HexaValue.vue";
+import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
 
 export default defineComponent({
   name: "KeyValue",
-  components: {HexaValue},
+  components: {ComplexKeyValue, HexaValue},
   props: {
     keyBytes: String,
     keyType: String,
@@ -47,6 +55,13 @@ export default defineComponent({
       default: false
     },
     noneExtra: String
+  },
+  setup(props) {
+
+    const isComplexKey = computed(() => props.keyType == "ProtobufEncoded")
+    return {
+      isComplexKey,
+    }
   }
 })
 

--- a/src/utils/ComplexKeyLine.ts
+++ b/src/utils/ComplexKeyLine.ts
@@ -1,0 +1,114 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import hashgraph from "@hashgraph/proto/lib/proto";
+import {byteToHex} from "@/utils/B64Utils";
+
+export class ComplexKeyLine {
+
+    public readonly key: hashgraph.proto.Key
+    public readonly level: number
+    public readonly seqNb: number
+
+    private static nextSeqNb = 0
+
+    //
+    // Public
+    //
+
+    public constructor(key: hashgraph.proto.Key, level: number) {
+        this.key = key
+        this.level = level
+        this.seqNb = ComplexKeyLine.nextSeqNb
+        ComplexKeyLine.nextSeqNb += 1
+    }
+
+    public static flattenComplexKey(key: hashgraph.proto.Key): ComplexKeyLine[] {
+        const result: ComplexKeyLine[] = []
+        this.flattenComplexKeyRec(key, 0, result)
+        return result
+    }
+
+    public innerKeyBytes(): string | null {
+        const bytes = this.key.ed25519 ?? this.key.ECDSASecp256k1 ?? this.key.ECDSA_384 ?? this.key.RSA_3072 ?? null
+        return bytes !== null ? byteToHex(bytes) : null
+    }
+
+    public innerKeyType(): string | null {
+        let result: string|null
+        if (this.key.ed25519) {
+            result = "ED25519"
+        } else if (this.key.ECDSASecp256k1) {
+            result = "ECDSA"
+        } else if (this.key.RSA_3072) {
+            result = "RSA_3072"
+        } else if (this.key.ECDSA_384) {
+            result = "ECDSA_384"
+        } else {
+            result = null
+        }
+        return result
+    }
+
+    public toString(): string {
+        return "" + this.level + " " + this.key.key
+    }
+
+    public static dump(lines: ComplexKeyLine[]): string {
+        let result = ""
+        for (const l of lines) {
+            result += l.toString() + "\n"
+        }
+        return result
+    }
+
+    //
+    // Private
+    //
+
+    public static flattenComplexKeyRec(key: hashgraph.proto.Key, level: number, result: ComplexKeyLine[]): void {
+
+        let newLine: ComplexKeyLine
+        let childKeys: hashgraph.proto.Key[]
+        if (key.keyList) {
+            if (key.keyList.keys && key.keyList.keys.length == 1) {
+                // Collapses singleton KeyList
+                newLine = new ComplexKeyLine(key.keyList.keys[0], level)
+                childKeys = []
+            } else {
+                newLine = new ComplexKeyLine(key, level)
+                childKeys = key.keyList?.keys ?? []
+            }
+            // newLine = new ComplexKeyLine(key, level)
+            // childKeys = key.keyList?.keys ?? []
+        } else if (key.thresholdKey) {
+            newLine = new ComplexKeyLine(key, level)
+            childKeys = key.thresholdKey?.keys?.keys ?? []
+        } else {
+            newLine = new ComplexKeyLine(key, level)
+            childKeys = []
+        }
+        result.push(newLine)
+
+        for (const childKey of childKeys) {
+            this.flattenComplexKeyRec(childKey, level + 1, result)
+        }
+    }
+}

--- a/tests/unit/utils/ComplexKeyLine.spec.ts
+++ b/tests/unit/utils/ComplexKeyLine.spec.ts
@@ -1,0 +1,43 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {ComplexKeyLine} from "@/utils/ComplexKeyLine";
+import hashgraph from "@hashgraph/proto/lib/proto";
+import {hexToByte} from "@/utils/B64Utils";
+
+const COMPLEX_KEY = "0x2a880208021283020a562a54080112500a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390aa8012aa501080212a0010a2632240a221220c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e06340a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a2632240a221220daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
+
+
+describe("ComplexKeyLine.ts", () => {
+
+    test("0.0.4 key", () => {
+
+        const keyBytes = hexToByte(COMPLEX_KEY)
+        expect(keyBytes).not.toBeNull()
+
+        const key = hashgraph.proto.Key.decode(keyBytes!)
+        expect(key).not.toBeNull()
+
+        const lines = ComplexKeyLine.flattenComplexKey(key)
+        expect(lines.length).toBe(9)
+    })
+
+})
+

--- a/tests/unit/values/ComplexKeyValue.spec.ts
+++ b/tests/unit/values/ComplexKeyValue.spec.ts
@@ -1,0 +1,77 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+import router from "@/router";
+import {mount} from "@vue/test-utils";
+import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
+
+describe("ComplexKeyValue.vue", () => {
+
+    const COMPLEX_KEY = "0x2a880208021283020a562a54080112500a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390aa8012aa501080212a0010a2632240a221220c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e06340a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a2632240a221220daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
+
+    it("props.keyBytes set", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(ComplexKeyValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                keyBytes: COMPLEX_KEY
+            },
+        });
+
+        expect(wrapper.text()).toBe("thresholdKey(2 of 2)thresholdKey(1 of 2)ef2d 877b 88b7 464d 9253 560b 8851 316f 5c2f 6ddf 935e b4ee c076 1a32 62b0 a48cCopy to ClipboardED25519a95d 54cf 49c1 d08c d16d 8908 f37d fad9 5637 134f faf5 28a1 d96d a7f2 8d45 f139Copy to ClipboardED25519thresholdKey(2 of 4)c44c 911f a451 66e3 56b4 9846 3184 459d d9ee 760b acc0 83de 3486 91d6 357e 0634Copy to ClipboardED25519ef2d 877b 88b7 464d 9253 560b 8851 316f 5c2f 6ddf 935e b4ee c076 1a32 62b0 a48cCopy to ClipboardED25519a95d 54cf 49c1 d08c d16d 8908 f37d fad9 5637 134f faf5 28a1 d96d a7f2 8d45 f139Copy to ClipboardED25519daa5 da86 6bf4 e990 c14e ff43 36f5 ab4b 416c 85a3 1289 c8cb 8ae1 b4a5 4ce8 c111Copy to ClipboardED25519")
+    });
+
+    it("props.keyBytes unset, showNone=false", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(ComplexKeyValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+            },
+        });
+
+        expect(wrapper.text()).toBe("")
+    });
+
+    it("props.keyBytes unset, showNone=true", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(ComplexKeyValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                showNone: true
+            },
+        });
+
+        expect(wrapper.text()).toBe("None")
+    });
+
+})


### PR DESCRIPTION
**Description**:

Changes below enable Explorer to decode and display complex keys (aka protobuf encoded keys).

**Related issue(s)**:

Fixes #131 

**Notes for reviewer**:

Sample accounts with complex keys (on mainnet):
- [0.0.2](https://hashscan-latest.hedera-devops.com/mainnet/account/0.0.2) // The big one
- [0.0.4](https://hashscan-latest.hedera-devops.com/mainnet/account/0.0.4?p3=1&k3=1667487924.110982197&p2=1&k2=1667488019.986301071&p1=1&k1=1667488019.743429090&p=1&k=1667488037.609174426)
- [0.0.88](https://hashscan-latest.hedera-devops.com/mainnet/account/0.0.88)
- [0.0.800](https://hashscan-latest.hedera-devops.com/mainnet/account/0.0.800) // The strange one

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
