### PR TITLE
00307 Navigating back from Transaction details to Account details does not preserve pagination).

### DIFF
--- a/src/components/transaction/TransactionTableControllerXL.ts
+++ b/src/components/transaction/TransactionTableControllerXL.ts
@@ -44,9 +44,15 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
             pageParamName, keyParamName);
         this.accountId = accountId
         this.accountIdMandatory = accountIdMandatory
-        this.watchAndReload([this.transactionType, this.accountId])
+        this.watchAndReload([this.transactionType])
         // this.accountId cannot be treated as this.transactionType :
         // when this.accountId changes, we don't want to move to auto-refresh mode.
+        watch(this.accountId, () => {
+            if (this.mounted.value) {
+                this.unmount()
+                this.mount()
+            }
+        })
     }
 
     public readonly transactionType: Ref<string> = ref("")

--- a/tests/unit/transaction/TransactionTableControllerXL.spec.ts
+++ b/tests/unit/transaction/TransactionTableControllerXL.spec.ts
@@ -131,7 +131,7 @@ describe("TransactionTableController.ts", () => {
         accountId.value = "0.0.4" // Value is unimportant
         await flushPromises()
         expect(tc.pageSize.value).toBe(PAGE_SIZE)
-        expect(tc.autoRefresh.value).toBe(true)
+        expect(tc.autoRefresh.value).toBe(false)
         expect(tc.autoStopped.value).toBe(false)
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loading.value).toBe(false)


### PR DESCRIPTION

Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Changes below fix TransactionTableControllerXL (and also fix wrong unit ... :( ...)
See #307 for details.

**Related issue(s)**:

Fixes #307

**Notes for reviewer**:

See #307 for details.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
