### PR TITLE
00307 Navigating back from Transaction details to Account details does not preserve pagination (Take #2)

### DIFF
--- a/src/components/transaction/TransactionTableControllerXL.ts
+++ b/src/components/transaction/TransactionTableControllerXL.ts
@@ -44,15 +44,7 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
             pageParamName, keyParamName);
         this.accountId = accountId
         this.accountIdMandatory = accountIdMandatory
-        this.watchAndReload([this.transactionType])
-        // this.accountId cannot be treated as this.transactionType :
-        // when this.accountId changes, we don't want to move to auto-refresh mode.
-        watch(this.accountId, () => {
-            if (this.mounted.value) {
-                this.unmount()
-                this.mount()
-            }
-        })
+        this.watchAndReload([this.transactionType, this.accountId])
     }
 
     public readonly transactionType: Ref<string> = ref("")

--- a/tests/unit/transaction/TransactionTableControllerXL.spec.ts
+++ b/tests/unit/transaction/TransactionTableControllerXL.spec.ts
@@ -126,12 +126,12 @@ describe("TransactionTableController.ts", () => {
 
         // Setup account id
         // After setup:
-        //      - auto-refresh is disabled
+        //      - auto-refresh is enabled
         //      - row array contains transactions from SAMPLE_CONTRACTCALL_TRANSACTIONS
         accountId.value = "0.0.4" // Value is unimportant
         await flushPromises()
         expect(tc.pageSize.value).toBe(PAGE_SIZE)
-        expect(tc.autoRefresh.value).toBe(false)
+        expect(tc.autoRefresh.value).toBe(true)
         expect(tc.autoStopped.value).toBe(false)
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loading.value).toBe(false)


### PR DESCRIPTION
Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Changes below override previous fix for #307 which is not working correctly.
#307 cannot be fixed correctly at TableController level.
It is now fixed at AccountDetails page level.

**Related issue(s)**:

Fixes #307

**Notes for reviewer**:

Fix is deployed on staging server:
https://hashscan-latest.hedera-devops.com/mainnet/account/0.0.21

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
