### PR TITLE
00305 fix html meta tags

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,13 @@
 VUE_APP_PRODUCT_NAME="Hedera Mirror Node Explorer"
 
 ### The prefix used in the document title
-VUE_APP_DOCUMENT_TITLE_PREFIX="Hedera"
+# VUE_APP_DOCUMENT_TITLE_SUFFIX="<suffix>"
+
+### The content of meta tag: name="description"
+# VUE_APP_META_DESCRIPTION="<description>"
+
+### The content of meta tag: property="og:url"
+# VUE_APP_META_URL="<URL of product>"
 
 ### The URL to which a click on the bottom-right sponsor logo will navigate
 # VUE_APP_SPONSOR_URL="<URL of sponsor>"

--- a/src/router.ts
+++ b/src/router.ts
@@ -342,24 +342,37 @@ export function addMetaTags(): void {
       ?? "Hedera Mirror Node Explorer is a ledger explorer for the Hedera network"
   const url = process.env.VUE_APP_META_URL
 
-  const header = document.getElementsByTagName('head')[0]
-
-  const metaDescription = document.createElement('meta');
-  metaDescription.name = 'description';
-  metaDescription.setAttribute('content', description);
-  header.appendChild(metaDescription);
-
-  const metaTitle = document.createElement('meta');
-  metaTitle.setAttribute('property', 'og:title')
-  metaTitle.setAttribute('content', title)
-  header.appendChild(metaTitle);
-
+  createOrUpdateTagName('description', description)
+  createOrUpdateTagProperty('og:title', title)
   if (url) {
-    const metaUrl = document.createElement('meta');
-    metaUrl.setAttribute('property', 'og:url')
-    metaUrl.setAttribute('content', url)
-    header.appendChild(metaUrl);
+    createOrUpdateTagProperty('og:url', url)
   }
+}
+
+export function createOrUpdateTagName(name: string, content: string): void {
+  const header = document.getElementsByTagName('head')[0]
+  for (const tag of document.getElementsByTagName('meta')) {
+    if (tag.getAttribute('name') === name) {
+      header.removeChild(tag)
+    }
+  }
+  const newTag = document.createElement('meta')
+  newTag.name = name
+  newTag.setAttribute('content', content)
+  header.appendChild(newTag)
+}
+
+export function createOrUpdateTagProperty(property: string, content: string): void {
+  const header = document.getElementsByTagName('head')[0]
+  for (const tag of document.getElementsByTagName('meta')) {
+    if (tag.getAttribute('property') === property) {
+      header.removeChild(tag)
+    }
+  }
+  const newTag = document.createElement('meta')
+  newTag.setAttribute('property', property)
+  newTag.setAttribute('content', content)
+  header.appendChild(newTag)
 }
 
 export function getNetworkEntryFromRoute(r: RouteLocationNormalized): NetworkEntry | null {

--- a/src/router.ts
+++ b/src/router.ts
@@ -286,39 +286,47 @@ router.beforeEach((to, from) => {
 })
 
 router.beforeEach((to) => {
-  const titlePrefix = process.env.VUE_APP_DOCUMENT_TITLE_PREFIX ?? "Hedera"
+  const titleSuffix = process.env.VUE_APP_DOCUMENT_TITLE_SUFFIX ? " | " + process.env.VUE_APP_DOCUMENT_TITLE_SUFFIX : ""
 
   switch (to.name as string) {
     case "MainDashboard":
-      document.title = titlePrefix + " | Dashboard";
+      document.title = "Hedera Dashboard" + titleSuffix
       break;
     case "TransactionDetails":
-      document.title = titlePrefix + " | Transaction " + to.params.transactionId;
+      document.title = "Hedera Transaction " + to.params.transactionId + titleSuffix
       break;
     case "TokenDetails":
-      document.title = titlePrefix + " | Token " + to.params.tokenId;
+      document.title = "Hedera Token " + to.params.tokenId + titleSuffix
       break;
     case "TopicDetails":
-      document.title = titlePrefix + " | Topic " + to.params.topicId;
+      document.title = "Hedera Topic " + to.params.topicId + titleSuffix
       break;
     case "ContractDetails":
-      document.title = titlePrefix + " | Contract " + to.params.contractId;
+      document.title = "Hedera Contract " + to.params.contractId + titleSuffix
       break;
     case "AccountDetails":
-      document.title = titlePrefix + " | Account " + to.params.accountId;
+      document.title = "Hedera Account " + to.params.accountId + titleSuffix
       break;
     case "AccountBalances":
-      document.title = titlePrefix + " | Balances for Account " + to.params.accountId;
+      document.title = "Balances for Hedera Account " + to.params.accountId + titleSuffix
+      break;
+    case "NodeDetails":
+      document.title = "Hedera Node " + to.params.nodeId + titleSuffix
+      break;
+    case "BlockDetails":
+      document.title = "Hedera Block " + to.params.blockHon + titleSuffix
       break;
     case "NoSearchResult":
-      document.title = titlePrefix + " | Search Results";
+      document.title = "Search Results" + titleSuffix
       break;
     case "PageNotFound":
-      document.title = titlePrefix + " | Page Not Found";
+      document.title = "Page Not Found" + titleSuffix
       break;
     default:
-      document.title = titlePrefix + " | " + (to.name as string);
+      document.title = "Hedera " + (to.name as string) + titleSuffix
   }
+
+  addMetaTags()
 });
 
 router.beforeEach(() => {
@@ -326,6 +334,33 @@ router.beforeEach(() => {
 })
 
 export default router
+
+export function addMetaTags(): void {
+
+  const title = document.title
+  const description = process.env.VUE_APP_META_DESCRIPTION
+      ?? "Hedera Mirror Node Explorer is a ledger explorer for the Hedera network"
+  const url = process.env.VUE_APP_META_URL
+
+  const header = document.getElementsByTagName('head')[0]
+
+  const metaDescription = document.createElement('meta');
+  metaDescription.name = 'description';
+  metaDescription.setAttribute('content', description);
+  header.appendChild(metaDescription);
+
+  const metaTitle = document.createElement('meta');
+  metaTitle.setAttribute('property', 'og:title')
+  metaTitle.setAttribute('content', title)
+  header.appendChild(metaTitle);
+
+  if (url) {
+    const metaUrl = document.createElement('meta');
+    metaUrl.setAttribute('property', 'og:url')
+    metaUrl.setAttribute('content', url)
+    header.appendChild(metaUrl);
+  }
+}
 
 export function getNetworkEntryFromRoute(r: RouteLocationNormalized): NetworkEntry | null {
 


### PR DESCRIPTION
**Description**:

The following changes make use of new environment variables to control the meta tags:
- `property="og:url"` 
- `name="description"`

They also rework the structure of the document title and set the meta tag `property="og:title"` with the same value.

**Related issue(s)**:

Fixes #305 