### PR TITLE
00317 staking fixes

### DIFF
--- a/.run/serve_https with branding.run.xml
+++ b/.run/serve_https with branding.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="serve:https with branding" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="serve:https" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs>
+      <env name="BRANDING_LOCATION" value="../branding" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/components/values/TransactionLink.vue
+++ b/src/components/values/TransactionLink.vue
@@ -26,7 +26,7 @@
 
   <div v-if="transactionId">
     <router-link :to="{name: 'TransactionDetails', params: {transactionId: transactionId}}">
-      <span class="is-numeric">{{ normalizedId }}</span>
+      <span class="is-numeric should-wrap">{{ normalizedId }}</span>
     </router-link>
   </div>
 

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -233,7 +233,6 @@ import {networkRegistry} from "@/schemas/NetworkRegistry";
 import router from "@/router";
 import {TransactionByTimestampLoader} from "@/components/transaction/TransactionByTimestampLoader";
 import TransactionLink from "@/components/values/TransactionLink.vue";
-import {HMSF} from "@/utils/HMSF";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -390,7 +389,10 @@ export default defineComponent({
       day: "numeric",
       month: "short",
       year: "numeric",
-      timeZone: HMSF.forceUTC ? "UTC" : undefined
+      minute: "numeric",
+      second: "numeric",
+      timeZoneName: "short",
+      timeZone: "UTC"
     }
     const stakedSince = computed(() => {
       const dateFormat = new Intl.DateTimeFormat(locale, dateOptions)

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -87,23 +87,21 @@
       </template>
 
       <template v-slot:leftContent>
-              <Property v-if="account?.staked_account_id" id="stakedAccount">
-                <template v-slot:name>Staked to Account</template>
-                <template v-slot:value>
-                  <AccountLink :accountId="account.staked_account_id" v-bind:show-extra="true"/>
+              <Property id="stakedTo">
+                <template v-slot:name>
+                  <span v-if="stakedAccountId">Staked to Account</span>
+                  <span v-else-if="stakedNodeId">Staked to Node</span>
+                  <span v-else>Staked to</span>
                 </template>
-              </Property>
-              <Property v-else id="stakedNode">
-                <template v-slot:name>Staked to Node</template>
                 <template v-slot:value>
-                  <div v-if="account?.staked_node_id != null">
-                    <router-link :to="{name: 'NodeDetails', params: {nodeId: account?.staked_node_id}}">
-                      {{ account?.staked_node_id }} - {{ stakedNodeDescription }}
-                    </router-link>
-                  </div>
+                  <AccountLink v-if="stakedAccountId" :accountId="account.staked_account_id" v-bind:show-extra="true"/>
+                  <router-link v-else-if="stakedNodeId" :to="{name: 'NodeDetails', params: {nodeId: account?.staked_node_id}}">
+                    {{ account?.staked_node_id }} - {{ stakedNodeDescription }}
+                  </router-link>
                   <span v-else class="has-text-grey">None</span>
                 </template>
               </Property>
+
               <Property id="pendingReward">
                 <template v-slot:name>Pending Reward</template>
                 <template v-slot:value>
@@ -431,6 +429,8 @@ export default defineComponent({
       elapsed,
       showContractVisible,
       stakedSince,
+      stakedNodeId: accountLoader.stakedNodeId,
+      stakedAccountId: accountLoader.stakedAccountId,
       stakedNodeDescription: stakeNodeLoader.nodeDescription,
       accountCreateTransactionId: accountCreateTransaction.transactionId,
       accountCreatorId: accountCreateTransaction.payerAccountId

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -69,13 +69,21 @@
         <template v-if="accountId">
           <div v-if="isSmallScreen">
             <div class="is-flex is-justify-content-space-between">
-              <NetworkDashboardItem :name="stakedSince" title="Staked to" :value="stakedTo"/>
-              <NetworkDashboardItem :name="stakedAmount ? 'HBAR' : ''" title="My Stake" :value="stakedAmount"/>
+              <NetworkDashboardItem :name="stakedSince"
+                                    title="Staked to"
+                                    :value="stakedTo"/>
+
+              <NetworkDashboardItem class="ml-4"
+                                    :name="stakedAmount ? 'HBAR' : ''"
+                                    title="My Stake"
+                                    :value="stakedAmount"/>
 
               <NetworkDashboardItem v-if="!ignoreReward && declineReward && !pendingReward"
+                                    class="ml-4"
                                     title="Rewards"
                                     value="Declined"/>
               <NetworkDashboardItem v-else
+                                    class="ml-4"
                                     title="Pending Reward"
                                     :name="pendingReward ? 'HBAR' : ''"
                                     :value="pendingReward"
@@ -188,7 +196,6 @@ import {walletManager} from "@/router";
 import NetworkDashboardItem from "@/components/node/NetworkDashboardItem.vue";
 import axios from "axios";
 import {Transaction, TransactionByIdResponse} from "@/schemas/HederaSchemas";
-import {HMSF} from "@/utils/HMSF";
 import {waitFor} from "@/utils/TimerUtils";
 import RewardsTransactionTable from "@/components/staking/RewardsTransactionTable.vue";
 import StakingDialog from "@/components/staking/StakingDialog.vue";
@@ -338,7 +345,10 @@ export default defineComponent({
       day: "numeric",
       month: "short",
       year: "numeric",
-      timeZone: HMSF.forceUTC ? "UTC" : undefined
+      minute: "numeric",
+      second: "numeric",
+      timeZoneName: "short",
+      timeZone: "UTC"
     }
     const dateFormat = new Intl.DateTimeFormat(locale, dateOptions)
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1455,7 +1455,7 @@ export const SAMPLE_ACCOUNT_STAKING_NODE = {
     "decline_reward": false,
     "staked_node_id": 1,
     "staked_account_id": null,
-    "stake_period_start" : "1646333100.356842286"
+    "stake_period_start" : "1668124800.000000000"
 }
 
 export const SAMPLE_ACCOUNT_STAKING_ACCOUNT = {
@@ -1478,7 +1478,7 @@ export const SAMPLE_ACCOUNT_STAKING_ACCOUNT = {
     "decline_reward": true,
     "staked_node_id": null,
     "staked_account_id": "0.0.5",
-    "stake_period_start": "1646333100.356842286",
+    "stake_period_start": "1668124800.000000000",
     "pending_reward": 12345678
 }
 

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -129,6 +129,9 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("false")
 
+        expect(wrapper.get("#stakedToName").text()).toBe("Staked to")
+        expect(wrapper.get("#stakedToValue").text()).toBe("None")
+
         expect(wrapper.find("#recentTransactions").exists()).toBe(true)
         expect(wrapper.findComponent(TransactionTable).exists()).toBe(true)
     });
@@ -311,8 +314,8 @@ describe("AccountDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.html())
 
-        expect(wrapper.get("#stakedNodeValue").text()).toBe("1 - Hosted by Hedera | East Coast, USA")
-        expect(wrapper.find("#stakedAccount").exists()).toBe(false)
+        expect(wrapper.get("#stakedToName").text()).toBe("Staked to Node")
+        expect(wrapper.get("#stakedToValue").text()).toBe("1 - Hosted by Hedera | East Coast, USA")
         expect(wrapper.get("#pendingRewardValue").text()).toBe("0.00000000$0.0000Period Started Mar 3, 2022")
         expect(wrapper.get("#declineRewardValue").text()).toBe("Accepted")
     });
@@ -351,8 +354,8 @@ describe("AccountDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.html())
 
-        expect(wrapper.get("#stakedAccountValue").text()).toBe("0.0.5Node 2 - testnet")
-        expect(wrapper.find("#stakedNodeValue").exists()).toBe(false)
+        expect(wrapper.get("#stakedToName").text()).toBe("Staked to Account")
+        expect(wrapper.get("#stakedToValue").text()).toBe("0.0.5Node 2 - testnet")
         expect(wrapper.get("#pendingRewardValue").text()).toBe("0.12345678$0.0304Period Started Mar 3, 2022")
         expect(wrapper.find("#declineRewardValue").exists()).toBe(false)
     });

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -316,7 +316,7 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.get("#stakedToName").text()).toBe("Staked to Node")
         expect(wrapper.get("#stakedToValue").text()).toBe("1 - Hosted by Hedera | East Coast, USA")
-        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.00000000$0.0000Period Started Mar 3, 2022")
+        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.00000000$0.0000Period Started Nov 11, 2022, 00:00 UTC")
         expect(wrapper.get("#declineRewardValue").text()).toBe("Accepted")
     });
 
@@ -356,7 +356,7 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.get("#stakedToName").text()).toBe("Staked to Account")
         expect(wrapper.get("#stakedToValue").text()).toBe("0.0.5Node 2 - testnet")
-        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.12345678$0.0304Period Started Mar 3, 2022")
+        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.12345678$0.0304Period Started Nov 11, 2022, 00:00 UTC")
         expect(wrapper.find("#declineRewardValue").exists()).toBe(false)
     });
 });

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -137,7 +137,7 @@ describe("Staking.vue", () => {
         // 1.3) Checks staking information
         const ndis = wrapper.findAllComponents(NetworkDashboardItem)
         expect(ndis.length).toBeGreaterThanOrEqual(3)
-        expect(ndis[0].text()).toBe("Staked toAccount 0.0.5since Mar 3, 2022")
+        expect(ndis[0].text()).toBe("Staked toAccount 0.0.5since Nov 11, 2022, 00:00 UTC")
         expect(ndis[1].text()).toBe("My Stake0.31669471HBAR")
         expect(ndis[2].text()).toBe("Pending RewardNone")
 
@@ -213,7 +213,7 @@ describe("Staking.vue", () => {
             "Updating stakingOperation completedwith transaction ID:0.0.29624024@1646025139.152901498CLOSE")
 
         // 2.8) Checks staking information
-        expect(ndis[0].text()).toBe("Staked toAccount 0.0.7since Mar 3, 2022")
+        expect(ndis[0].text()).toBe("Staked toAccount 0.0.7since Nov 11, 2022, 00:00 UTC")
         expect(ndis[1].text()).toBe("My Stake0.31669471HBAR")
         expect(ndis[2].text()).toBe("Pending RewardNone")
 
@@ -270,7 +270,7 @@ describe("Staking.vue", () => {
         expect(testDriver.account.decline_reward).toBeTruthy()
 
         // 3.8) Checks staking information
-        expect(ndis[0].text()).toBe("Staked toNode 2 - Hosted by Hedera since Mar 3, 2022")
+        expect(ndis[0].text()).toBe("Staked toNode 2 - Hosted by Hedera since Nov 11, 2022, 00:00 UTC")
         expect(ndis[1].text()).toBe("My Stake0.31669471HBAR")
         expect(ndis[2].text()).toBe("Pending RewardNone")
 
@@ -314,7 +314,7 @@ describe("Staking.vue", () => {
         expect(testDriver.account.decline_reward).toBeFalsy()
 
         // 4.8) Checks staking information
-        expect(ndis[0].text()).toBe("Staked toNode 2 - Hosted by Hedera since Mar 3, 2022")
+        expect(ndis[0].text()).toBe("Staked toNode 2 - Hosted by Hedera since Nov 11, 2022, 00:00 UTC")
         expect(ndis[1].text()).toBe("My Stake0.31669471HBAR")
         expect(ndis[2].text()).toBe("Pending RewardNone")
 


### PR DESCRIPTION
**Description**:

With these changes, the AccountDetails view will display one of the following:

- `Staked to Node ........... NN hosted by XYZ`
- `Staked to Account ........ 0.0.12345`
- `Staked to ................ None`

Also, the stake_period_start is now displayed including its UTC time in addition to the date.

**Related issue(s)**:

Fixes #317 

**Notes for reviewer**:

Examples:

- [account staking to node](https://hashscan-latest.hedera-devops.com/testnet/account/0.0.47813131)
- [account staking to another account](https://hashscan-latest.hedera-devops.com/testnet/account/0.0.15818224)
- [account not staking](https://hashscan-latest.hedera-devops.com/testnet/account/0.0.3)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
