### PR TITLE
00314 search txn using timestamp

### DIFF
--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -51,6 +51,7 @@
           an entity ID (0.0.x),<br/>
           a transaction ID (0.0.x@seconds.nanoseconds),<br/>
           a transaction hash (48 bytes in hexadecimal notation),<br/>
+          a transaction timestamp (seconds.nanoseconds),<br/>
           an ethereum address (20 bytes in hexadecimal notation),<br/>
           an account public key (32 or 33 bytes in hexadecimal notation),<br/>
           an account alias (string in base 32 or hexadecimal notation).<br/>

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -111,6 +111,18 @@ describe('Search Bar', () => {
         )
     })
 
+    it('should find the transaction by timestamp', () => {
+        const searchTimestamp = "1669195027.532177053"
+        const transactionId = "0.0.282498@1669195016.605846807"
+        testBody(
+            transactionId,
+            '/testnet/transaction/' + normalizeTransactionId(transactionId),
+            'Transaction ',
+            false,
+            searchTimestamp
+        )
+    })
+
     it('should find the NFT ID', () => {
         const searchNFT = "0.0.30961728"
         testBody(searchNFT, '/testnet/token/' + searchNFT, 'Token ', true)

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -98,17 +98,18 @@ describe('Search Bar', () => {
             .should('contain', 'Child')  // criteria to check
     })
 
-    //
-    // To be uncommented when api/v1/transactions accepts transaction hash
-    //
-    // it('should find the transaction by hash', () => {
-    //     const searchTransaction = "0x1dc948b993ec66c161f83d8c686b641152d5a6f49b79550db9a22dd0d44cb60cd814c50c3b8abdabb8bc3d457adbfc38"
-    //     testBody(
-    //         searchTransaction,
-    //         '/testnet/transaction/' + searchTransaction,
-    //         'Transaction '
-    //     )
-    // })
+    it('should find the transaction by hash', () => {
+        cy.visit('/mainnet/dashboard')
+        const searchHash = "0xe4c9408e65d41bb0b3a417065e0cd98c1fedc98663db7c06909cb63e0236f39848d80fd006da39326800cb896898a85a"
+        const transactionId = "0.0.19789@1669194618.004968459"
+        testBody(
+            transactionId,
+            '/mainnet/transaction/' + normalizeTransactionId(transactionId),
+            'Transaction ',
+            false,
+            searchHash
+        )
+    })
 
     it('should find the NFT ID', () => {
         const searchNFT = "0.0.30961728"
@@ -160,9 +161,17 @@ describe('Search Bar', () => {
 
 })
 
-const testBody = (searchID: string, expectedPath: string, expectedTitle: string = null, expectTable = false) => {
+const testBody = (searchID: string,
+                  expectedPath: string,
+                  expectedTitle: string = null,
+                  expectTable = false,
+                  searchString: string = null) => {
     cy.get('[data-cy=searchBar]').within(() => {
-        cy.get('input').type(searchID)
+        if (searchString !== null) {
+            cy.get('input').type(searchString )
+        } else {
+            cy.get('input').type(searchID)
+        }
     }).submit()
 
     cy.url({timeout: 5000}).should('include', expectedPath)


### PR DESCRIPTION
**Description**:

These changes allow to search transactions using their timestamp using the Hedera format:  "seconds.nanoseconds"
**Related issue(s)**:

Fixes #314 

**Notes for reviewer**:

Deployed on staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (e2e)
