### PR TITLE
00016 display message content in HCS SUBMIT MESSAGE transaction

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,7 @@ export default defineComponent({
     provide('isTouchDevice', isTouchDevice)
 
     const windowWidth = ref(window.screen.width)
+    provide('windowWidth', windowWidth)
 
     const isSmallScreen = computed(() => {
       return windowWidth.value > SMALL_BREAKPOINT

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -191,6 +191,15 @@ body {
     content: "\210F";
     font-weight: lighter;
 }
+.h-is-json {
+    white-space: pre-wrap;
+}
+.h-is-one-line {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
 .w200 {
     max-width: 200px;
     overflow: hidden;

--- a/src/components/topic/TopicMessage.vue
+++ b/src/components/topic/TopicMessage.vue
@@ -1,0 +1,117 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <div v-if="message">
+
+    <DashboardCard class="h-card">
+      <template v-slot:title>
+        <span class="h-is-secondary-title">Message Submitted</span>
+      </template>
+      <template v-slot:content>
+        <Property id="sequenceNumber" :full-width="true">
+          <template v-slot:name>Sequence Number</template>
+          <template v-slot:value>
+            {{ sequence_number }}
+          </template>
+        </Property>
+        <Property id="message" :full-width="true">
+          <template v-slot:name>Message</template>
+          <template v-slot:value>
+            <BlobValue :blob-value="message" :show-none="true" :base64="true" :pretty="true" class="should-wrap is-numeric"/>
+          </template>
+        </Property>
+        <Property id="runningHashVersion" :full-width="true">
+          <template v-slot:name>Running Hash Version</template>
+          <template v-slot:value>
+            <PlainAmount :amount="running_hash_version"/>
+          </template>
+        </Property>
+        <Property id="runningHash" :full-width="true">
+          <template v-slot:name>Running Hash</template>
+          <template v-slot:value>
+            <BlobValue :blob-value="running_hash" :show-none="true" class="should-wrap is-numeric"/>
+          </template>
+        </Property>
+      </template>
+    </DashboardCard>
+
+  </div>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, inject, PropType} from 'vue';
+import DashboardCard from "@/components/DashboardCard.vue";
+import Property from "@/components/Property.vue";
+import PlainAmount from "@/components/values/PlainAmount.vue";
+import {TopicMessageLoader} from "@/components/topic/TopicMessageLoader";
+import BlobValue from "@/components/values/BlobValue.vue";
+
+export default defineComponent({
+
+  name: 'TopicMessage',
+
+  components: {
+    PlainAmount,
+    BlobValue,
+    Property,
+    DashboardCard
+  },
+
+  props: {
+    messageLoader: {
+      type: Object as PropType<TopicMessageLoader>,
+      required: true
+    }
+  },
+
+  setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+
+    return {
+      isSmallScreen,
+      isTouchDevice,
+      sequence_number: props.messageLoader.sequence_number,
+      message: props.messageLoader.message,
+      running_hash_version: props.messageLoader.running_hash_version,
+      running_hash: props.messageLoader.running_hash
+    }
+  },
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/components/topic/TopicMessageLoader.ts
+++ b/src/components/topic/TopicMessageLoader.ts
@@ -1,0 +1,62 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {TopicMessage} from "@/schemas/HederaSchemas";
+import {EntityLoader} from "@/utils/loader/EntityLoader";
+import axios, {AxiosResponse} from "axios";
+import {computed, ComputedRef, Ref} from "vue";
+
+export class TopicMessageLoader extends EntityLoader<TopicMessage> {
+
+    public readonly timestamp: Ref<string|null>
+
+    //
+    // Public
+    //
+
+    public constructor(timestamp: Ref<string|null>) {
+        super()
+        this.timestamp = timestamp
+        this.watchAndReload([this.timestamp])
+    }
+
+    public readonly message: ComputedRef<string|null> = computed(() => this.entity.value?.message ?? null)
+
+    public readonly sequence_number: ComputedRef<number|null> = computed(() => this.entity.value?.sequence_number ?? null)
+
+    public readonly running_hash_version: ComputedRef<number|null> = computed(() => this.entity.value?.running_hash_version ?? null)
+
+    public readonly running_hash: ComputedRef<string|null> = computed(() => this.entity.value?.running_hash ?? null)
+
+    //
+    // EntityLoader
+    //
+
+    protected async load(): Promise<AxiosResponse<TopicMessage>|null> {
+        console.log("load - timestamp: " + this.timestamp.value)
+        let result: Promise<AxiosResponse<TopicMessage>|null>
+        if (this.timestamp.value != null) {
+            result = axios.get<TopicMessage>("api/v1/topics/messages/" + this.timestamp.value)
+        } else {
+            result = Promise.resolve(null)
+        }
+        return result
+    }
+}

--- a/src/components/topic/TopicMessageLoader.ts
+++ b/src/components/topic/TopicMessageLoader.ts
@@ -25,13 +25,13 @@ import {computed, ComputedRef, Ref} from "vue";
 
 export class TopicMessageLoader extends EntityLoader<TopicMessage> {
 
-    public readonly timestamp: Ref<string|null>
+    public readonly timestamp: Ref<string>
 
     //
     // Public
     //
 
-    public constructor(timestamp: Ref<string|null>) {
+    public constructor(timestamp: Ref<string>) {
         super()
         this.timestamp = timestamp
         this.watchAndReload([this.timestamp])
@@ -52,7 +52,8 @@ export class TopicMessageLoader extends EntityLoader<TopicMessage> {
     protected async load(): Promise<AxiosResponse<TopicMessage>|null> {
         console.log("load - timestamp: " + this.timestamp.value)
         let result: Promise<AxiosResponse<TopicMessage>|null>
-        if (this.timestamp.value != null) {
+
+        if (this.timestamp.value) {
             result = axios.get<TopicMessage>("api/v1/topics/messages/" + this.timestamp.value)
         } else {
             result = Promise.resolve(null)

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -33,9 +33,10 @@
         :total="total"
         v-model:current-page="currentPage"
         :per-page="perPage"
+        focusable
         @page-change="onPageChange"
+        @click="handleClick"
 
-        :striped="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
         aria-current-label="Current page"
@@ -79,6 +80,8 @@ import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TopicMessage} from "@/schemas/HederaSchemas";
+import router from "@/router";
+import {TransactionID} from "@/utils/TransactionID";
 
 export default defineComponent({
 
@@ -97,6 +100,20 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
+    const handleClick = (t: TopicMessage) => {
+      const entityId = t.chunk_info?.initial_transaction_id.account_id
+      const timestamp = t.chunk_info?.initial_transaction_id.transaction_valid_start
+      if (entityId && timestamp) {
+        const transactionId = TransactionID.parse(entityId + '@' + timestamp)
+        if (transactionId) {
+          router.push({
+            name: 'TransactionDetails',
+            params: {transactionId: transactionId.toString(false)},
+            query: {t: t.consensus_timestamp}})
+        }
+      }
+    }
+
     return {
       isTouchDevice,
       isMediumScreen,
@@ -107,7 +124,8 @@ export default defineComponent({
       onPageChange: props.controller.onPageChange,
       perPage: props.controller.pageSize as Ref<number>,
       paginated: props.controller.paginated,
-      ORUGA_MOBILE_BREAKPOINT
+      ORUGA_MOBILE_BREAKPOINT,
+      handleClick
     }
   }
 });

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -57,7 +57,7 @@
 
       <o-table-column v-slot="props" field="message" label="Message">
         <div class="should-wrap">
-          <BlobValue v-bind:blob-value="props.row.message" v-bind:base64="true" v-bind:show-none="true"/>
+          <BlobValue :blob-value="props.row.message" :base64="true" :limiting-factor="520" :show-none="true"/>
         </div>
       </o-table-column>
 

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -24,7 +24,8 @@
 
 <template>
   <a v-if="isURL" v-bind:href="blobValue">{{ blobValue }}</a>
-  <span v-else-if="jsonValue" class="h-is-json is-family-monospace h-is-text-size-3">{{ jsonValue }}</span>
+  <div v-else-if="jsonValue"
+       class="h-is-json is-inline-block has-text-left is-family-monospace h-is-text-size-3">{{ jsonValue }}</div>
   <template v-else-if="blobValue">
     <div v-if="limitingFactor && isMediumScreen" class="h-is-one-line is-inline-block"
          :style="{'max-width': windowWidth-limitingFactor + 'px'}">{{ decodedValue }}</div>
@@ -140,19 +141,4 @@ export default defineComponent({
 <!--                                                      STYLE                                                      -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style>
-.h-is-json {
-  white-space: pre-wrap;
-}
-@media (max-width: 767px) {
-  .h-is-json {
-    white-space: normal;
-  }
-}
-
-.h-is-one-line {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-</style>
+<style/>

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -24,6 +24,7 @@
 
 <template>
   <a v-if="isURL" v-bind:href="blobValue">{{ blobValue }}</a>
+  <span v-else-if="jsonValue" class="h-is-json is-family-monospace h-is-text-size-3">{{ jsonValue }}</span>
   <span v-else-if="blobValue">{{ decodedValue }}</span>
   <span v-else-if="showNone && !initialLoading" class="has-text-grey">None</span>
   <span v-else/>
@@ -50,10 +51,16 @@ export default defineComponent({
     base64: {
       type: Boolean,
       default: false
+    },
+    pretty: {
+      type: Boolean,
+      default: false
     }
   },
 
   setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
+
     const isURL = computed(() => {
       let result: boolean
       if (props.blobValue) {
@@ -65,6 +72,23 @@ export default defineComponent({
         }
       } else {
         result = false
+      }
+      return result
+    })
+
+    const jsonValue = computed(() => {
+      let result
+      if (decodedValue.value && props.pretty) {
+        try {
+          result = JSON.parse(decodedValue.value)
+          const sValue = Buffer.from(result.s, 'base64').toString()
+          console.log("s: " + result.s)
+          console.log("sValue: " + sValue)
+        } catch (e) {
+          result = null
+        }
+      } else {
+        result = null
       }
       return result
     })
@@ -93,7 +117,9 @@ export default defineComponent({
     const initialLoading = inject(initialLoadingKey, ref(false))
 
     return {
+      isSmallScreen,
       isURL,
+      jsonValue,
       decodedValue,
       initialLoading
     }
@@ -106,4 +132,13 @@ export default defineComponent({
 <!--                                                      STYLE                                                      -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style/>
+<style>
+.h-is-json {
+  white-space: pre-wrap;
+}
+@media (max-width: 767px) {
+  .h-is-json {
+    white-space: normal;
+  }
+}
+</style>

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -68,7 +68,7 @@ export default defineComponent({
 
   setup(props) {
     const isMediumScreen = inject('isMediumScreen', true)
-    const windowWidth = inject('windowWidth')
+    const windowWidth = inject('windowWidth', 1280)
     const isURL = computed(() => {
       let result: boolean
       if (props.blobValue) {

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -89,9 +89,6 @@ export default defineComponent({
       if (decodedValue.value && props.pretty) {
         try {
           result = JSON.parse(decodedValue.value)
-          const sValue = Buffer.from(result.s, 'base64').toString()
-          console.log("s: " + result.s)
-          console.log("sValue: " + sValue)
         } catch (e) {
           result = null
         }

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -25,7 +25,13 @@
 <template>
   <a v-if="isURL" v-bind:href="blobValue">{{ blobValue }}</a>
   <span v-else-if="jsonValue" class="h-is-json is-family-monospace h-is-text-size-3">{{ jsonValue }}</span>
-  <span v-else-if="blobValue">{{ decodedValue }}</span>
+  <template v-else-if="blobValue">
+    <div v-if="limitingFactor && isMediumScreen" class="h-is-one-line is-inline-block"
+         :style="{'max-width': windowWidth-limitingFactor + 'px'}">{{ decodedValue }}</div>
+    <div v-else-if="limitingFactor" class="h-is-one-line is-inline-block"
+         :style="{'max-width': windowWidth-limitingFactor+200 + 'px'}">{{ decodedValue }}</div>
+    <div v-else>{{ decodedValue }}</div>
+  </template>
   <span v-else-if="showNone && !initialLoading" class="has-text-grey">None</span>
   <span v-else/>
 </template>
@@ -55,12 +61,13 @@ export default defineComponent({
     pretty: {
       type: Boolean,
       default: false
-    }
+    },
+    limitingFactor: Number
   },
 
   setup(props) {
-    const isSmallScreen = inject('isSmallScreen', true)
-
+    const isMediumScreen = inject('isMediumScreen', true)
+    const windowWidth = inject('windowWidth')
     const isURL = computed(() => {
       let result: boolean
       if (props.blobValue) {
@@ -117,7 +124,8 @@ export default defineComponent({
     const initialLoading = inject(initialLoadingKey, ref(false))
 
     return {
-      isSmallScreen,
+      isMediumScreen,
+      windowWidth,
       isURL,
       jsonValue,
       decodedValue,
@@ -140,5 +148,11 @@ export default defineComponent({
   .h-is-json {
     white-space: normal;
   }
+}
+
+.h-is-one-line {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 </style>

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -229,7 +229,7 @@
         <Property id="sequenceNumber" :full-width="true">
           <template v-slot:name>Sequence Number</template>
           <template v-slot:value>
-            <PlainAmount :amount="sequence_number"/>
+            {{ sequence_number }}
           </template>
         </Property>
         <Property id="message" :full-width="true">

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -221,37 +221,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard class="h-card">
-      <template v-slot:title>
-        <span class="h-is-secondary-title">Message Submitted</span>
-      </template>
-      <template v-slot:content>
-        <Property id="sequenceNumber" :full-width="true">
-          <template v-slot:name>Sequence Number</template>
-          <template v-slot:value>
-            {{ sequence_number }}
-          </template>
-        </Property>
-        <Property id="message" :full-width="true">
-          <template v-slot:name>Message</template>
-          <template v-slot:value>
-            <BlobValue :blob-value="message" :show-none="true" :base64="true" :pretty="true" class="should-wrap is-numeric"/>
-          </template>
-        </Property>
-        <Property id="runningHashVersion" :full-width="true">
-          <template v-slot:name>Running Hash Version</template>
-          <template v-slot:value>
-            <PlainAmount :amount="running_hash_version"/>
-          </template>
-        </Property>
-        <Property id="runningHash" :full-width="true">
-          <template v-slot:name>Running Hash</template>
-          <template v-slot:value>
-            <BlobValue :blob-value="running_hash" :show-none="true" class="should-wrap is-numeric"/>
-          </template>
-        </Property>
-      </template>
-    </DashboardCard>
+    <TopicMessage :message-loader="topicMessageLoader"/>
 
     <ContractResult v-if="hasContractResult" :transaction-id-or-hash="transaction?.transaction_id"/>
 
@@ -287,8 +257,8 @@ import DurationValue from "@/components/values/DurationValue.vue";
 import BlockLink from "@/components/values/BlockLink.vue";
 import ContractResult from "@/components/contract/ContractResult.vue";
 import {TransactionType} from "@/schemas/HederaSchemas";
+import TopicMessage from "@/components/topic/TopicMessage.vue";
 import {TopicMessageLoader} from "@/components/topic/TopicMessageLoader";
-import PlainAmount from "@/components/values/PlainAmount.vue";
 
 const MAX_INLINE_CHILDREN = 9
 
@@ -297,7 +267,7 @@ export default defineComponent({
   name: 'TransactionDetails',
 
   components: {
-    PlainAmount,
+    TopicMessage,
     ContractResult,
     BlockLink,
     Property,
@@ -355,10 +325,9 @@ export default defineComponent({
 
     const messageTimestamp = computed(() =>
         (transactionLoader.transactionType.value === TransactionType.CONSENSUSSUBMITMESSAGE)
-            ? transactionLoader.consensusTimestamp.value
-            : null
+            ? transactionLoader.consensusTimestamp.value ?? ""
+            : ""
     )
-
     const topicMessageLoader = new TopicMessageLoader(messageTimestamp)
 
     return {
@@ -386,10 +355,7 @@ export default defineComponent({
       makeOperatorAccountLabel,
       showAllTransactionVisible,
       displayAllChildrenLinks,
-      sequence_number: topicMessageLoader.sequence_number,
-      message: topicMessageLoader.message,
-      running_hash_version: topicMessageLoader.running_hash_version,
-      running_hash: topicMessageLoader.running_hash
+      topicMessageLoader
     }
   },
 })

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -221,6 +221,38 @@
       </template>
     </DashboardCard>
 
+    <DashboardCard class="h-card">
+      <template v-slot:title>
+        <span class="h-is-secondary-title">Message Submitted</span>
+      </template>
+      <template v-slot:content>
+        <Property id="sequenceNumber" :full-width="true">
+          <template v-slot:name>Sequence Number</template>
+          <template v-slot:value>
+            <PlainAmount :amount="sequence_number"/>
+          </template>
+        </Property>
+        <Property id="message" :full-width="true">
+          <template v-slot:name>Message</template>
+          <template v-slot:value>
+            <BlobValue :blob-value="message" :show-none="true" :base64="true" :pretty="true" class="should-wrap is-numeric"/>
+          </template>
+        </Property>
+        <Property id="runningHashVersion" :full-width="true">
+          <template v-slot:name>Running Hash Version</template>
+          <template v-slot:value>
+            <PlainAmount :amount="running_hash_version"/>
+          </template>
+        </Property>
+        <Property id="runningHash" :full-width="true">
+          <template v-slot:name>Running Hash</template>
+          <template v-slot:value>
+            <BlobValue :blob-value="running_hash" :show-none="true" class="should-wrap is-numeric"/>
+          </template>
+        </Property>
+      </template>
+    </DashboardCard>
+
     <ContractResult v-if="hasContractResult" :transaction-id-or-hash="transaction?.transaction_id"/>
 
   </section>
@@ -254,6 +286,9 @@ import Property from "@/components/Property.vue";
 import DurationValue from "@/components/values/DurationValue.vue";
 import BlockLink from "@/components/values/BlockLink.vue";
 import ContractResult from "@/components/contract/ContractResult.vue";
+import {TransactionType} from "@/schemas/HederaSchemas";
+import {TopicMessageLoader} from "@/components/topic/TopicMessageLoader";
+import PlainAmount from "@/components/values/PlainAmount.vue";
 
 const MAX_INLINE_CHILDREN = 9
 
@@ -262,6 +297,7 @@ export default defineComponent({
   name: 'TransactionDetails',
 
   components: {
+    PlainAmount,
     ContractResult,
     BlockLink,
     Property,
@@ -279,7 +315,7 @@ export default defineComponent({
     network: String
   },
 
-  setup(props) {
+  setup: function (props) {
     const isSmallScreen = inject('isSmallScreen', true)
     const isLargeScreen = inject('isLargeScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
@@ -297,7 +333,7 @@ export default defineComponent({
     })
 
     const displayAllChildrenLinks = computed(
-        () => transactionLoader.childTransactions.value.length > MAX_INLINE_CHILDREN )
+        () => transactionLoader.childTransactions.value.length > MAX_INLINE_CHILDREN)
 
     const notification = computed(() => {
       let result
@@ -316,6 +352,14 @@ export default defineComponent({
     const routeName = computed(() => {
       return transactionLoader.entityDescriptor.value?.routeName
     })
+
+    const messageTimestamp = computed(() =>
+        (transactionLoader.transactionType.value === TransactionType.CONSENSUSSUBMITMESSAGE)
+            ? transactionLoader.consensusTimestamp.value
+            : null
+    )
+
+    const topicMessageLoader = new TopicMessageLoader(messageTimestamp)
 
     return {
       isSmallScreen,
@@ -342,6 +386,10 @@ export default defineComponent({
       makeOperatorAccountLabel,
       showAllTransactionVisible,
       displayAllChildrenLinks,
+      sequence_number: topicMessageLoader.sequence_number,
+      message: topicMessageLoader.message,
+      running_hash_version: topicMessageLoader.running_hash_version,
+      running_hash: topicMessageLoader.running_hash
     }
   },
 })

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -371,6 +371,7 @@ export interface TopicMessagesResponse {
 }
 
 export interface TopicMessage {
+    chunk_info: ChunkInfo | null,
     consensus_timestamp: string,
     topic_id: string | null,
     message: string,
@@ -379,6 +380,18 @@ export interface TopicMessage {
     sequence_number: number
 }
 
+export interface ChunkInfo {
+    initial_transaction_id: TransactionId,
+    number: number,
+    total: number
+}
+
+export interface TransactionId {
+    account_id: string | null,
+    nonce: number | null,
+    scheduled: boolean | null,
+    transaction_valid_start: string
+}
 
 // ---------------------------------------------------------------------------------------------------------------------
 //                                                      Contract

--- a/tests/e2e/specs/TopicNavigation.spec.ts
+++ b/tests/e2e/specs/TopicNavigation.spec.ts
@@ -20,6 +20,8 @@
 
 // https://docs.cypress.io/api/introduction/api.html
 
+import {normalizeTransactionId} from "../../../src/utils/TransactionID";
+
 describe('Topic Navigation', () => {
 
     it('should navigate from topic table to topic messages', () => {
@@ -41,4 +43,32 @@ describe('Topic Navigation', () => {
             })
     })
 
+    it('should navigate from transaction details to topic message table back to transaction', () => {
+        let transactionId = "0.0.48961401@1669313485.710762293"
+        cy.visit('/testnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/testnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.contains('Transaction ' + transactionId)
+
+        cy.get('#entityId')
+            .find('a')
+            .click()
+            .then(($topicId) => {
+                cy.url().should('include', '/testnet/topic/' + $topicId.text())
+                cy.contains('Messages for Topic ' + $topicId.text())
+
+                cy.get('table')
+                    .find('tbody tr')
+                    .should('have.length.at.least', 2)
+                    .eq(0)
+                    .find('td')
+                    .eq(0)
+                    .click()
+                    .then(($seqNumber) => {
+                        cy.url().should('include', '/testnet/transaction/')
+                        cy.contains('Topic ID' + $topicId.text())
+                        cy.contains('Message Submitted')
+                        cy.contains('Sequence Number' + $seqNumber.text())
+                    })
+            })
+    })
 })


### PR DESCRIPTION
**Description**:

With these changes:
- the TransactionDetails view includes the details of the Topic Message when the type of the transaction is `CONSENSUSSUBMITMESSAGE`.
- the TopicMessageTable allows to navigate to the details of the corresponding transaction.

**Related issue(s)**:

Fixes #16 

**Notes for reviewer**:

Deployed to staging environment (or should be in a short while...)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
