### PR TITLE
00338 fix navigation from account to contract with evm address

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -159,7 +159,7 @@
                 </template>
               </Property>
             <Property id="key">
-              <template v-slot:name>Key</template>
+              <template v-slot:name>Admin Key</template>
               <template v-slot:value>
                 <KeyValue :key-bytes="account?.key?.key" :key-type="account?.key?._type" :show-none="true"/>
               </template>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -32,7 +32,7 @@
         <span class="h-is-secondary-text">{{ normalizedAccountId ?? "" }}</span>
         <span v-if="accountChecksum" class="has-text-grey" style="font-size: 28px">-{{ accountChecksum }}</span>
         <span v-if="showContractVisible" class="is-inline-block ml-3" id="showContractLink">
-          <router-link :to="{name: 'ContractDetails', params: {contractId: accountId}}">
+          <router-link :to="{name: 'ContractDetails', params: {contractId: normalizedAccountId}}">
             <span class="h-is-property-text">Show associated contract</span>
           </router-link>
         </span>

--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -193,6 +193,25 @@ describe('Account Navigation', () => {
         cy.contains('Account ' + accountId)
     })
 
+    it('should follow link to associated contract and back using evm address', () => {
+        const accountID = "0.0.48949369"
+        const evmAddress = "0x0000000000000000000000000000000002eAE879"
+
+        cy.visit('testnet/account/' + evmAddress)
+        cy.url().should('include', '/testnet/account/' + evmAddress)
+        cy.contains('Account ' + accountID)
+        cy.contains('a', "Show associated contract")
+            .click()
+
+        cy.url().should('include', '/testnet/contract/' + accountID)
+        cy.contains('Contract ' + accountID)
+        cy.contains('a', "Show associated account")
+            .click()
+
+        cy.url().should('include', '/testnet/account/' + accountID)
+        cy.contains('Account ' + accountID)
+    })
+
     it('should not show a link to associated contract', () => {
         const accountId = '0.0.47981544'
         const searchId = '0.0.3'


### PR DESCRIPTION
**Description**:

This is a one-line fix for the broken link from AccountDetails view to ContractDetails view when the initial navigation to the account used an EVM address.

**Related issue(s)**:

Relates to #338 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
