### PR TITLE
00340 contract result for child transactions

### DIFF
--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -124,7 +124,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onMounted, ref} from 'vue';
+import {computed, defineComponent, inject, onMounted} from 'vue';
 import {ContractResultDetailsLoader} from "@/components/contract/ContractResultDetailsLoader";
 import HexaValue from "@/components/values/HexaValue.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
@@ -155,6 +155,8 @@ export default defineComponent({
   },
 
   props: {
+    timestamp: String,
+    contractId: String,
     transactionIdOrHash: String,
     topLevel: {
       type: Boolean,
@@ -167,8 +169,8 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
 
     const contractResultDetailsLoader = new ContractResultDetailsLoader(
-        ref(null),
-        ref(null),
+        computed(() => props.contractId ?? null),
+        computed(() => props.timestamp ?? null),
         computed(() => props.transactionIdOrHash ?? null))
     onMounted(() => contractResultDetailsLoader.requestLoad())
 

--- a/src/components/transaction/TransactionLoader.ts
+++ b/src/components/transaction/TransactionLoader.ts
@@ -65,10 +65,16 @@ export class TransactionLoader extends EntityLoader<TransactionByIdResponse> {
 
     public readonly transactionType = computed(() => this.transaction.value?.name ?? null)
 
-    public readonly hasContractResult = computed(
-        () => this.transactionType.value === TransactionType.CONTRACTCREATEINSTANCE
-            || this.transactionType.value === TransactionType.CONTRACTCALL
-            || this.transactionType.value === TransactionType.ETHEREUMTRANSACTION)
+    public readonly contractId = computed(() => {
+        return (this.transactionType.value === TransactionType.ETHEREUMTRANSACTION)
+            ? this.contractLoader.contractId.value ?? null
+            : (this.transactionType.value === TransactionType.CONTRACTCREATEINSTANCE
+                || this.transactionType.value === TransactionType.CONTRACTCALL
+                || this.transactionType.value === TransactionType.CONTRACTUPDATEINSTANCE
+                || this.transactionType.value === TransactionType.CONTRACTDELETEINSTANCE)
+                ? this.transaction.value?.entity_id
+                : null
+    })
 
     public readonly result: ComputedRef<string|null> = computed(
         () => this.transaction.value?.result ?? null)

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -223,7 +223,7 @@
 
     <TopicMessage :message-loader="topicMessageLoader"/>
 
-    <ContractResult v-if="hasContractResult" :transaction-id-or-hash="transaction?.transaction_id"/>
+    <ContractResult :timestamp="transaction?.consensus_timestamp" :contract-id="contractId"/>
 
   </section>
 
@@ -338,7 +338,7 @@ export default defineComponent({
       formattedTransactionId: transactionLoader.formattedTransactionId,
       netAmount: transactionLoader.netAmount,
       entity: transactionLoader.entityDescriptor,
-      hasContractResult: transactionLoader.hasContractResult,
+      contractId: transactionLoader.contractId,
       systemContract: transactionLoader.systemContract,
       maxFee: transactionLoader.maxFee,
       formattedHash: transactionLoader.formattedHash,

--- a/tests/e2e/specs/ContractResultDetails.spec.ts
+++ b/tests/e2e/specs/ContractResultDetails.spec.ts
@@ -1,0 +1,94 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// https://docs.cypress.io/api/introduction/api.html
+
+import {normalizeTransactionId} from "../../../src/utils/TransactionID";
+
+describe('ContractResultDetails', () => {
+
+    it('should display contract result of contract call transaction', () => {
+        const transactionId = "0.0.47818344@1669816707.173720575"
+        const consensusTimestamp = "1669816716.094396003"
+
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + consensusTimestamp)
+        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', normalizeTransactionId(transactionId))
+        cy.url().should('include', consensusTimestamp)
+
+        cy.get('#transactionTypeValue').should('have.text', 'CONTRACT CALL')
+        cy.get('#entityIdValue').should('have.text', '0.0.48997098')
+        cy.contains('Contract Result')
+        cy.get('#resultValue').should('have.text', 'SUCCESS')
+        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668')
+        cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000002eba2ea')
+    })
+
+    it('should display contract result of child (contract call) transaction', () => {
+        const transactionId = "0.0.47818344@1669816707.173720575"
+        const consensusTimestamp = "1669816716.094396005"
+
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + consensusTimestamp)
+        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', normalizeTransactionId(transactionId))
+        cy.url().should('include', consensusTimestamp)
+
+        cy.get('#transactionTypeValue').should('have.text', 'CONTRACT CALL')
+        cy.get('#entityIdValue').should('have.text', 'Hedera Token Service System Contract')
+        cy.contains('Contract Result')
+        cy.get('#resultValue').should('have.text', 'SUCCESS')
+        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668')
+        cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000000167')
+    })
+
+    it('should display contract result of child (token burn) transaction', () => {
+        const transactionId = "0.0.47818344@1669816707.173720575"
+        const consensusTimestamp = "1669816716.094396009"
+
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + consensusTimestamp)
+        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', normalizeTransactionId(transactionId))
+        cy.url().should('include', consensusTimestamp)
+
+        cy.get('#transactionTypeValue').should('have.text', 'TOKEN BURN')
+        cy.get('#entityIdValue').should('have.text', '0.0.47879696')
+        cy.contains('Contract Result')
+        cy.get('#resultValue').should('have.text', 'SUCCESS')
+        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668')
+        cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000000167')
+    })
+
+    it('should display contract result of child (crypto transfer) transaction', () => {
+        const transactionId = "0.0.47818344@1669816707.173720575"
+        const consensusTimestamp = "1669816716.094396011"
+
+        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId) + "?t=" + consensusTimestamp)
+        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', normalizeTransactionId(transactionId))
+        cy.url().should('include', consensusTimestamp)
+
+        cy.get('#transactionTypeValue').should('have.text', 'CRYPTO TRANSFER')
+        cy.get('#entityIdValue').should('not.exist')
+        cy.contains('Contract Result')
+        cy.get('#resultValue').should('have.text', 'SUCCESS')
+        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668')
+        cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000000167')
+    })
+})

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -144,10 +144,11 @@ describe("TransactionDetails.vue", () => {
 
         const transactionId = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].transaction_id
         const contractId = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].entity_id
+        const timestamp = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].consensus_timestamp
 
         const matcher1 = "/api/v1/transactions/" + transactionId
         mock.onGet(matcher1).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS);
-        const matcher2 = "/api/v1/contracts/results/" + transactionId
+        const matcher2 = "/api/v1/contracts/" + contractId + "/results/" + timestamp
         mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
         const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
@@ -199,10 +200,11 @@ describe("TransactionDetails.vue", () => {
         const transactionId = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].transaction_id
         const transactionHash = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].transaction_hash
         const contractId = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].entity_id
+        const timestamp = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].consensus_timestamp
 
         const matcher1 = "/api/v1/transactions/" + transactionHash
         mock.onGet(matcher1).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS);
-        const matcher2 = "/api/v1/contracts/results/" + transactionId
+        const matcher2 = "/api/v1/contracts/" + contractId  + "/results/" + timestamp
         mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
         const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);


### PR DESCRIPTION
**Description**:

- With these changes, the `TransactionDetails` view now displays the contract result (if any exists) in all cases, whatever the type of the transaction.
- Furthermore, we pick up the result based on the consensus timestamp of the transaction, whereas we were previously picking up the result based on the transactionId. This means that in the case of a child transaction, we show its corresponding contract result, whereas we were previously always showing the result corresponding to the parent transaction.
- Note that when getting a contract result based on timestamp only (i.e. `transaction.entity_id` is not a contractId) we first make a synchronous call to `/api/contracts/results?timestamp={timestamp}` to retrieve the contractId and then call `/api/contracts/{contractId}/results/{timestamp}` to retrieve the full `ContractResultDetails`.

**Related issue(s)**:

Fixes #340 

**Notes for reviewer**:

(not yet on stage -- merge needed).

Example:  <server-url>/testnet/transactionsById/0.0.47818344-1669816707-173720575
Observe how the parent and child transactions each display a distinct contract result.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
