### PR TITLE
Fix for #351 (EntityID.fromAddress() should be more robust).

### DIFF
--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -92,7 +92,7 @@ export class EntityID {
             if (buffer !== null && buffer.length == 20) {
                 const view = new DataView(buffer.buffer)
                 const bigNum = view.getBigInt64(12)
-                const num = bigNum < EntityID.MAX_INT ? Number(bigNum) : null
+                const num = 0 <= bigNum && bigNum < EntityID.MAX_INT ? Number(bigNum) : null
                 result = num != null ? new EntityID(0, 0, num) : null
             } else {
                 result = null

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -217,5 +219,21 @@ describe("EntityID.ts", () => {
             expect(id1.compareAccountID(id1) == 0).toBe(true)
             expect(id2.compareAccountID(id2) == 0).toBe(true)
         }
+    })
+
+    //
+    // EntityID.fromAddress()
+    //
+
+    test("fromAddress(0x00000000000000000000000000000000000000ff)", () => {
+        const evmAddress = "0x00000000000000000000000000000000000000ff"
+        const id = EntityID.fromAddress(evmAddress)
+        expect(id?.toString()).toBe("0.0.255")
+    })
+
+    test("fromAddress(0x6482571dbbE4E68CbcDC6207f82d701804b8664a)", () => {
+        const evmAddress = "0x6482571dbbE4E68CbcDC6207f82d701804b8664a"
+        const id = EntityID.fromAddress(evmAddress)
+        expect(id).toBeNull()
     })
 })


### PR DESCRIPTION
Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:
Fix and unit test for #351.

**Related issue(s)**:

Fixes #351

**Notes for reviewer**:

On staging server:
1) search for transaction 1669904326.061513245 (on mainnet)
2) look for sender argument in Contract Result section 
    => account id 0.0.-563671129890724300 is displayed (it should not)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
