### PR TITLE
Fix for #353 (Broken transfer diagram).

### DIFF
--- a/src/components/transfer_graphs/HbarTransferGraphC.vue
+++ b/src/components/transfer_graphs/HbarTransferGraphC.vue
@@ -98,7 +98,7 @@ export default defineComponent({
     const hbarTransferLayout = ref(new HbarTransferLayout(props.transaction, false))
 
     watch(() => props.transaction, () => {
-      hbarTransferLayout.value = new HbarTransferLayout(props.transaction)
+      hbarTransferLayout.value = new HbarTransferLayout(props.transaction, false)
     })
 
     return {


### PR DESCRIPTION
Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:
One line fix: HbarTransferGraphC.setup() forgot to pass "false" value to HbarTransferLayout.

**Related issue(s)**:

Fixes #353

**Notes for reviewer**:

See #353 for instructions.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
