### PR TITLE
00313 use reward api

### DIFF
--- a/src/components/staking/RewardsTransactionTable.vue
+++ b/src/components/staking/RewardsTransactionTable.vue
@@ -52,7 +52,7 @@
     </o-table-column>
 
     <o-table-column v-slot="props" field="amount" label="Amount Rewarded" position="right">
-      <HbarAmount v-bind:amount="props.raw.amount"/>
+      <HbarAmount v-bind:amount="props.row.amount"/>
     </o-table-column>
 
   </o-table>

--- a/src/components/staking/RewardsTransactionTable.vue
+++ b/src/components/staking/RewardsTransactionTable.vue
@@ -26,7 +26,7 @@
 <template>
 
   <o-table
-      :data="transactions"
+      :data="rewards"
       :loading="loading"
       :paginated="paginated"
       backend-pagination
@@ -47,17 +47,17 @@
       aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
   >
-    <o-table-column v-slot="props" field="consensus_timestamp" label="Time">
-      <TimestampValue v-bind:timestamp="props.row.consensus_timestamp"/>
+    <o-table-column v-slot="props" field="timestamp" label="Time">
+      <TimestampValue v-bind:timestamp="props.row.timestamp"/>
     </o-table-column>
 
     <o-table-column v-slot="props" field="amount" label="Amount Rewarded" position="right">
-      <HbarAmount v-bind:amount="amountRewarded(props.row)"/>
+      <HbarAmount v-bind:amount="props.raw.amount"/>
     </o-table-column>
 
   </o-table>
 
-  <EmptyTable v-if="!transactions.length"/>
+  <EmptyTable v-if="!rewards.length"/>
 
 </template>
 
@@ -68,7 +68,7 @@
 <script lang="ts">
 
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
-import {Transaction} from '@/schemas/HederaSchemas';
+import {Reward} from '@/schemas/HederaSchemas';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -94,19 +94,14 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
-    const handleClick = (t: Transaction) => {
-      routeManager.routeToTransaction(t)
-    }
-
-    const amountRewarded = (t: Transaction) => {
-      const accountId = props.controller.accountId.value
-      return accountId !== null ? RewardsTransactionTableController.getAmountRewarded(t, accountId) : 0
+    const handleClick = (t: Reward) => {
+      routeManager.routeToTransaction(t.timestamp, undefined)
     }
 
     return {
       isTouchDevice,
       isMediumScreen,
-      transactions: props.controller.rows as ComputedRef<Transaction[]>,
+      rewards: props.controller.rows as ComputedRef<Reward[]>,
       loading: props.controller.loading as ComputedRef<boolean>,
       total: props.controller.totalRowCount as ComputedRef<number>,
       currentPage: props.controller.currentPage as Ref<number>,
@@ -115,7 +110,6 @@ export default defineComponent({
       paginated: props.controller.paginated as Ref<boolean>,
       accountId: props.controller.accountId as Ref<string>,
       handleClick,
-      amountRewarded,
 
       // From App
       ORUGA_MOBILE_BREAKPOINT,

--- a/src/components/staking/RewardsTransactionTable.vue
+++ b/src/components/staking/RewardsTransactionTable.vue
@@ -68,7 +68,7 @@
 <script lang="ts">
 
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
-import {Reward} from '@/schemas/HederaSchemas';
+import {StakingReward} from '@/schemas/HederaSchemas';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -94,14 +94,14 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
-    const handleClick = (t: Reward) => {
+    const handleClick = (t: StakingReward) => {
       routeManager.routeToTransactionId(undefined, t.timestamp)
     }
 
     return {
       isTouchDevice,
       isMediumScreen,
-      rewards: props.controller.rows as ComputedRef<Reward[]>,
+      rewards: props.controller.rows as ComputedRef<StakingReward[]>,
       loading: props.controller.loading as ComputedRef<boolean>,
       total: props.controller.totalRowCount as ComputedRef<number>,
       currentPage: props.controller.currentPage as Ref<number>,

--- a/src/components/staking/RewardsTransactionTable.vue
+++ b/src/components/staking/RewardsTransactionTable.vue
@@ -95,7 +95,7 @@ export default defineComponent({
     const isMediumScreen = inject('isMediumScreen', true)
 
     const handleClick = (t: Reward) => {
-      routeManager.routeToTransaction(t.timestamp, undefined)
+      routeManager.routeToTransactionId(undefined, t.timestamp)
     }
 
     return {

--- a/src/components/staking/RewardsTransactionTableController.ts
+++ b/src/components/staking/RewardsTransactionTableController.ts
@@ -19,13 +19,13 @@
  */
 
 import {KeyOperator, SortOrder, TableController} from "@/utils/table/TableController";
-import {Reward, RewardResponse, Transaction, TransactionResponse} from "@/schemas/HederaSchemas";
+import {StakingReward, StakingRewardsResponse, Transaction, TransactionResponse} from "@/schemas/HederaSchemas";
 import {ComputedRef, Ref} from "vue";
 import axios from "axios";
 import {Router} from "vue-router";
 
 
-export class RewardsTransactionTableController extends TableController<Reward, string> {
+export class RewardsTransactionTableController extends TableController<StakingReward, string> {
 
     public readonly accountId: Ref<string|null>
 
@@ -46,8 +46,8 @@ export class RewardsTransactionTableController extends TableController<Reward, s
     private mode = Mode.Unknown
 
     public async load(consensusTimestamp: string | null, operator: KeyOperator,
-                      order: SortOrder, limit: number): Promise<Reward[] | null> {
-        let result: Reward[] | null
+                      order: SortOrder, limit: number): Promise<StakingReward[] | null> {
+        let result: StakingReward[] | null
 
         if (this.mode == Mode.Real || this.mode == Mode.Unknown) {
             try {
@@ -70,7 +70,7 @@ export class RewardsTransactionTableController extends TableController<Reward, s
         return Promise.resolve(result)
     }
 
-    public keyFor(row: Reward): string {
+    public keyFor(row: StakingReward): string {
         return row.timestamp ?? ""
     }
 
@@ -87,8 +87,8 @@ export class RewardsTransactionTableController extends TableController<Reward, s
     //
 
     private async loadNextReal(consensusTimestamp: string | null, operator: KeyOperator,
-                         order: SortOrder, limit: number): Promise<Reward[] | null> {
-        let result: Reward[] | null
+                         order: SortOrder, limit: number): Promise<StakingReward[] | null> {
+        let result: StakingReward[] | null
 
         const accountId = this.accountId.value
         if (accountId === null) {
@@ -105,7 +105,7 @@ export class RewardsTransactionTableController extends TableController<Reward, s
                 params.timestamp =  operator + ":" + consensusTimestamp
             }
             const url = "api/v1/accounts/" + accountId + "/rewards"
-            const response = await axios.get<RewardResponse>(url, {params: params})
+            const response = await axios.get<StakingRewardsResponse>(url, {params: params})
             result = response.data.rewards ?? []
         }
 
@@ -113,8 +113,8 @@ export class RewardsTransactionTableController extends TableController<Reward, s
     }
 
     private async loadNextEmulated(consensusTimestamp: string | null, operator: KeyOperator,
-                             order: SortOrder, limit: number): Promise<Reward[] | null> {
-        let result: Reward[] | null
+                             order: SortOrder, limit: number): Promise<StakingReward[] | null> {
+        let result: StakingReward[] | null
 
         const accountId = this.accountId.value
         if (accountId === null) {
@@ -147,12 +147,12 @@ export class RewardsTransactionTableController extends TableController<Reward, s
 
     private static rewardAccountId = "0.0.800"
 
-    private static filterTransactions(input: Array<Transaction>, accountId: string): Array<Reward> {
-        const result: Array<Reward> = []
+    private static filterTransactions(input: Array<Transaction>, accountId: string): Array<StakingReward> {
+        const result: Array<StakingReward> = []
         for (const t of input) {
             const amountRewarded = RewardsTransactionTableController.getAmountRewarded(t, accountId)
             if (amountRewarded > 0) {
-                const newReward: Reward = {
+                const newReward: StakingReward = {
                     account_id: accountId,
                     timestamp: t.consensus_timestamp ?? "0",
                     amount: amountRewarded

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -651,12 +651,12 @@ export interface TimestampRange {
 //                                               StakingRewardTransfer
 // ---------------------------------------------------------------------------------------------------------------------
 
-export interface RewardResponse {
-    rewards: Array<Reward> | undefined
+export interface StakingRewardsResponse {
+    rewards: Array<StakingReward> | undefined
     links: Links | undefined
 }
 
-export interface Reward {
+export interface StakingReward {
     account_id: string|null
     amount: number
     timestamp: string

--- a/src/utils/downloader/EntityDownloader.ts
+++ b/src/utils/downloader/EntityDownloader.ts
@@ -186,6 +186,18 @@ export abstract class EntityDownloader<E, R> {
         return entities
     }
 
+
+    protected checkStartDate(): Date {
+        let result: Date
+        if (this.startDate.value !== null) {
+            result = this.startDate.value
+        } else {
+            throw new Error("this.startDate is null")
+        }
+        return result
+    }
+
+
     //
     // Private
     //

--- a/src/utils/downloader/RewardDownloader.ts
+++ b/src/utils/downloader/RewardDownloader.ts
@@ -18,14 +18,14 @@
  *
  */
 
-import {Reward, RewardResponse, TransactionResponse} from "@/schemas/HederaSchemas";
+import {StakingReward, StakingRewardsResponse, TransactionResponse} from "@/schemas/HederaSchemas";
 import {Ref, watch} from "vue";
 import {dateToTimestamp, EntityDownloader} from "@/utils/downloader/EntityDownloader";
 import axios, {AxiosResponse} from "axios";
 import {CSVEncoder} from "@/utils/CSVEncoder";
 import {RewardsTransactionTableController} from "@/components/staking/RewardsTransactionTableController";
 
-export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
+export class RewardDownloader extends EntityDownloader<StakingReward, StakingRewardsResponse> {
 
     public readonly accountId: Ref<string|null>
 
@@ -48,8 +48,8 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
     // EntityDownloader
     //
 
-    protected async loadNext(nextURL: string|null): Promise<AxiosResponse<RewardResponse>> {
-        let result: AxiosResponse<RewardResponse>
+    protected async loadNext(nextURL: string|null): Promise<AxiosResponse<StakingRewardsResponse>> {
+        let result: AxiosResponse<StakingRewardsResponse>
 
         try {
             result = await this.loadNextReal(nextURL)
@@ -64,19 +64,19 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
         return Promise.resolve(result)
     }
 
-    protected fetchEntities(response: RewardResponse): Reward[] {
+    protected fetchEntities(response: StakingRewardsResponse): StakingReward[] {
         return response.rewards ?? []
     }
 
-    protected nextURL(response: RewardResponse): string | null {
+    protected nextURL(response: StakingRewardsResponse): string | null {
         return response.links?.next ?? null
     }
 
-    protected entityTimestamp(entity: Reward): string | null {
+    protected entityTimestamp(entity: StakingReward): string | null {
         return entity.timestamp ?? null
     }
 
-    protected makeCSVEncoder(dateFormat: Intl.DateTimeFormat): CSVEncoder<Reward> {
+    protected makeCSVEncoder(dateFormat: Intl.DateTimeFormat): CSVEncoder<StakingReward> {
         return new RewardEncoder(this.getEntities(), this.checkAccountId(), dateFormat)
     }
 
@@ -98,7 +98,7 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
         return result
     }
 
-    private async loadNextReal(nextURL: string|null): Promise<AxiosResponse<RewardResponse>> {
+    private async loadNextReal(nextURL: string|null): Promise<AxiosResponse<StakingRewardsResponse>> {
 
         if (nextURL == null) {
 
@@ -113,11 +113,11 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
             nextURL += "&limit=100"
         }
 
-        return axios.get<RewardResponse>(nextURL)
+        return axios.get<StakingRewardsResponse>(nextURL)
     }
 
 
-    private async loadNextEmulated(nextURL: string|null): Promise<AxiosResponse<RewardResponse>> {
+    private async loadNextEmulated(nextURL: string|null): Promise<AxiosResponse<StakingRewardsResponse>> {
 
         if (nextURL == null) {
             const startTimestamp = dateToTimestamp(this.checkStartDate())
@@ -136,13 +136,13 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
         return Promise.resolve(this.makeRewardResponse(transactionResponse))
     }
 
-    private makeRewardResponse(transactionResponse: AxiosResponse<TransactionResponse>): AxiosResponse<RewardResponse> {
-        const rewards: Reward[] = []
+    private makeRewardResponse(transactionResponse: AxiosResponse<TransactionResponse>): AxiosResponse<StakingRewardsResponse> {
+        const rewards: StakingReward[] = []
         const accountId = this.checkAccountId()
         for (const t of transactionResponse.data.transactions ?? []) {
             const amount = RewardsTransactionTableController.getAmountRewarded(t, accountId)
             if (amount > 0) {
-                const newReward: Reward = {
+                const newReward: StakingReward = {
                     account_id: accountId,
                     amount: amount,
                     timestamp: t.consensus_timestamp ?? "0"
@@ -150,7 +150,7 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
                 rewards.push(newReward)
             }
         }
-        const rewardResponse: RewardResponse = {
+        const rewardResponse: StakingRewardsResponse = {
             rewards: rewards,
             links: transactionResponse.data.links
         }
@@ -165,7 +165,7 @@ export class RewardDownloader extends EntityDownloader<Reward, RewardResponse> {
     }
 }
 
-export class RewardEncoder extends CSVEncoder<Reward> {
+export class RewardEncoder extends CSVEncoder<StakingReward> {
 
     private readonly accountId: string
 
@@ -173,7 +173,7 @@ export class RewardEncoder extends CSVEncoder<Reward> {
     // Public
     //
 
-    constructor(rewards: Reward[], accountId: string, dateFormat: Intl.DateTimeFormat) {
+    constructor(rewards: StakingReward[], accountId: string, dateFormat: Intl.DateTimeFormat) {
         super(rewards, dateFormat)
         this.accountId = accountId
     }
@@ -182,7 +182,7 @@ export class RewardEncoder extends CSVEncoder<Reward> {
     // CSVEncoder
     //
 
-    protected encodeEntity(t: Reward): string[][] {
+    protected encodeEntity(t: StakingReward): string[][] {
         const timestamp = t.timestamp ? this.formatTimestamp(t.timestamp) : ""
         const reward = this.formatAmount(t.amount)
         return [[timestamp, reward]]


### PR DESCRIPTION
**Description**:
With changes below, Explorer now uses `api/v1/account/{accountId}/rewards` to fill `Recent Staking Rewards` table in `Staking` tab.
This API is available on preview net only for now.
When testnet or mainnet are selected, Explorer fallback using `api/v1/transactions`.

**Related issue(s)**:

Fixes #313

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
