### PR TITLE
00371 move route logic to RouteManager

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@
 # VUE_APP_LOCAL_MIRROR_NODE_URL=http://localhost:5551/
 
 ### When set to 'true', this variable will enable the 'Staking' page
-# VUE_APP_ENABLE_STAKING=true
+VUE_APP_ENABLE_STAKING=true
 
 ### The name of the product as shown in the footer tagline
 # VUE_APP_PRODUCT_NAME=Hedera Mirror Node Explorer

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -115,9 +115,8 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, ref, watch, WatchStopHandle} from "vue";
-import {useRoute} from "vue-router";
-import router, {routeManager} from "@/router";
+import {defineComponent, inject, onMounted, ref} from "vue";
+import {routeManager} from "@/router";
 import SearchBar from "@/components/SearchBar.vue";
 import AxiosStatus from "@/components/AxiosStatus.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
@@ -136,66 +135,12 @@ export default defineComponent({
     const productName = getEnv('VUE_APP_PRODUCT_NAME') ?? "Hedera Mirror Node Explorer"
     const isStakingEnabled = getEnv('VUE_APP_ENABLE_STAKING') === 'true'
 
-    const route = useRoute()
-    const network = computed( () => { return route.params.network })
-    const name = computed( () => { return route.name })
-
     const isMobileMenuOpen = ref(false)
 
-    watch(network, (value) => {
-      updateSelectedNetworkSilently(value)
-    })
-
-    const selectedNetwork = ref(network.value)
-    
-    let selectedNetworkWatchHandle: WatchStopHandle|undefined
-    const updateSelectedNetworkSilently = (newValue: string|string[]) => {
-      if (selectedNetworkWatchHandle) {
-        selectedNetworkWatchHandle()
-      }
-      selectedNetwork.value = newValue as string
-      selectedNetworkWatchHandle = watch(selectedNetwork, (selection) => {
-        router.push({
-          name: "MainDashboard",
-          params: { network: selection }
-        })
-      })
-    }
-
-    const isDashboardRoute = computed(() => {
-      return name.value === 'MainDashboard'
-    })
-
-    const isTransactionRoute = computed(() => {
-      return name.value === 'Transactions' || name.value === 'TransactionsById' || name.value === 'TransactionDetails'
-    })
-
-    const isTokenRoute = computed(() => {
-      return name.value === 'Tokens' || name.value === 'TokenDetails'
-    })
-
-    const isTopicRoute = computed(() => {
-      return name.value === 'Topics' || name.value === 'TopicDetails'
-    })
-
-    const isContractRoute = computed(() => {
-      return name.value === 'Contracts' || name.value === 'ContractDetails'
-    })
-
-    const isAccountRoute = computed(() => {
-      return name.value === 'Accounts' || name.value === 'AccountDetails' || name.value === 'AccountBalances'
-    })
-
-    const isNodeRoute = computed(() => {
-      return name.value === 'Nodes' || name.value === 'NodeDetails'
-    })
-
-    const isStakingRoute = computed(() => {
-      return name.value === 'Staking'
-    })
-
-    const isBlocksRoute = computed(() => {
-      return name.value === 'Blocks'
+    const selectedNetwork = ref(routeManager.currentNetwork.value)
+    onMounted(() => {
+      routeManager.selectedNetwork = selectedNetwork
+      routeManager.updateSelectedNetworkSilently()
     })
 
     return {
@@ -205,19 +150,19 @@ export default defineComponent({
       buildTime,
       productName,
       isStakingEnabled,
-      name,
       isMobileMenuOpen,
       networkRegistry,
       selectedNetwork,
-      isDashboardRoute,
-      isTransactionRoute,
-      isTokenRoute,
-      isTopicRoute,
-      isContractRoute,
-      isAccountRoute,
-      isNodeRoute,
-      isStakingRoute,
-      isBlocksRoute,
+      name: routeManager.currentRoute,
+      isDashboardRoute: routeManager.isDashboardRoute,
+      isTransactionRoute: routeManager.isTransactionRoute,
+      isTokenRoute: routeManager.isTokenRoute,
+      isTopicRoute: routeManager.isTopicRoute,
+      isContractRoute: routeManager.isContractRoute,
+      isAccountRoute: routeManager.isAccountRoute,
+      isNodeRoute: routeManager.isNodeRoute,
+      isStakingRoute: routeManager.isStakingRoute,
+      isBlocksRoute: routeManager.isBlocksRoute,
       routeManager,
     }
   },

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -39,32 +39,32 @@
           </o-field>
         </div>
         <a id="dashboard-menu-item"
-           :class="{'is-rimmed': isDashboardRoute}"
+           :class="{'is-rimmed': isDashboardRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.mainDashboardRoute)">Dashboard</a>
-        <a :class="{ 'is-rimmed': isTransactionRoute}"
+        <a :class="{ 'is-rimmed': isTransactionRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.transactionsRoute)">Transactions</a>
-        <a :class="{ 'is-rimmed': isTokenRoute}"
+        <a :class="{ 'is-rimmed': isTokenRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.tokensRoute)">Tokens</a>
-        <a :class="{ 'is-rimmed': isTopicRoute}"
+        <a :class="{ 'is-rimmed': isTopicRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.topicsRoute)">Topics</a>
-        <a :class="{ 'is-rimmed': isContractRoute}"
+        <a :class="{ 'is-rimmed': isContractRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.contractsRoute)">Contracts</a>
-        <a :class="{ 'is-rimmed': isAccountRoute}"
+        <a :class="{ 'is-rimmed': isAccountRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.accountsRoute)">Accounts</a>
-        <a :class="{ 'is-rimmed': isNodeRoute}"
+        <a :class="{ 'is-rimmed': isNodeRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.nodesRoute)">Nodes</a>
         <a v-if="isStakingEnabled"
-           :class="{ 'is-rimmed': isStakingRoute}"
+           :class="{ 'is-rimmed': isStakingRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.stakingRoute)">Staking</a>
-        <a :class="{ 'is-rimmed': isBlocksRoute}"
+        <a :class="{ 'is-rimmed': isBlocksRoute(previousRoute)}"
            class="button is-ghost h-is-mobile-navbar-item h-is-dense"
            @click="$router.replace(routeManager.blocksRoute)">Blocks</a>
       </div>
@@ -83,8 +83,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
-import {useRoute} from "vue-router";
+import {defineComponent, inject, onBeforeUnmount, onMounted, ref} from 'vue';
 import router, {routeManager} from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/App.vue";
 import Footer from "@/components/Footer.vue";
@@ -103,42 +102,10 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isStakingEnabled = getEnv('VUE_APP_ENABLE_STAKING') === 'true'
 
-    const route = useRoute()
-    const network = computed(() => { return route.params.network })
-    const name = computed(() => { return route.query.from })
-    const selectedNetwork = ref(network.value)
-    watch(selectedNetwork, (selection) => {
-      router.replace({
-        params: {network: selection}
-      })
-    })
-
-    const isDashboardRoute = computed(() => {
-      return name.value === 'MainDashboard'
-    })
-    const isTransactionRoute = computed(() => {
-      return name.value === 'Transactions' || name.value === 'TransactionsById' || name.value === 'TransactionDetails'
-    })
-    const isTokenRoute = computed(() => {
-      return name.value === 'Tokens' || name.value === 'TokenDetails'
-    })
-    const isTopicRoute = computed(() => {
-      return name.value === 'Topics' || name.value === 'TopicDetails'
-    })
-    const isContractRoute = computed(() => {
-      return name.value === 'Contracts' || name.value === 'ContractDetails'
-    })
-    const isAccountRoute = computed(() => {
-      return name.value === 'Accounts' || name.value === 'AccountDetails' || name.value === 'AccountBalances'
-    })
-    const isNodeRoute = computed(() => {
-      return name.value === 'Nodes' || name.value === 'NodeDetails'
-    })
-    const isStakingRoute = computed(() => {
-      return name.value === 'Staking'
-    })
-    const isBlocksRoute = computed(() => {
-      return name.value === 'Blocks'
+    const selectedNetwork = ref(routeManager.currentNetwork.value)
+    onMounted(() => {
+      routeManager.selectedNetwork = selectedNetwork
+      routeManager.updateSelectedNetworkSilently()
     })
 
     const  onResizeHandler = () => {
@@ -158,15 +125,16 @@ export default defineComponent({
       isTouchDevice,
       isStakingEnabled,
       selectedNetwork,
-      isDashboardRoute,
-      isTransactionRoute,
-      isTokenRoute,
-      isTopicRoute,
-      isContractRoute,
-      isAccountRoute,
-      isNodeRoute,
-      isStakingRoute,
-      isBlocksRoute,
+      previousRoute: routeManager.previousRoute,
+      isDashboardRoute: routeManager.testDashboardRoute,
+      isTransactionRoute: routeManager.testTransactionRoute,
+      isTokenRoute: routeManager.testTokenRoute,
+      isTopicRoute: routeManager.testTopicRoute,
+      isContractRoute: routeManager.testContractRoute,
+      isAccountRoute: routeManager.testAccountRoute,
+      isNodeRoute: routeManager.testNodeRoute,
+      isStakingRoute: routeManager.testStakingRoute,
+      isBlocksRoute: routeManager.testBlocksRoute,
       networkRegistry,
       routeManager
     }

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -76,37 +76,62 @@ export class RouteManager {
         })
     }
 
-    public readonly isDashboardRoute = computed(() => this.currentRoute.value === 'MainDashboard')
+    public readonly previousRoute = computed(() => (this.router?.currentRoute.value?.query.from as string))
 
-    public readonly isTransactionRoute = computed(
-        () => this.currentRoute.value === 'Transactions'
-            || this.currentRoute.value === 'TransactionsById'
-            || this.currentRoute.value === 'TransactionDetails')
+    public readonly isDashboardRoute = computed(() => this.testDashboardRoute())
+    public readonly isTransactionRoute = computed(() => this.testTransactionRoute())
+    public readonly isTokenRoute = computed(() => this.testTokenRoute())
+    public readonly isTopicRoute = computed(() => this.testTopicRoute())
+    public readonly isContractRoute = computed(() => this.testContractRoute())
+    public readonly isAccountRoute = computed(() => this.testAccountRoute())
+    public readonly isNodeRoute = computed(() => this.testNodeRoute())
+    public readonly isStakingRoute = computed(() => this.testStakingRoute())
+    public readonly isBlocksRoute = computed(() => this.testBlocksRoute())
 
-    public readonly isTokenRoute = computed(
-        () => this.currentRoute.value === 'Tokens'
-            || this.currentRoute.value === 'TokenDetails')
+    public testDashboardRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'MainDashboard'
+    }
 
-    public readonly isTopicRoute = computed(
-        () => this.currentRoute.value === 'Topics'
-            || this.currentRoute.value === 'TopicDetails')
+    public testTransactionRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Transactions' || r === 'TransactionsById' || r === 'TransactionDetails'
+    }
 
-    public readonly isContractRoute = computed(
-        () => this.currentRoute.value === 'Contracts'
-            || this.currentRoute.value === 'ContractDetails')
+    public testTokenRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Tokens' || r === 'TokenDetails'
+    }
 
-    public readonly isAccountRoute = computed(
-        () => this.currentRoute.value === 'Accounts'
-            || this.currentRoute.value === 'AccountDetails'
-            || this.currentRoute.value === 'AccountBalances')
+    public testTopicRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Topics' || r === 'TopicDetails'
+    }
 
-    public readonly isNodeRoute = computed(
-        () => this.currentRoute.value === 'Nodes'
-            || this.currentRoute.value === 'NodeDetails')
+    public testContractRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Contracts' || r === 'ContractDetails'
+    }
 
-    public readonly isStakingRoute = computed(() => this.currentRoute.value === 'Staking')
+    public testAccountRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Accounts' || r === 'AccountDetails' || r === 'AccountBalances'
+    }
 
-    public readonly isBlocksRoute = computed(() => this.currentRoute.value === 'Blocks')
+    public testNodeRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Nodes' || r === 'NodeDetails'
+    }
+
+    public testStakingRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Staking'
+    }
+
+    public testBlocksRoute(route: string|null = null): boolean {
+        const r = route ?? this.currentRoute.value
+        return r === 'Blocks' || r === 'BlockDetails'
+    }
 
     //
     // Transaction


### PR DESCRIPTION
**Description**:

With these changes, the route logic currently still in TopNavBar and MobileMenu is moved to RouteManager.
This will later allow RouteManager to centralise logic related to network switching (i.e clearing the contents of Collectors and reloading the contents of NodesLoader singleton).

**Related issue(s)**:

Fixes #371 

**Notes for reviewer**:

Should be deployed shortly to staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
