### PR TITLE
00369 clear collectors when switching

### DIFF
--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -115,7 +115,7 @@
 
 <script lang="ts">
 
-import {defineComponent, inject, onMounted, ref} from "vue";
+import {defineComponent, inject, ref} from "vue";
 import {routeManager} from "@/router";
 import SearchBar from "@/components/SearchBar.vue";
 import AxiosStatus from "@/components/AxiosStatus.vue";
@@ -136,8 +136,6 @@ export default defineComponent({
     const isStakingEnabled = getEnv('VUE_APP_ENABLE_STAKING') === 'true'
 
     const isMobileMenuOpen = ref(false)
-
-    onMounted(() => routeManager.updateSelectedNetworkSilently())
 
     return {
       isSmallScreen,

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -137,11 +137,7 @@ export default defineComponent({
 
     const isMobileMenuOpen = ref(false)
 
-    const selectedNetwork = ref(routeManager.currentNetwork.value)
-    onMounted(() => {
-      routeManager.selectedNetwork = selectedNetwork
-      routeManager.updateSelectedNetworkSilently()
-    })
+    onMounted(() => routeManager.updateSelectedNetworkSilently())
 
     return {
       isSmallScreen,
@@ -152,7 +148,7 @@ export default defineComponent({
       isStakingEnabled,
       isMobileMenuOpen,
       networkRegistry,
-      selectedNetwork,
+      selectedNetwork: routeManager.selectedNetwork,
       name: routeManager.currentRoute,
       isDashboardRoute: routeManager.isDashboardRoute,
       isTransactionRoute: routeManager.isTransactionRoute,

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -83,7 +83,7 @@
 
 <script lang="ts">
 
-import {defineComponent, inject, onBeforeUnmount, onMounted, ref} from 'vue';
+import {defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
 import router, {routeManager} from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/App.vue";
 import Footer from "@/components/Footer.vue";
@@ -102,11 +102,7 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isStakingEnabled = getEnv('VUE_APP_ENABLE_STAKING') === 'true'
 
-    const selectedNetwork = ref(routeManager.currentNetwork.value)
-    onMounted(() => {
-      routeManager.selectedNetwork = selectedNetwork
-      routeManager.updateSelectedNetworkSilently()
-    })
+    onMounted(() => routeManager.updateSelectedNetworkSilently())
 
     const  onResizeHandler = () => {
       if (window.innerWidth >= MEDIUM_BREAKPOINT) {
@@ -124,7 +120,7 @@ export default defineComponent({
       isSmallScreen,
       isTouchDevice,
       isStakingEnabled,
-      selectedNetwork,
+      selectedNetwork: routeManager.selectedNetwork,
       previousRoute: routeManager.previousRoute,
       isDashboardRoute: routeManager.testDashboardRoute,
       isTransactionRoute: routeManager.testTransactionRoute,

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -102,8 +102,6 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isStakingEnabled = getEnv('VUE_APP_ENABLE_STAKING') === 'true'
 
-    onMounted(() => routeManager.updateSelectedNetworkSilently())
-
     const  onResizeHandler = () => {
       if (window.innerWidth >= MEDIUM_BREAKPOINT) {
         router.back()

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -41,7 +41,7 @@ export class RouteManager {
         watch(this.currentNetwork, () => {
             this.updateSelectedNetworkSilently()
             RouteManager.resetSingletons()
-        })
+        }, { immediate: true})
     }
 
     public readonly currentRoute = computed(() => this.router?.currentRoute.value?.name)
@@ -69,11 +69,11 @@ export class RouteManager {
     public selectedNetworkWatchHandle: WatchStopHandle|undefined
 
     public updateSelectedNetworkSilently(): void {
-        if (routeManager.selectedNetworkWatchHandle) {
-            routeManager.selectedNetworkWatchHandle()
+        if (this.selectedNetworkWatchHandle) {
+            this.selectedNetworkWatchHandle()
         }
         this.selectedNetwork.value = this.currentNetwork.value
-        routeManager.selectedNetworkWatchHandle = watch(this.selectedNetwork, (selection) => {
+        this.selectedNetworkWatchHandle = watch(this.selectedNetwork, (selection) => {
             router.push({
                 name: "MainDashboard",
                 params: { network: selection }

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -23,6 +23,10 @@ import {Transaction} from "@/schemas/HederaSchemas";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import {computed, ref, watch, WatchStopHandle} from "vue";
 import router, {routeManager} from "@/router";
+import {BlocksResponseCollector} from "@/utils/collector/BlocksResponseCollector";
+import {TokenInfoCollector} from "@/utils/collector/TokenInfoCollector";
+import {TransactionByHashCollector} from "@/utils/collector/TransactionByHashCollector";
+import {TransactionCollector} from "@/utils/collector/TransactionCollector";
 
 export class RouteManager {
 
@@ -36,6 +40,7 @@ export class RouteManager {
         this.router = router
         watch(this.currentNetwork, () => {
             this.updateSelectedNetworkSilently()
+            RouteManager.resetSingletons()
         })
     }
 
@@ -277,6 +282,17 @@ export class RouteManager {
 
     public routeToMainDashboard(): Promise<NavigationFailure | void | undefined> {
         return this.router.push(this.mainDashboardRoute)
+    }
+
+    //
+    // Private
+    //
+
+    private static resetSingletons() {
+        BlocksResponseCollector.instance.clear()
+        TokenInfoCollector.instance.clear()
+        TransactionByHashCollector.instance.clear()
+        TransactionCollector.instance.clear()
     }
 }
 

--- a/src/utils/collector/Collector.ts
+++ b/src/utils/collector/Collector.ts
@@ -77,6 +77,10 @@ export abstract class Collector<E, K> {
         return result
     }
 
+    public clear(): void {
+        this.entries.clear()
+    }
+
     //
     // Protected
     //


### PR DESCRIPTION
**Description**:

With these simple changes, the contents of `TransactionCollector`, `TransactionByHashCollector` , `TokenInfoCollector` and `BlockResponseCollector` is cleared by `RouteManager` when switching networks.

**Related issue(s)**:

Fixes #369 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
