### PR TITLE
00276 show rewards in accountdetails

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -194,6 +194,15 @@
       </template>
     </DashboardCard>
 
+    <DashboardCard v-if="normalizedAccountId">
+      <template v-slot:title>
+        <span class="h-is-secondary-title">Recent Staking Rewards</span>
+      </template>
+      <template v-slot:content>
+        <StakingRewardsTable :controller="rewardsTableController"/>
+      </template>
+    </DashboardCard>
+
   </section>
 
   <Footer/>
@@ -233,6 +242,8 @@ import AliasValue from "@/components/values/AliasValue.vue";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
 import router, {routeManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
+import {StakingRewardsTableController} from "@/components/staking/StakingRewardsTableController";
+import StakingRewardsTable from "@/components/staking/StakingRewardsTable.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -258,7 +269,8 @@ export default defineComponent({
     KeyValue,
     EthAddress,
     DurationValue,
-    StringValue
+    StringValue,
+    StakingRewardsTable
   },
 
   props: {
@@ -377,8 +389,12 @@ export default defineComponent({
     const stakeNodeLoader = new NodeLoader(accountLoader.stakedNodeId)
 
     //
-    // account create transaction
+    // Rewards Table Controller
     //
+    const rewardsTableController = new StakingRewardsTableController(router, accountLoader.accountId, perPage)
+    onMounted(() => rewardsTableController.mount())
+    onBeforeUnmount(() => rewardsTableController.unmount())
+
     const contractRoute = computed(() => {
       const accountId = accountLoader.accountId.value
       return accountId ? routeManager.makeRouteToContract(accountId) : null
@@ -416,6 +432,7 @@ export default defineComponent({
       stakedNodeId: accountLoader.stakedNodeId,
       stakedAccountId: accountLoader.stakedAccountId,
       stakedNodeDescription: stakeNodeLoader.nodeDescription,
+      rewardsTableController,
       contractRoute,
       stakedNodeRoute,
       operatorNodeRoute,

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -194,7 +194,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard v-if="normalizedAccountId">
+    <DashboardCard v-if="normalizedAccountId && availableAPI">
       <template v-slot:title>
         <span class="h-is-secondary-title">Recent Staking Rewards</span>
       </template>
@@ -436,6 +436,7 @@ export default defineComponent({
       contractRoute,
       stakedNodeRoute,
       operatorNodeRoute,
+      availableAPI: rewardsTableController.availableAPI
     }
   }
 });

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -22,6 +22,7 @@ import {computed, ComputedRef, ref, Ref, watch, WatchSource, WatchStopHandle} fr
 import {LocationQuery, Router} from "vue-router";
 import {fetchNumberQueryParam, fetchStringQueryParam} from "@/utils/RouteManager";
 import {RowBuffer} from "@/utils/table/RowBuffer";
+import axios, {AxiosError} from "axios";
 
 export abstract class TableController<R, K> {
 
@@ -216,6 +217,10 @@ export abstract class TableController<R, K> {
 
     private readonly errorHandler = (reason: unknown): void => {
         console.log("reason=" + reason)
+        if (axios.isAxiosError(reason)) {
+            const axiosError = reason as AxiosError
+            console.log("url=" + axiosError.config.url)
+        }
     }
 
     private getPageParam(): number|null {

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -103,6 +105,9 @@ describe("AccountDetails.vue", () => {
         const matcher7 = "/api/v1/transactions?timestamp=" + SAMPLE_ACCOUNT.created_timestamp
         mock.onGet(matcher7).reply(200, SAMPLE_TRANSACTIONS);
 
+        const matcher8 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -176,6 +181,9 @@ describe("AccountDetails.vue", () => {
         const matcher6 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher6).reply(200, SAMPLE_COINGECKO);
 
+        let matcher8 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -201,6 +209,9 @@ describe("AccountDetails.vue", () => {
         const token2 = SAMPLE_TOKEN_DUDE
         matcher3 = "/api/v1/tokens/" + token2.token_id
         mock.onGet(matcher3).reply(200, token2);
+
+        matcher8 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
 
         await wrapper.setProps({
             accountId: SAMPLE_ACCOUNT_DUDE.account ?? undefined
@@ -274,6 +285,9 @@ describe("AccountDetails.vue", () => {
         const matcher6 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher6).reply(200, SAMPLE_COINGECKO);
 
+        const matcher8 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DELETED.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -315,6 +329,9 @@ describe("AccountDetails.vue", () => {
         const matcher5 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher5).reply(200, SAMPLE_COINGECKO);
 
+        const matcher8 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_NODE.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -354,6 +371,9 @@ describe("AccountDetails.vue", () => {
 
         const matcher5 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher5).reply(200, SAMPLE_COINGECKO);
+
+        const matcher8 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_ACCOUNT.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
 
         const wrapper = mount(AccountDetails, {
             global: {

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -138,6 +140,9 @@ describe("NodeDetails.vue", () => {
         const matcher6 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
         mock.onGet(matcher6).reply(200, SAMPLE_COINGECKO);
 
+        let matcher8 = "/api/v1/accounts/" + account1.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -163,6 +168,9 @@ describe("NodeDetails.vue", () => {
         const token2 = SAMPLE_TOKEN_DUDE
         matcher3 = "/api/v1/tokens/" + token2.token_id
         mock.onGet(matcher3).reply(200, token2);
+
+        matcher8 = "/api/v1/accounts/" + account2.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
 
         await wrapper.setProps({
             accountId: SAMPLE_ACCOUNT_DUDE.account ?? undefined

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -109,6 +109,8 @@ describe("Staking.vue", () => {
         mock.onGet(matcher4).reply(200, STAKE_UPDATE_TRANSACTIONS)
         const matcher5 = "/api/v1/transactions"
         mock.onGet(matcher5).reply(200, SAMPLE_TRANSACTIONS)
+        const matcher8 = "/api/v1/accounts/" + testDriver.account.account + "/rewards"
+        mock.onGet(matcher8).reply(200, { rewards: [] })
 
         const wrapper = mount(Staking, {
             global: {


### PR DESCRIPTION
**Description**:

Changes below:
- display staking rewards in account details page (if `api/v1/accounts/{accountId}/rewards`  is available)
- remove logic emulating reward collection using `api/v1/transactions`

**Related issue(s)**:

Fixes #276

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
