### PR TITLE
00385 display ethereum nonce

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -172,6 +172,12 @@
                             :show-none="true"/>
               </template>
             </Property>
+            <Property>
+              <template v-slot:name>Ethereum Nonce</template>
+              <template v-slot:value>
+                <StringValue :string-value="account?.ethereum_nonce?.toString()"/>
+              </template>
+            </Property>
       </template>
     </DashboardCard>
 

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -165,7 +165,7 @@
               </template>
             </Property>
             <Property id="ethereumAddress">
-              <template v-slot:name>Ethereum Address</template>
+              <template v-slot:name>EVM Address</template>
               <template v-slot:value>
                 <EthAddress v-if="ethereumAddress"
                             :address="ethereumAddress"

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -164,7 +164,7 @@
                 <KeyValue :key-bytes="account?.key?.key" :key-type="account?.key?._type" :show-none="true"/>
               </template>
             </Property>
-            <Property id="ethereumAddress">
+            <Property id="evmAddress">
               <template v-slot:name>EVM Address</template>
               <template v-slot:value>
                 <EthAddress v-if="ethereumAddress"
@@ -172,7 +172,7 @@
                             :show-none="true"/>
               </template>
             </Property>
-            <Property>
+            <Property id="ethereumNonce">
               <template v-slot:name>Ethereum Nonce</template>
               <template v-slot:value>
                 <StringValue :string-value="account?.ethereum_nonce?.toString()"/>

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -134,8 +134,8 @@
                 <TokenAmount v-else :amount="parseIntString(tokenInfo?.max_supply)" :show-extra="false" :token-id="normalizedTokenId"/>
               </template>
             </Property>
-            <Property id="ethereumAddress">
-              <template v-slot:name>ERC20 Address</template>
+            <Property id="evmAddress">
+              <template v-slot:name>EVM Address</template>
               <template v-slot:value>
                 <EthAddress v-if="ethereumAddress"
                             :address="ethereumAddress"

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1398,7 +1398,7 @@ export const SAMPLE_ACCOUNT = {
     "memo": "",
     "receiver_sig_required": false,
     "evm_address": null,
-    "ethereum_nonce": null,
+    "ethereum_nonce": 0,
     "decline_reward": null,
     "staked_node_id": null,
     "staked_account_id": null,

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -136,6 +136,11 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("false")
 
+        expect(wrapper.get("#evmAddressValue").text()).toBe(
+            "0000 0000 0000 0000 0000 0000 0000 0000 000b 2607" +
+            "Copy to Clipboard")
+        expect(wrapper.get("#ethereumNonceValue").text()).toBe("0")
+
         expect(wrapper.get("#stakedToName").text()).toBe("Staked to")
         expect(wrapper.get("#stakedToValue").text()).toBe("None")
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -111,7 +111,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#totalSupplyValue").text()).toBe("1")
         expect(wrapper.get("#initialSupplyValue").text()).toBe("1")
         expect(wrapper.get("#maxSupplyValue").text()).toBe("Infinite")
-        expect(wrapper.get("#ethereumAddressValue").text()).toBe("0000 0000 0000 0000 0000 0000 0000 0000 01c4 9eecCopy to ClipboardImport in MetaMaskPlease install MetaMask! To watch this asset with MetaMask, you must download and install MetaMask extension for your browser.")
+        expect(wrapper.get("#evmAddressValue").text()).toBe("0000 0000 0000 0000 0000 0000 0000 0000 01c4 9eecCopy to ClipboardImport in MetaMaskPlease install MetaMask! To watch this asset with MetaMask, you must download and install MetaMask extension for your browser.")
 
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)


### PR DESCRIPTION
**Description**:

With these changes:
- the AccountDetails view now displays the _Ethereum Nonce_ property
- the property _Ethereum Address_ has been renamed _EVM Address_ in the AccountDetails view, for consistency with the ContractDetails view and to avoid any confusion with a real Ethereum Address.

**Related issue(s)**:

Fixes #385 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
