### PR TITLE
00388 SearchBar now detects if public key has multiple associated accounts …

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -127,9 +127,14 @@ export default defineComponent({
                 routeManager.routeToAccount(r.account.account)
               }
               searchDidEnd(true)
-            } else if (r.accountWithKey != null) {
-              if (r.accountWithKey.account) {
-                routeManager.routeToAccount(r.accountWithKey.account)
+            } else if (r.accountsWithKey.length >= 1) {
+              if (r.accountsWithKey.length >= 2) {
+                routeManager.routeToAccountsWithKey(r.searchedId)
+              } else {
+                const accountId = r.accountsWithKey[0].account
+                if (accountId) {
+                  routeManager.routeToAccount(accountId)
+                }
               }
               searchDidEnd(true)
             } else if (r.transactions.length >= 1) {

--- a/src/components/account/AccountTableController.ts
+++ b/src/components/account/AccountTableController.ts
@@ -26,12 +26,15 @@ import {Router} from "vue-router";
 
 export class AccountTableController extends TableController<AccountInfo, string> {
 
+    private readonly pubKey: string|null
+
     //
     // Public
     //
 
-    public constructor(router: Router, pageSize: ComputedRef<number>) {
-        super(router, pageSize, 10 * pageSize.value, 5000, 10, 100);
+    public constructor(router: Router, pageSize: ComputedRef<number>, pubKey: string|null = null) {
+        super(router, pageSize, 10 * pageSize.value, 5000, 10, 100)
+        this.pubKey = pubKey
     }
 
     //
@@ -42,13 +45,17 @@ export class AccountTableController extends TableController<AccountInfo, string>
 
         const params = {} as {
             limit: number
-            "account.id": string | undefined
+            "account.id": string | undefined,
+            "account.publickey": string | undefined,
             order: string
         }
         params.limit = limit
         params.order = order
         if (accountId !== null) {
             params["account.id"] = operator + ":" + accountId
+        }
+        if (this.pubKey !== null) {
+            params["account.publickey"] = this.pubKey
         }
         const cb = (r: AxiosResponse<AccountsResponse>): Promise<AccountInfo[] | null> => {
             return Promise.resolve(r.data.accounts ?? [])

--- a/src/pages/AccountsWithKey.vue
+++ b/src/pages/AccountsWithKey.vue
@@ -1,0 +1,104 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <section :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}" class="section">
+
+    <DashboardCard>
+      <template v-slot:title>
+        <span class="h-is-primary-title">Accounts with Key </span>
+        <span class="h-is-tertiary-text">{{ pubKey }}</span>
+      </template>
+      <template v-slot:control>
+        <PlayPauseButton v-bind:controller="accountTableController"/>
+      </template>
+      <template v-slot:content>
+        <AccountTable :controller="accountTableController"/>
+      </template>
+    </DashboardCard>
+
+  </section>
+
+  <Footer/>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
+import AccountTable from "@/components/account/AccountTable.vue";
+import DashboardCard from "@/components/DashboardCard.vue";
+import Footer from "@/components/Footer.vue";
+import {AccountTableController} from "@/components/account/AccountTableController";
+import PlayPauseButton from "@/components/PlayPauseButton.vue";
+import {useRouter} from "vue-router";
+
+export default defineComponent({
+  name: 'AccountsWithKey',
+
+  props: {
+    network: String,
+    pubKey: String
+  },
+
+  components: {
+    PlayPauseButton,
+    Footer,
+    DashboardCard,
+    AccountTable
+  },
+
+  setup(props) {
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isMediumScreen = inject('isMediumScreen', true)
+    const isTouchDevice = inject('isTouchDevice', false)
+
+    //
+    // AccountTableController
+    //
+    const perPage = computed(() => isMediumScreen ? 15 : 10)
+    const accountTableController = new AccountTableController(useRouter(), perPage, props.pubKey ?? null)
+    onMounted(() => accountTableController.mount())
+    onBeforeUnmount(() => accountTableController.unmount())
+
+    return {
+      isSmallScreen,
+      isTouchDevice,
+      accountTableController,
+    }
+  }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped/>

--- a/src/router.ts
+++ b/src/router.ts
@@ -47,6 +47,7 @@ import {WalletManager} from "@/utils/wallet/WalletManager";
 import BlockDetails from "@/pages/BlockDetails.vue";
 import Blocks from "@/pages/Blocks.vue";
 import {getEnv} from "@/utils/getEnv";
+import AccountsWithKey from "@/pages/AccountsWithKey.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -94,6 +95,12 @@ const routes: Array<RouteRecordRaw> = [
     path: '/:network/accounts',
     name: 'Accounts',
     component: Accounts,
+    props: true
+  },
+  {
+    path: '/:network/accountsWithKey/:pubKey',
+    name: 'AccountsWithKey',
+    component: AccountsWithKey,
     props: true
   },
   {

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -126,7 +126,7 @@ export class RouteManager {
 
     public testAccountRoute(route: string|null = null): boolean {
         const r = route ?? this.currentRoute.value
-        return r === 'Accounts' || r === 'AccountDetails' || r === 'AccountBalances'
+        return r === 'Accounts' || r === 'AccountDetails' || r === 'AccountBalances' || r === 'AccountsWithKey'
     }
 
     public testNodeRoute(route: string|null = null): boolean {
@@ -193,6 +193,20 @@ export class RouteManager {
 
     public routeToAccount(accountId: string): Promise<NavigationFailure | void | undefined> {
         return this.router.push(this.makeRouteToAccount(accountId))
+    }
+
+    //
+    // Accounts with key
+    //
+
+    public makeRouteToAccountsWithKey(pubKey: string): RouteLocationRaw {
+        return {
+            name: 'AccountsWithKey', params: {pubKey: pubKey}
+        }
+    }
+
+    public routeToAccountsWithKey(pubKey: string): Promise<NavigationFailure | void | undefined> {
+        return this.router.push(this.makeRouteToAccountsWithKey(pubKey))
     }
 
     //

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -39,7 +39,7 @@ export class SearchRequest {
 
     public readonly searchedId: string
     public account: AccountInfo|null = null
-    public accountWithKey: AccountInfo|null = null
+    public accountsWithKey = Array<AccountInfo>()
     public transactions = Array<Transaction>()
     public tokenInfo: TokenInfo|null = null
     public topicMessages = Array<TopicMessage>()
@@ -136,10 +136,9 @@ export class SearchRequest {
         // 2) Searches accounts with public key
         if (publicKey !== null) {
             axios
-                .get<AccountsResponse>("api/v1/accounts/?account.publickey=" + publicKey)
+                .get<AccountsResponse>("api/v1/accounts/?account.publickey=" + publicKey + "&limit=2")
                 .then(response => {
-                    const accounts = response.data.accounts ?? []
-                    this.accountWithKey = accounts.length >= 1 ? accounts[0] : null
+                    this.accountsWithKey = response.data.accounts ?? []
                 })
                 .catch((reason: unknown) => {
                     this.updateErrorCount(reason)

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -49,7 +49,8 @@ const SAMPLE_ACCOUNT_ADDRESS = EntityID.parse(SAMPLE_ACCOUNT.account)!.toAddress
 const matcher_account_with_address = "/api/v1/accounts/" + SAMPLE_ACCOUNT_ADDRESS
 mock.onGet(matcher_account_with_address).reply(200, SAMPLE_ACCOUNT)
 
-const matcher_account_with_public_key = "/api/v1/accounts/?account.publickey=" + SAMPLE_ACCOUNTS.accounts[0].key.key
+const matcher_account_with_public_key = "/api/v1/accounts/?account.publickey="
+    + SAMPLE_ACCOUNTS.accounts[0].key.key + "&limit=2"
 mock.onGet(matcher_account_with_public_key).reply(200, SAMPLE_ACCOUNTS)
 
 
@@ -95,7 +96,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT.account)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -110,7 +111,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT_ADDRESS)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -125,7 +126,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT.key.key)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toStrictEqual(SAMPLE_ACCOUNT)
+        expect(r.accountsWithKey).toStrictEqual([SAMPLE_ACCOUNT])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -140,7 +141,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_ACCOUNT.alias)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -156,7 +157,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_ALIAS_HEX)
         expect(r.account).toStrictEqual(SAMPLE_ACCOUNT)
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -175,7 +176,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_TRANSACTION.transaction_id)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([SAMPLE_TRANSACTION])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -190,7 +191,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(TRANSACTION_HASH)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([SAMPLE_TRANSACTION])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -209,7 +210,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_TOKEN.token_id)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toStrictEqual(SAMPLE_TOKEN)
         expect(r.topicMessages).toStrictEqual([])
@@ -224,7 +225,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_TOKEN_ADDRESS)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toStrictEqual(SAMPLE_TOKEN)
         expect(r.topicMessages).toStrictEqual([])
@@ -243,7 +244,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_TOPIC_ID)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual(SAMPLE_TOPIC_MESSAGES.messages)
@@ -262,7 +263,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_CONTRACT.contract_id)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -277,7 +278,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(SAMPLE_CONTRACT.evm_address)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -293,7 +294,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(UNKNOWN_ID)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -308,7 +309,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(INVALID_EVM_ADDRESS)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
@@ -321,7 +322,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r2.searchedId).toBe(aliasHex2)
         expect(r2.account).toBeNull()
-        expect(r2.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r2.transactions).toStrictEqual([])
         expect(r2.tokenInfo).toBeNull()
         expect(r2.topicMessages).toStrictEqual([])
@@ -337,7 +338,7 @@ describe("SearchRequest.ts", () => {
 
         expect(r.searchedId).toBe(INVAlID_ID)
         expect(r.account).toBeNull()
-        expect(r.accountWithKey).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
         expect(r.transactions).toStrictEqual([])
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])


### PR DESCRIPTION
**Description**:

With the changes below, `SearchBar` now detects if a public key has multiple associated accounts and displays them in a separate page so that user can walk through and choose the interesting one.

**Related issue(s)**:

Fixes #388

**Notes for reviewer**:

On mainnet, the following public key:
- `0x00032e74f928e6d5cf9ec40f554cf2172f379776e4591f75973c8c013295dd41 `

has two associated accounts:
- `0.0.1188864`
- `0.0.1188869`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
