### PR TITLE
00389 improve help text

### DIFF
--- a/.run/serve_https with branding.run.xml
+++ b/.run/serve_https with branding.run.xml
@@ -7,7 +7,7 @@
     </scripts>
     <node-interpreter value="project" />
     <envs>
-      <env name="BRANDING_LOCATION" value="../branding" />
+      <env name="BRANDING_LOCATION" value="../hashscan.io" />
     </envs>
     <method v="2" />
   </configuration>

--- a/src/components/values/AliasValuev2.vue
+++ b/src/components/values/AliasValuev2.vue
@@ -1,0 +1,75 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <div class="should-wrap">
+
+    <HexaValue :byte-string="hexValue" :show-none="true"/>
+
+  </div>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent} from "vue";
+import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
+import HexaValue from "@/components/values/HexaValue.vue";
+
+export default defineComponent({
+  name: "AliasValuev2",
+  components: {HexaValue},
+  props: {
+    aliasValue: String,
+  },
+  setup(props) {
+    const hexValue = computed(() => {
+      let result
+      if (props.aliasValue) {
+        const alias = base32ToAlias(props.aliasValue)
+        result = alias ? "0x" + byteToHex(alias) : null
+      } else {
+        result = null
+      }
+      return result
+    })
+    return {
+      hexValue
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+
+</style>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -133,21 +133,21 @@
                 <DurationValue v-bind:number-value="account?.auto_renew_period"/>
               </template>
             </Property>
+            <Property id="maxAutoAssociation">
+              <template v-slot:name>Max. Auto. Association</template>
+              <template v-slot:value>
+                <StringValue :string-value="account?.max_automatic_token_associations?.toString()"/>
+              </template>
+            </Property>
+            <Property id="receiverSigRequired">
+              <template v-slot:name>Receiver Sig. Required</template>
+              <template v-slot:value>
+                <StringValue :string-value="account?.receiver_sig_required?.toString()"/>
+              </template>
+            </Property>
       </template>
 
       <template v-slot:rightContent>
-              <Property id="maxAutoAssociation">
-                <template v-slot:name>Max. Auto. Association</template>
-                <template v-slot:value>
-                  <StringValue :string-value="account?.max_automatic_token_associations?.toString()"/>
-                </template>
-              </Property>
-              <Property id="receiverSigRequired">
-                <template v-slot:name>Receiver Sig. Required</template>
-                <template v-slot:value>
-                  <StringValue :string-value="account?.receiver_sig_required?.toString()"/>
-                </template>
-              </Property>
             <Property id="key">
               <template v-slot:name>Admin Key</template>
               <template v-slot:value>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -74,16 +74,6 @@
             </div>
           </div>
         </div>
-        <div class="columns h-is-property-text">
-          <div class="column">
-            <Property id="alias" :class="{'mb-0':account?.alias}" :full-width="true">
-              <template v-slot:name>Alias</template>
-              <template v-slot:value>
-                <AliasValue :alias-value="account?.alias"/>
-              </template>
-            </Property>
-          </div>
-        </div>
       </template>
 
       <template v-slot:leftContent>
@@ -164,8 +154,16 @@
                 <KeyValue :key-bytes="account?.key?.key" :key-type="account?.key?._type" :show-none="true"/>
               </template>
             </Property>
+
+            <Property id="alias" :class="{'mb-0':account?.alias}">
+              <template v-slot:name>public-key-format Alias</template>
+              <template v-slot:value>
+                <AliasValuev2 :alias-value="account?.alias"/>
+              </template>
+            </Property>
+
             <Property id="evmAddress">
-              <template v-slot:name>EVM Address</template>
+              <template v-slot:name>Ethereum-format Alias</template>
               <template v-slot:value>
                 <EthAddress v-if="ethereumAddress"
                             :address="ethereumAddress"
@@ -244,12 +242,12 @@ import AccountLink from "@/components/values/AccountLink.vue";
 import {AccountLoader} from "@/components/account/AccountLoader";
 import {ContractLoader} from "@/components/contract/ContractLoader";
 import {NodeLoader} from "@/components/node/NodeLoader";
-import AliasValue from "@/components/values/AliasValue.vue";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
 import router, {routeManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
 import {StakingRewardsTableController} from "@/components/staking/StakingRewardsTableController";
 import StakingRewardsTable from "@/components/staking/StakingRewardsTable.vue";
+import AliasValuev2 from "@/components/values/AliasValuev2.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -258,8 +256,8 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
+    AliasValuev2,
     TransactionLink,
-    AliasValue,
     AccountLink,
     NotificationBanner,
     Property,

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -36,8 +36,7 @@
     </p>
     <br/>
 
-    <div class="block">
-      <p class="h-is-tertiary-text" style="font-weight: 300">
+    <div class="block h-is-tertiary-text" style="font-weight: 300">
         <template v-if="errorCount >= 1">
           Server reported errors during the search execution.<br/>
           This might be transient. Try to search again in a few moments.
@@ -47,16 +46,56 @@
           <span style="font-weight: 400">{{ this.searchedId }}</span>
           <span >".</span>
           <br/><br/>
-          Make sure you enter one of the expressions below:<br/><br/>
-          an entity ID (0.0.x),<br/>
-          a transaction ID (0.0.x@seconds.nanoseconds),<br/>
-          a transaction hash (48 bytes in hexadecimal notation),<br/>
-          a transaction timestamp (seconds.nanoseconds),<br/>
-          an ethereum address (20 bytes in hexadecimal notation),<br/>
-          an account public key (32 or 33 bytes in hexadecimal notation),<br/>
-          an account alias (string in base 32 or hexadecimal notation).<br/>
+          <hr style="height: 1px" />
+          <br/>
+
+          <div class="has-text-centered">
+            <ul class="has-text-left" style="display: inline-block; max-width: 1024px">
+              <span style="display: inline-block">Make sure you enter one of the expressions below:</span>
+              <br/><br/>
+              <li>
+                &bull; an entity ID (0.0.x)<br/>
+              </li>
+              <li>
+                &bull; a transaction ID (0.0.x@seconds.nanoseconds)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;0.0.1484550@1672860351.268707677
+                </span>
+              </li>
+              <li>
+                &bull; a transaction hash (96 characters in hexadecimal notation)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;0x7b35c2dba2199cea846d96b58d8786132831a3522650bb369899e6fac01933a8ca3d79da0db93cd2bf816c1b97819afa
+                </span>
+              </li>
+              <li>
+                &bull; a transaction timestamp (seconds.nanoseconds)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;1672860351.268707677
+                </span>
+              </li>
+              <li>
+                &bull; an account public key (64 or 66 characters in hexadecimal notation)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;0xe3cc1bffc8668948721a6fe1816d282137222ab3a8e83dc1f45d3199a395e0f5
+                </span>
+              </li>
+              <li>
+                &bull; a public-key-format alias (string in base 32 or hexadecimal notation)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;0x1220e3cc1bffc8668948721a6fe1816d282137222ab3a8e83dc1f45d3199a395e0f5
+                </span>
+              </li>
+              <li>
+                &bull; an Ethereum-format alias (40 characters in hexadecimal notation)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;0x0000000000000000000000000000000000000455
+                </span>
+              </li>
+            </ul>
+          </div>
+
         </template>
-      </p>
     </div>
 
   </section>

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -54,45 +54,48 @@
               <br/><br/>
               <div>
                 &bull; an entity ID (0.0.x)<br/>
-                <span class="should-wrap h-help-item">
+                <div class="should-wrap h-help-item">
                   Example:&nbsp;0.0.1484550
-                </span>
+                </div>
               </div>
               <div>
                 &bull; a transaction ID (0.0.x@seconds.nanoseconds)<br/>
-                <span class="should-wrap h-help-item">
+                <div class="should-wrap h-help-item">
                   Example:&nbsp;0.0.1484550@1672860351.268707677
-                </span>
+                </div>
               </div>
               <div>
                 &bull; a transaction hash (96 characters in hexadecimal notation)<br/>
-                <span class="should-wrap h-help-item">
+                <div class="should-wrap h-help-item">
                   Example:&nbsp;0x7b35c2dba2199cea846d96b58d8786132831a3522650bb369899e6fac01933a8ca3d79da0db93cd2bf816c1b97819afa
-                </span>
+                </div>
               </div>
               <div>
                 &bull; a transaction timestamp (seconds.nanoseconds)<br/>
-                <span class="should-wrap h-help-item">
+                <div class="should-wrap h-help-item">
                   Example:&nbsp;1672860361.726937910
-                </span>
+                </div>
               </div>
               <div>
                 &bull; an account public key (64 or 66 characters in hexadecimal notation)<br/>
-                <span class="should-wrap h-help-item">
+                <div class="should-wrap h-help-item">
                   Example:&nbsp;0x0000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296
-                </span>
+                </div>
               </div>
               <div>
                 &bull; a public-key-format alias (string in base 32 or hexadecimal notation)<br/>
-                <span class="should-wrap h-help-item">
-                  Example:&nbsp;0x12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296
-                </span>
+                <div class="should-wrap h-help-item">
+                  Example:&nbsp;CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ
+                </div>
+                <div class="should-wrap h-help-item">
+                  or:&nbsp;0x12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296
+                </div>
               </div>
               <div>
                 &bull; an Ethereum-format alias (40 characters in hexadecimal notation)<br/>
-                <span class="should-wrap h-help-item">
+                <div class="should-wrap h-help-item">
                   Example:&nbsp;0x00000000000000000000000000000000000b03ae
-                </span>
+                </div>
               </div>
             </div>
           </div>
@@ -135,7 +138,6 @@ export default defineComponent({
 <style scoped>
 
 .h-help-item {
-  display: inline-block;
   margin-left: 15px;
   font-weight: 200;
   font-size: 14px;

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -46,7 +46,7 @@
           <span style="font-weight: 400">{{ this.searchedId }}</span>
           <span >".</span>
           <br/><br/>
-          <hr style="height: 1px" />
+          <hr style="height: 0.5px" />
           <br/>
 
           <div class="has-text-centered">
@@ -55,6 +55,9 @@
               <br/><br/>
               <li>
                 &bull; an entity ID (0.0.x)<br/>
+                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                  Example:&nbsp;0.0.1484550
+                </span>
               </li>
               <li>
                 &bull; a transaction ID (0.0.x@seconds.nanoseconds)<br/>

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -43,59 +43,58 @@
         </template>
         <template v-else>
           <span >No account, transaction, contract, token or topic matches "</span>
-          <span style="font-weight: 400">{{ this.searchedId }}</span>
+          <span style="font-weight: 400">{{ searchedId }}</span>
           <span >".</span>
           <br/><br/>
           <hr style="height: 0.5px" />
           <br/>
-
           <div class="has-text-centered">
-            <ul class="has-text-left" style="display: inline-block; max-width: 1024px">
+            <div class="has-text-left" style="display: inline-block; max-width: 1024px">
               <span style="display: inline-block">Make sure you enter one of the expressions below:</span>
               <br/><br/>
-              <li>
+              <div>
                 &bull; an entity ID (0.0.x)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                <span class="should-wrap h-help-item">
                   Example:&nbsp;0.0.1484550
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 &bull; a transaction ID (0.0.x@seconds.nanoseconds)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                <span class="should-wrap h-help-item">
                   Example:&nbsp;0.0.1484550@1672860351.268707677
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 &bull; a transaction hash (96 characters in hexadecimal notation)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
+                <span class="should-wrap h-help-item">
                   Example:&nbsp;0x7b35c2dba2199cea846d96b58d8786132831a3522650bb369899e6fac01933a8ca3d79da0db93cd2bf816c1b97819afa
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 &bull; a transaction timestamp (seconds.nanoseconds)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
-                  Example:&nbsp;1672860351.268707677
+                <span class="should-wrap h-help-item">
+                  Example:&nbsp;1672860361.726937910
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 &bull; an account public key (64 or 66 characters in hexadecimal notation)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
-                  Example:&nbsp;0xe3cc1bffc8668948721a6fe1816d282137222ab3a8e83dc1f45d3199a395e0f5
+                <span class="should-wrap h-help-item">
+                  Example:&nbsp;0x0000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 &bull; a public-key-format alias (string in base 32 or hexadecimal notation)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
-                  Example:&nbsp;0x1220e3cc1bffc8668948721a6fe1816d282137222ab3a8e83dc1f45d3199a395e0f5
+                <span class="should-wrap h-help-item">
+                  Example:&nbsp;0x12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 &bull; an Ethereum-format alias (40 characters in hexadecimal notation)<br/>
-                <span class="should-wrap" style="display: inline-block; margin-left: 15px; font-weight: 200; font-size: 14px">
-                  Example:&nbsp;0x0000000000000000000000000000000000000455
+                <span class="should-wrap h-help-item">
+                  Example:&nbsp;0x00000000000000000000000000000000000b03ae
                 </span>
-              </li>
-            </ul>
+              </div>
+            </div>
           </div>
 
         </template>
@@ -134,5 +133,12 @@ export default defineComponent({
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style scoped>
+
+.h-help-item {
+  display: inline-block;
+  margin-left: 15px;
+  font-weight: 200;
+  font-size: 14px;
+}
 
 </style>

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -74,8 +74,7 @@ HMSF.forceUTC = true
 
 describe("AccountDetails.vue", () => {
 
-    const ALIAS_B32 = "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ"
-    const ALIAS_HEX = "0x12200000fc0634e2ab455eff393f04819efa262fe5e6ab1c7ed1d4f85fbcd8e6e296"
+    const ALIAS_HEX = "1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296"
 
     it("Should display account details", async () => {
 
@@ -128,7 +127,7 @@ describe("AccountDetails.vue", () => {
             "Copy to Clipboard" +
             "ED25519")
         expect(wrapper.get("#memoValue").text()).toBe("None")
-        expect(wrapper.get("#aliasValue").text()).toBe(ALIAS_B32 + ALIAS_HEX)
+        expect(wrapper.get("#aliasValue").text()).toBe(ALIAS_HEX + "Copy to Clipboard")
         expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
 
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")


### PR DESCRIPTION
**Description**:

With these changes:
- the "no search result" inline help now provides examples of all supported search patterns
- the "no search result" inline help now gives length in “characters” instead of "bytes"
- in the "no search result" page as well as the "account details" view, the following terminology is used:
   -  “public-key-format alias” instead of "alias"
   -  “Ethereum-format alias” instead of "EVM Address"
- in the "account details" view, the _public-key-format alias_ is made less prominent, and displayed in hexa, next to the _Admin Key_

Note it is still possible to search using base32 and hexa forms of _public-key-format alias_

**Related issue(s)**:

Fixes #389 

**Notes for reviewer**:

This is currently being deployed on staging.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
