### PR TITLE
00136 token associate txn info

### DIFF
--- a/src/components/account/AccountLoader.ts
+++ b/src/components/account/AccountLoader.ts
@@ -54,7 +54,7 @@ export class AccountLoader extends EntityLoader<AccountBalanceTransactions> {
 
     public readonly createdTimestamp: Ref<string|null> = computed(() => this.entity.value?.created_timestamp ?? null)
 
-    public readonly tokens: Ref<[TokenBalance]|null> = computed(() => this.entity.value?.balance?.tokens ?? null)
+    public readonly tokens: Ref<TokenBalance[]|null> = computed(() => this.entity.value?.balance?.tokens ?? null)
 
     public readonly stakedNodeId: Ref<number|null> = computed(() => this.entity.value?.staked_node_id ?? null)
 

--- a/src/components/token/TokenRelationshipLoader.ts
+++ b/src/components/token/TokenRelationshipLoader.ts
@@ -1,0 +1,70 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {TokenRelationshipResponse} from "@/schemas/HederaSchemas";
+import axios, {AxiosResponse} from "axios";
+import {computed, Ref} from "vue";
+import {EntityBatchLoader} from "@/utils/loader/EntityBatchLoader";
+
+export class TokenRelationshipLoader extends EntityBatchLoader<TokenRelationshipResponse> {
+
+    //
+    // Public
+    //
+
+    public constructor(accountLocator: Ref<string|null>) {
+        super()
+        this.accountLocator = accountLocator
+        this.watchAndReload([this.accountLocator])
+    }
+
+    public readonly accountLocator: Ref<string|null> // Entity Id or Alias or EVM Address
+
+    public readonly tokens = computed(() => this.entity.value?.tokens ?? null)
+
+    //
+    // EntityBatchLoader
+    //
+
+    protected async loadNext(nextURL:string | null): Promise<AxiosResponse<TokenRelationshipResponse> | null> {
+        let result: Promise<AxiosResponse<TokenRelationshipResponse> | null>
+        if (this.accountLocator.value !== null) {
+            result = axios.get<TokenRelationshipResponse>(
+                nextURL ?? "api/v1/accounts/" + this.accountLocator.value + "/tokens"
+            )
+
+        } else {
+            result = Promise.resolve(null)
+        }
+        return result
+    }
+
+    protected nextURL(entity: TokenRelationshipResponse): string | null {
+        return entity.links?.next ?? null;
+    }
+
+    protected mergeResponses(last: AxiosResponse<TokenRelationshipResponse>,
+                             next: AxiosResponse<TokenRelationshipResponse>): AxiosResponse<TokenRelationshipResponse> {
+        const lastActions = last.data.tokens ?? []
+        const nextActions = next.data.tokens ?? []
+        last.data.tokens = lastActions.concat(nextActions)
+        return last
+    }
+}

--- a/src/components/token/TokenRelationshipLoader.ts
+++ b/src/components/token/TokenRelationshipLoader.ts
@@ -40,7 +40,7 @@ export class TokenRelationshipLoader extends EntityBatchLoader<TokenRelationship
     public readonly tokens = computed(() => this.entity.value?.tokens ?? null)
 
     public lookupTokens(createdTimestamp: string): Array<string> {
-        let result = Array<string>()
+        const result = Array<string>()
         for (const t of this.tokens.value ?? []) {
             if (t.created_timestamp === createdTimestamp && t.token_id) {
                 result.push(t.token_id)

--- a/src/components/token/TokenRelationshipLoader.ts
+++ b/src/components/token/TokenRelationshipLoader.ts
@@ -39,6 +39,17 @@ export class TokenRelationshipLoader extends EntityBatchLoader<TokenRelationship
 
     public readonly tokens = computed(() => this.entity.value?.tokens ?? null)
 
+    public lookupToken(createdTimestamp: string): string|null {
+        let result = null
+        for (const t of this.tokens.value ?? []) {
+            if (t.created_timestamp === createdTimestamp) {
+                result = t.token_id
+                break
+            }
+        }
+        return result
+    }
+
     //
     // EntityBatchLoader
     //

--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -29,9 +29,12 @@
         v-bind:compact="true"/>
     <div v-else-if="isTokenAssociation">
       {{ transaction?.entity_id }}
-      <span v-if="token">
+      <span v-if="tokens.length">
         <i class="fas fa-link mr-1 has-text-grey"></i>
-        <TokenExtra :token-id="token" :show-name="true"/>
+        <TokenExtra :token-id="tokens[0]" :show-name="true"/>
+        <span v-if="additionalTokensNumber" class="h-is-smaller h-is-extra-text should-wrap">
+          {{ ' ( + ' + additionalTokensNumber + ' more )' }}
+        </span>
       </span>
     </div>
     <div v-else class="w250">
@@ -78,13 +81,16 @@ export default defineComponent({
     const tokenRelationships = new TokenRelationshipLoader(ref(props.transaction?.entity_id ?? null))
     onMounted(() => tokenRelationships.requestLoad())
 
-    const token = computed(
-        () => tokenRelationships.lookupToken(props.transaction?.consensus_timestamp ?? ""))
+    const tokens = computed(
+        () => tokenRelationships.lookupTokens(props.transaction?.consensus_timestamp ?? ""))
+
+    const additionalTokensNumber = computed(() => tokens.value.length ?  tokens.value.length - 1 : 0)
 
     return {
       shouldGraph,
       isTokenAssociation,
-      token,
+      tokens,
+      additionalTokensNumber,
       // From TransactionTools
       makeSummaryLabel,
       TransactionType

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -252,6 +252,7 @@ import {TopicMessageLoader} from "@/components/topic/TopicMessageLoader";
 import {routeManager} from "@/router"
 import {Timestamp} from "@/utils/Timestamp";
 import {TransactionHash} from "@/utils/TransactionHash";
+import {TokenRelationshipLoader} from "@/components/token/TokenRelationshipLoader";
 
 const MAX_INLINE_CHILDREN = 9
 
@@ -331,6 +332,19 @@ export default defineComponent({
     )
     const topicMessageLoader = new TopicMessageLoader(messageTimestamp)
 
+    const associatedAccount = computed(() =>
+        (transactionLoader.transactionType.value === TransactionType.TOKENASSOCIATE)
+            ? transactionLoader.entity.value?.entity_id ?? null
+            : null
+    )
+    const tokenRelationships = new TokenRelationshipLoader(associatedAccount)
+
+    const associatedToken = computed(() =>
+        transactionLoader.consensusTimestamp.value
+            ? tokenRelationships.lookupToken(transactionLoader.consensusTimestamp.value )
+            : null
+    )
+
     return {
       isSmallScreen,
       isLargeScreen,
@@ -357,7 +371,8 @@ export default defineComponent({
       makeOperatorAccountLabel,
       routeToAllTransactions,
       displayAllChildrenLinks,
-      topicMessageLoader
+      topicMessageLoader,
+      associatedToken
     }
   },
 })

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -347,6 +347,7 @@ export default defineComponent({
         () => isTokenAssociation.value ? transactionLoader.entity.value?.entity_id ?? null : null
     )
     const tokenRelationships = new TokenRelationshipLoader(associatedAccount)
+    onMounted(() => tokenRelationships.requestLoad())
 
     const associatedToken = computed(() =>
         transactionLoader.consensusTimestamp.value

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -99,10 +99,12 @@
       </template>
 
       <template v-slot:rightContent>
-        <Property v-if="isTokenAssociation" id="associatedTokenId">
-          <template v-slot:name>Associated Token</template>
+        <Property v-if="isTokenAssociation && associatedTokens.length" id="associatedTokenId">
+          <template v-slot:name>
+            Associated Token<span v-if="associatedTokens.length > 1">s</span>
+          </template>
           <template v-slot:value>
-            <TokenLink :token-id="associatedToken" :show-extra="true"/>
+            <TokenLink v-for="t of associatedTokens" :key="t" :token-id="t" :show-extra="true"/>
           </template>
         </Property>
         <Property v-if="systemContract" id="entityId">
@@ -349,10 +351,8 @@ export default defineComponent({
     const tokenRelationships = new TokenRelationshipLoader(associatedAccount)
     onMounted(() => tokenRelationships.requestLoad())
 
-    const associatedToken = computed(() =>
-        transactionLoader.consensusTimestamp.value
-            ? tokenRelationships.lookupToken(transactionLoader.consensusTimestamp.value )
-            : null
+    const associatedTokens = computed(
+        () =>  tokenRelationships.lookupTokens(transactionLoader.consensusTimestamp.value ?? "")
     )
 
     return {
@@ -383,7 +383,7 @@ export default defineComponent({
       displayAllChildrenLinks,
       topicMessageLoader,
       isTokenAssociation,
-      associatedToken
+      associatedTokens
     }
   },
 })

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -99,6 +99,12 @@
       </template>
 
       <template v-slot:rightContent>
+        <Property v-if="isTokenAssociation" id="associatedTokenId">
+          <template v-slot:name>Associated Token</template>
+          <template v-slot:value>
+            <TokenLink :token-id="associatedToken" :show-extra="true"/>
+          </template>
+        </Property>
         <Property v-if="systemContract" id="entityId">
           <template v-slot:name>Contract ID</template>
           <template v-slot:value>{{ systemContract }}</template>
@@ -253,6 +259,7 @@ import {routeManager} from "@/router"
 import {Timestamp} from "@/utils/Timestamp";
 import {TransactionHash} from "@/utils/TransactionHash";
 import {TokenRelationshipLoader} from "@/components/token/TokenRelationshipLoader";
+import TokenLink from "@/components/values/TokenLink.vue";
 
 const MAX_INLINE_CHILDREN = 9
 
@@ -261,6 +268,7 @@ export default defineComponent({
   name: 'TransactionDetails',
 
   components: {
+    TokenLink,
     TopicMessage,
     ContractResult,
     BlockLink,
@@ -332,10 +340,11 @@ export default defineComponent({
     )
     const topicMessageLoader = new TopicMessageLoader(messageTimestamp)
 
-    const associatedAccount = computed(() =>
-        (transactionLoader.transactionType.value === TransactionType.TOKENASSOCIATE)
-            ? transactionLoader.entity.value?.entity_id ?? null
-            : null
+    const isTokenAssociation = computed(
+        () => transactionLoader.transactionType.value === TransactionType.TOKENASSOCIATE)
+
+    const associatedAccount = computed(
+        () => isTokenAssociation.value ? transactionLoader.entity.value?.entity_id ?? null : null
     )
     const tokenRelationships = new TokenRelationshipLoader(associatedAccount)
 
@@ -372,6 +381,7 @@ export default defineComponent({
       routeToAllTransactions,
       displayAllChildrenLinks,
       topicMessageLoader,
+      isTokenAssociation,
       associatedToken
     }
   },

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -63,12 +63,26 @@ export interface AccountBalanceTransactions extends AccountInfo {
 export interface Balance {
     timestamp: string | null
     balance: number | null
-    tokens: [TokenBalance]
+    tokens: TokenBalance[]
 }
 
 export interface TokenBalance {
     token_id: string | null // Network entity ID in the format of shard.realm.num
     balance: number
+}
+
+export interface TokenRelationshipResponse {
+    tokens: Array<TokenRelationship>,
+    links: Links
+}
+
+export interface TokenRelationship {
+    automatic_association: boolean,
+    balance: number,
+    created_timestamp: string,
+    freeze_status: string, // [ NOT_APPLICABLE, FROZEN, UNFROZEN ]
+    kyc_status: string,    // [ NOT_APPLICABLE, GRANTED, REVOKED ]
+    token_id: string | null,
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -164,7 +178,7 @@ export interface TokenTransfer extends Transfer {
 export interface CustomFee {
     amount: number | undefined
     collector_account_id: string | undefined        // Network entity ID in the format of shard.realm.num
-    effective_payer_account_ids: [string] | undefined
+    effective_payer_account_ids: string[] | undefined
     token_id: string | null | undefined             // Network entity ID in the format of shard.realm.num
 }
 
@@ -253,7 +267,7 @@ export function compareTokenTransferByTokenId(t1: TokenTransfer, t2: TokenTransf
 // ---------------------------------------------------------------------------------------------------------------------
 
 export interface TokensResponse {
-    tokens: [Token] | undefined
+    tokens: Token[] | undefined
     links: Links | undefined
 }
 
@@ -297,9 +311,9 @@ export interface TokenInfo {
 
 export interface CustomFees {
     created_timestamp: string | undefined
-    fixed_fees: [FixedFee] | undefined                    // Network entity ID in the format of shard.realm.num
-    fractional_fees: [FractionalFee] | undefined
-    royalty_fees: [RoyaltyFee] | null | undefined             // Network entity ID in the format of shard.realm.num
+    fixed_fees: FixedFee[] | undefined                    // Network entity ID in the format of shard.realm.num
+    fractional_fees: FractionalFee[] | undefined
+    royalty_fees: RoyaltyFee[] | null | undefined             // Network entity ID in the format of shard.realm.num
 }
 
 export interface FixedFee {
@@ -335,7 +349,7 @@ export interface FractionAmount {
 
 export interface TokenBalancesResponse {
     timestamp: string | null | undefined
-    balances: [TokenDistribution] | undefined
+    balances: TokenDistribution[] | undefined
     links: Links | undefined
 }
 
@@ -349,7 +363,7 @@ export interface TokenDistribution {
 // ---------------------------------------------------------------------------------------------------------------------
 
 export interface Nfts {
-    nfts: [Nft] | undefined
+    nfts: Nft[] | undefined
     links: Links | undefined
 }
 
@@ -400,7 +414,7 @@ export interface TransactionId {
 // ---------------------------------------------------------------------------------------------------------------------
 
 export interface ContractsResponse {
-    contracts: [Contract] | undefined
+    contracts: Contract[] | undefined
     links: Links | undefined
 }
 
@@ -542,7 +556,7 @@ export interface NetworkNode {
     node_account_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     node_cert_hash: string | null | undefined
     public_key: string | null | undefined   // hex encoded X509 RSA public key used to sign stream files
-    service_endpoints: [ServiceEndPoint] | undefined
+    service_endpoints: ServiceEndPoint[] | undefined
     timestamp: TimestampRange | undefined
     max_stake: number | null // The maximum stake (rewarded or not rewarded) this node can have as consensus weight
     min_stake: number | null // The minimum stake (rewarded or not rewarded) this node must reach before having non-zero consensus weight

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -79,6 +79,8 @@ export function makeSummaryLabel(row: Transaction): string {
             result = ""
             break
     }
+    console.log("makeSummaryLabel - row.name: " + row.name)
+    console.log("makeSummaryLabel - result: " + result)
     return result
 }
 

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -79,8 +79,6 @@ export function makeSummaryLabel(row: Transaction): string {
             result = ""
             break
     }
-    console.log("makeSummaryLabel - row.name: " + row.name)
-    console.log("makeSummaryLabel - result: " + result)
     return result
 }
 

--- a/src/utils/loader/EntityBatchLoader.ts
+++ b/src/utils/loader/EntityBatchLoader.ts
@@ -27,7 +27,7 @@ export abstract class EntityBatchLoader<E> extends EntityLoader<E> {
     // Public
     //
 
-    public constructor(recursionLimit: number = 100) {
+    public constructor(recursionLimit = 100) {
         super()
         this.recursionLimit = recursionLimit
     }

--- a/src/utils/loader/EntityBatchLoader.ts
+++ b/src/utils/loader/EntityBatchLoader.ts
@@ -24,6 +24,15 @@ import {AxiosResponse} from "axios";
 export abstract class EntityBatchLoader<E> extends EntityLoader<E> {
 
     //
+    // Public
+    //
+
+    public constructor(recursionLimit: number = 100) {
+        super()
+        this.recursionLimit = recursionLimit
+    }
+
+    //
     // Protected
     //
 
@@ -40,12 +49,14 @@ export abstract class EntityBatchLoader<E> extends EntityLoader<E> {
     //
 
     protected async load(): Promise<AxiosResponse<E>|null> {
-        return this.recurseLoad(null, null, 100)
+        return this.recurseLoad(null, null, this.recursionLimit)
     }
 
     //
     // Private
     //
+
+    private readonly recursionLimit: number
 
     private async recurseLoad(nextURL: string|null, previous: AxiosResponse<E>|null, recursionCount: number): Promise<AxiosResponse<E>|null> {
         let result: Promise<AxiosResponse<E>|null>

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1395,28 +1395,6 @@ export const SAMPLE_TOKEN_ASSOCIATE_TRANSACTION = {
     "valid_start_timestamp": "1671648699.088023490"
 }
 
-//
-// Inspired from https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.642949/tokens
-//
-
-export const SAMPLE_TOKEN_ASSOCIATIONS = {
-    "tokens": [{
-        "automatic_association": false,
-        "balance": 0,
-        "created_timestamp": "1647994323.478512577",
-        "freeze_status": "NOT_APPLICABLE",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": "0.0.26568643"
-    }, {
-        "automatic_association": false,
-        "balance": 0,
-        "created_timestamp": "1671648712.150557003",
-        "freeze_status": "UNFROZEN",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": "0.0.34332104"
-    }], "links": {"next": null}
-}
-
 export const SAMPLE_ASSOCIATED_TOKEN = {
     "admin_key": {"_type": "ED25519", "key": "c350fb04dc8b75e0f2bae193f42f6d08c337bd627f731b19a67231cffe325ebe"},
     "auto_renew_account": "0.0.1856648",
@@ -1445,6 +1423,65 @@ export const SAMPLE_ASSOCIATED_TOKEN = {
     "treasury_account_id": "0.0.34332092",
     "type": "FUNGIBLE_COMMON",
     "wipe_key": {"_type": "ED25519", "key": "fd5f6414ae9437854b31c81251b5e4be7b56a435dd749473da6feeecd85d6eaf"}
+}
+
+export const SAMPLE_ASSOCIATED_TOKEN_2 = {
+    "admin_key": null,
+    "auto_renew_account": "0.0.49288723",
+    "auto_renew_period": 7776000,
+    "created_timestamp": "1673613321.257283003",
+    "custom_fees": {"created_timestamp": "1673613321.257283003", "fixed_fees": [], "fractional_fees": []},
+    "decimals": "8",
+    "deleted": false,
+    "expiry_timestamp": 1681389321257283003,
+    "fee_schedule_key": null,
+    "freeze_default": false,
+    "freeze_key": null,
+    "initial_supply": "20000000000000",
+    "kyc_key": null,
+    "max_supply": "0",
+    "memo": "",
+    "modified_timestamp": "1673613321.257283003",
+    "name": "TokenA7",
+    "pause_key": null,
+    "pause_status": "NOT_APPLICABLE",
+    "supply_key": {"_type": "ED25519", "key": "2e61deb649eee47b0693d878fc5b2d8baa733f5e7b625314519064616ead62fe"},
+    "supply_type": "INFINITE",
+    "symbol": "Token SymbolA7",
+    "token_id": "0.0.49292859",
+    "total_supply": "20000000000000",
+    "treasury_account_id": "0.0.49288723",
+    "type": "FUNGIBLE_COMMON",
+    "wipe_key": null
+}
+
+//
+// Inspired from https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.642949/tokens
+//
+
+export const SAMPLE_TOKEN_ASSOCIATIONS = {
+    "tokens": [{
+        "automatic_association": false,
+        "balance": 0,
+        "created_timestamp": "1647994323.478512577",
+        "freeze_status": "NOT_APPLICABLE",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": "0.0.26568643"
+    }, {
+        "automatic_association": false,
+        "balance": 0,
+        "created_timestamp": SAMPLE_TOKEN_ASSOCIATE_TRANSACTION.consensus_timestamp,
+        "freeze_status": "UNFROZEN",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": SAMPLE_ASSOCIATED_TOKEN.token_id
+    }, {
+        "automatic_association": false,
+        "balance": 0,
+        "created_timestamp": "1671648712.150557003",
+        "freeze_status": "UNFROZEN",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": SAMPLE_ASSOCIATED_TOKEN_2.token_id
+    }]
 }
 
 //

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -19,7 +19,6 @@
  */
 
 
-
 //
 // Fungible token inspired from https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.29662956
 //
@@ -478,7 +477,7 @@ export const SAMPLE_TRANSACTION = {
     "bytes": null,
     "charged_tx_fee": 470065,
     "consensus_timestamp": "1646025151.667604000",
-    "entity_id": SAMPLE_TOKEN.token_id,
+    "entity_id": null,
     "max_fee": "100000000",
     "memo_base64": "",
     "name": "CRYPTOTRANSFER",
@@ -1366,6 +1365,86 @@ export const SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS = {
         "valid_duration_seconds": null,
         "valid_start_timestamp": "1665085799.890453831"
     }]
+}
+//
+// TOKEN ASSOCIATE Transaction inspired from https://hashscan-latest.hedera-devops.com/testnet/transaction/1671648712.150557003
+//
+
+export const SAMPLE_TOKEN_ASSOCIATE_TRANSACTION = {
+    "bytes": null,
+    "charged_tx_fee": 115905210,
+    "consensus_timestamp": "1671648712.150557003",
+    "entity_id": "0.0.642949",
+    "max_fee": "500000000",
+    "memo_base64": "",
+    "name": "TOKENASSOCIATE",
+    "node": "0.0.3",
+    "nonce": 0,
+    "parent_consensus_timestamp": null,
+    "result": "SUCCESS",
+    "scheduled": false,
+    "staking_reward_transfers": [],
+    "transaction_hash": "R4YHmZnfFpo4NJJJ08mlSJqD8cfFG2se3rgTR6SW2TGD4kpDrQM3LrxQFSimAy3r",
+    "transaction_id": "0.0.642949-1671648699-088023490",
+    "transfers": [{"account": "0.0.3", "amount": 5805847, "is_approval": false}, {
+        "account": "0.0.98",
+        "amount": 110099363,
+        "is_approval": false
+    }, {"account": "0.0.642949", "amount": -115905210, "is_approval": false}],
+    "valid_duration_seconds": "120",
+    "valid_start_timestamp": "1671648699.088023490"
+}
+
+//
+// Inspired from https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.642949/tokens
+//
+
+export const SAMPLE_TOKEN_ASSOCIATIONS = {
+    "tokens": [{
+        "automatic_association": false,
+        "balance": 0,
+        "created_timestamp": "1647994323.478512577",
+        "freeze_status": "NOT_APPLICABLE",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": "0.0.26568643"
+    }, {
+        "automatic_association": false,
+        "balance": 0,
+        "created_timestamp": "1671648712.150557003",
+        "freeze_status": "UNFROZEN",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": "0.0.34332104"
+    }], "links": {"next": null}
+}
+
+export const SAMPLE_ASSOCIATED_TOKEN = {
+    "admin_key": {"_type": "ED25519", "key": "c350fb04dc8b75e0f2bae193f42f6d08c337bd627f731b19a67231cffe325ebe"},
+    "auto_renew_account": "0.0.1856648",
+    "auto_renew_period": 7776000,
+    "created_timestamp": "1651133913.387572000",
+    "custom_fees": {"created_timestamp": "1651133913.387572000", "fixed_fees": [], "fractional_fees": []},
+    "decimals": "4",
+    "deleted": false,
+    "expiry_timestamp": "1658909913.387572000",
+    "fee_schedule_key": {"_type": "ED25519", "key": "d0475f0732bd44a9e0a817c8e670e5372b3bf2631f71fb6966d71e8a56e71845"},
+    "freeze_default": false,
+    "freeze_key": {"_type": "ED25519", "key": "e46e5f2c3ca46d68c814ee2d645ad59c8b5441c99fc193321659f620e6468a7d"},
+    "initial_supply": "500000000000000",
+    "kyc_key": null,
+    "max_supply": "500000000000000",
+    "memo": "",
+    "modified_timestamp": "1664459798.418712003",
+    "name": "HSuite",
+    "pause_key": {"_type": "ED25519", "key": "8d2e8b0cc2518eb79d4ab07188387fe6f297ca230bd2f9b1faf31f889bf65f40"},
+    "pause_status": "UNPAUSED",
+    "supply_key": {"_type": "ED25519", "key": "f53f56ca2a83399aff9163c15a3868135a6d0589ce011e4eb2e98166148039d2"},
+    "supply_type": "FINITE",
+    "symbol": "HSUITE",
+    "token_id": "0.0.34332104",
+    "total_supply": "500000000000000",
+    "treasury_account_id": "0.0.34332092",
+    "type": "FUNGIBLE_COMMON",
+    "wipe_key": {"_type": "ED25519", "key": "fd5f6414ae9437854b31c81251b5e4be7b56a435dd749473da6feeecd85d6eaf"}
 }
 
 //

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -22,6 +22,8 @@ import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
 import {
+    SAMPLE_CONTRACTCALL_TRANSACTIONS,
+    SAMPLE_MESSAGE_TRANSACTIONS,
     SAMPLE_NETWORK_EXCHANGERATE,
     SAMPLE_NETWORK_SUPPLY,
     SAMPLE_TOKEN,
@@ -37,6 +39,7 @@ import MessageTransactionTable from "@/components/dashboard/MessageTransactionTa
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
+import {TransactionType} from "@/schemas/HederaSchemas";
 
 /*
     Bookmarks
@@ -70,7 +73,12 @@ describe("MainDashboard.vue", () => {
         const mock = new MockAdapter(axios)
 
         const matcher1 = "/api/v1/transactions"
-        mock.onGet(matcher1).reply(200, SAMPLE_TRANSACTIONS)
+        let body = {params: {limit: 5, order: 'desc', transactiontype: TransactionType.CRYPTOTRANSFER,}}
+        mock.onGet(matcher1, body).reply(200, SAMPLE_TRANSACTIONS)
+        body = {params: {limit: 5, order: 'desc', transactiontype: TransactionType.CONSENSUSSUBMITMESSAGE,}}
+        mock.onGet(matcher1, body).reply(200, SAMPLE_MESSAGE_TRANSACTIONS)
+        body = {params: {limit: 5, order: 'desc', transactiontype: TransactionType.CONTRACTCALL,}}
+        mock.onGet(matcher1, body).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS)
 
         const matcher2 = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN)
@@ -80,6 +88,7 @@ describe("MainDashboard.vue", () => {
 
         const matcher4 = "/api/v1/network/exchangerate"
         mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
+
 
         const wrapper = mount(MainDashboard, {
             global: {
@@ -125,9 +134,8 @@ describe("MainDashboard.vue", () => {
         expect(t1.exists()).toBe(true)
         expect(t1.get('thead').text()).toBe("ID Content Time")
         expect(t1.get('tbody').text()).toBe(
-            "0.0.29624024@1646025139.1529014980.0.29624024\n\n" +
-            "1\n\n" +
-            "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC"
+            "0.0.950@1646665756.235554077" + "Contract ID: 0.0.749774" + "3:09:26.5747 PMMar 7, 2022, UTC" +
+            "0.0.950@1646664143.028737238" + "Contract ID: 0.0.749723" + "2:42:34.8669 PMMar 7, 2022, UTC"
         )
 
         expect(cards[2].text()).toMatch(RegExp("^HCS Messages"))
@@ -136,11 +144,8 @@ describe("MainDashboard.vue", () => {
         expect(t2.exists()).toBe(true)
         expect(t2.get('thead').text()).toBe("Topic ID Memo Time")
         expect(t2.get('tbody').text()).toBe(
-            "0.0.29662956" +
-            "None" +
-            "5:12:31.6676 AMFeb 28, 2022, UTC"
+            "0.0.120438" + "None" + "1:59:03.9969 PMMar 8, 2022, UTC" +
+            "0.0.120438" + "None" + "1:59:03.9622 PMMar 8, 2022, UTC"
         )
-
     });
-
 });

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -29,7 +29,7 @@ import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue"
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import axios from "axios";
 import {
-    SAMPLE_ASSOCIATED_TOKEN,
+    SAMPLE_ASSOCIATED_TOKEN, SAMPLE_ASSOCIATED_TOKEN_2,
     SAMPLE_BLOCKSRESPONSE,
     SAMPLE_COINGECKO,
     SAMPLE_CONTRACT_RESULT_DETAILS,
@@ -528,14 +528,17 @@ describe("TransactionDetails.vue", () => {
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = SAMPLE_TOKEN_ASSOCIATE_TRANSACTION
-        const token = SAMPLE_ASSOCIATED_TOKEN
+        const token1 = SAMPLE_ASSOCIATED_TOKEN
+        const token2 = SAMPLE_ASSOCIATED_TOKEN_2
 
         const matcher1 = "/api/v1/transactions/" + transaction.transaction_id
         mock.onGet(matcher1).reply(200, { transactions: [transaction]});
         const matcher3 = "/api/v1/accounts/" + transaction.entity_id + "/tokens"
         mock.onGet(matcher3).reply(200, SAMPLE_TOKEN_ASSOCIATIONS);
-        const matcher5 = "/api/v1/tokens/" + token.token_id
-        mock.onGet(matcher5).reply(200, token);
+        const matcher4 = "/api/v1/tokens/" + token1.token_id
+        mock.onGet(matcher4).reply(200, token1);
+        const matcher5 = "/api/v1/tokens/" + token2.token_id
+        mock.onGet(matcher5).reply(200, token2);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -557,7 +560,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#consensusAtValue").text()).toBe("6:51:52.1505 PMDec 21, 2022, UTC") // UTC because of HMSF.forceUTC
         expect(wrapper.get("#transactionHashValue").text()).toBe("4786 0799 99df 169a 3834 9249 d3c9 a548 9a83 f1c7 c51b 6b1e deb8 1347 a496 d931 83e2 4a43 ad03 372e bc50 1528 a603 2debCopy to Clipboard")
 
-        expect(wrapper.get("#associatedTokenIdValue").text()).toBe("0.0.34332104HSuite")
+        expect(wrapper.get("#associatedTokenIdValue").text()).toBe("0.0.34332104HSuite0.0.49292859TokenA7")
         expect(wrapper.get("#entityIdValue").text()).toBe("0.0.642949")
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -29,6 +29,7 @@ import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue"
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import axios from "axios";
 import {
+    SAMPLE_ASSOCIATED_TOKEN,
     SAMPLE_BLOCKSRESPONSE,
     SAMPLE_COINGECKO,
     SAMPLE_CONTRACT_RESULT_DETAILS,
@@ -37,7 +38,7 @@ import {
     SAMPLE_FAILED_TRANSACTIONS, SAMPLE_NETWORK_NODES, SAMPLE_PARENT_CHILD_TRANSACTIONS,
     SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
     SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS,
-    SAMPLE_TOKEN,
+    SAMPLE_TOKEN, SAMPLE_TOKEN_ASSOCIATE_TRANSACTION, SAMPLE_TOKEN_ASSOCIATIONS,
     SAMPLE_TRANSACTION,
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
@@ -74,27 +75,25 @@ HMSF.forceUTC = true
 
 describe("TransactionDetails.vue", () => {
 
+    const mock = new MockAdapter(axios);
+    const matcher1 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
+    mock.onGet(matcher1).reply(200, SAMPLE_COINGECKO);
+    const matcher2 = "/api/v1/blocks"
+    mock.onGet(matcher2).reply(200, SAMPLE_BLOCKSRESPONSE);
+    const matcher3 = "api/v1/network/nodes"
+    mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
+    NodeRegistry.instance.reload()
+
+
     it("Should display transaction details with token transfers and fee transfers", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
-
-        const mock = new MockAdapter(axios);
 
         const matcher1 = "/api/v1/transactions/" + SAMPLE_TRANSACTION.transaction_id
         mock.onGet(matcher1).reply(200, SAMPLE_TRANSACTIONS);
 
         const matcher2 = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
-
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
-
-        const matcher5 = "api/v1/network/nodes"
-        mock.onGet(matcher5).reply(200, SAMPLE_NETWORK_NODES);
-        NodeRegistry.instance.reload()
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -123,7 +122,8 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#operatorAccountValue").text()).toBe("0.0.29624024")
         expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.5Hosted by Hedera | Central, USA")
         expect(wrapper.get("#durationValue").text()).toBe("2min")
-        expect(wrapper.get("#entityId").text()).toBe("Account ID0.0.29662956")
+        expect(() => wrapper.get("#associatedTokenId")).toThrowError()
+        expect(() => wrapper.get("#entityId")).toThrowError()
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
@@ -147,8 +147,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const transactionId = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].transaction_id
         const contractId = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].entity_id
         const timestamp = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].consensus_timestamp
@@ -157,11 +155,6 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS);
         const matcher2 = "/api/v1/contracts/" + contractId + "/results/" + timestamp
         mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
-
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 
@@ -203,8 +196,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const SAMPLE_TRANSACTION = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0]
         const transactionId = SAMPLE_TRANSACTION.transaction_id
         const transactionHashBase64 = SAMPLE_TRANSACTION.transaction_hash
@@ -218,11 +209,6 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher11).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS);
         const matcher2 = "/api/v1/contracts/" + contractId  + "/results/" + timestamp
         mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
-
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 
@@ -263,8 +249,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         let matcher1 = "/api/v1/transactions?timestamp=" + SAMPLE_TRANSACTION.consensus_timestamp
         mock.onGet(matcher1).reply(200, { transactions: [SAMPLE_TRANSACTION]})
 
@@ -273,12 +257,6 @@ describe("TransactionDetails.vue", () => {
 
         const matcher2 = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
-
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -325,19 +303,11 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const matcher1 = "/api/v1/transactions?timestamp=" + SAMPLE_FAILED_TRANSACTION.consensus_timestamp
         mock.onGet(matcher1).reply(200, SAMPLE_FAILED_TRANSACTIONS);
 
         const matcher11 = "/api/v1/transactions/" + SAMPLE_FAILED_TRANSACTION.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_FAILED_TRANSACTIONS);
-
-        const matcher2 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher2).reply(200, SAMPLE_COINGECKO);
-
-        const matcher3 = "/api/v1/blocks"
-        mock.onGet(matcher3).reply(200, SAMPLE_BLOCKSRESPONSE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -384,15 +354,10 @@ describe("TransactionDetails.vue", () => {
 
         const transaction = SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS.transactions[0]
 
-        const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/transactions?timestamp=" + transaction.consensus_timestamp
         mock.onGet(matcher1).reply(200, { transactions: [transaction]})
         const matcher11 = "/api/v1/transactions/" + transaction.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS)
-        const matcher2 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher2).reply(200, SAMPLE_COINGECKO);
-        const matcher3 = "/api/v1/blocks"
-        mock.onGet(matcher3).reply(200, SAMPLE_BLOCKSRESPONSE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -415,8 +380,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const SCHEDULING = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[0]
         const SCHEDULED = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[1]
         const TOKEN_ID = SCHEDULED.token_transfers ? SCHEDULED.token_transfers[0].token_id : "0.0.1304757"
@@ -424,13 +387,6 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher1).reply(200, { transactions: [SCHEDULING]});
         const matcher11 = "/api/v1/transactions/" + SCHEDULING.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
-
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
-
         const matcher5 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher5).reply(200, SAMPLE_TOKEN)
 
@@ -460,8 +416,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const SCHEDULING = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[0]
         const SCHEDULED = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions[1]
         const TOKEN_ID = SCHEDULED.token_transfers ? SCHEDULED.token_transfers[0].token_id : "0.0.1304757"
@@ -469,15 +423,8 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher1).reply(200, { transactions: [SCHEDULED]});
         const matcher11 = "/api/v1/transactions/" + SCHEDULED.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
-
         const matcher2 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
-
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -505,8 +452,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const PARENT = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[0]
         const CHILD = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[1]
         const TOKEN_ID = CHILD.nft_transfers ? CHILD.nft_transfers[0].token_id : "0.0.48193741"
@@ -514,15 +459,8 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher1).reply(200, { transactions: [CHILD]});
         const matcher11 = "/api/v1/transactions/" + CHILD.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_PARENT_CHILD_TRANSACTIONS);
-
         const matcher2 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
-
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -550,8 +488,6 @@ describe("TransactionDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const mock = new MockAdapter(axios);
-
         const PARENT = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[0]
         const CHILD1 = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[1]
         const CHILD2 = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[2]
@@ -559,12 +495,6 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher1).reply(200, {transactions: [PARENT]});
         const matcher11 = "/api/v1/transactions/" + PARENT.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_PARENT_CHILD_TRANSACTIONS);
-
-        const matcher3 = "https://api.coingecko.com/api/v3/coins/hedera-hashgraph"
-        mock.onGet(matcher3).reply(200, SAMPLE_COINGECKO);
-
-        const matcher4 = "/api/v1/blocks"
-        mock.onGet(matcher4).reply(200, SAMPLE_BLOCKSRESPONSE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -591,5 +521,54 @@ describe("TransactionDetails.vue", () => {
         expect(links[1].attributes("href")).toBe(
             "/mainnet/transaction/" + CHILD2.consensus_timestamp + "?tid=" + CHILD2.transaction_id
         )
+    });
+
+    it("Should display transaction details with account/token association", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const transaction = SAMPLE_TOKEN_ASSOCIATE_TRANSACTION
+        const token = SAMPLE_ASSOCIATED_TOKEN
+
+        const matcher1 = "/api/v1/transactions/" + transaction.transaction_id
+        mock.onGet(matcher1).reply(200, { transactions: [transaction]});
+        const matcher3 = "/api/v1/accounts/" + transaction.entity_id + "/tokens"
+        mock.onGet(matcher3).reply(200, SAMPLE_TOKEN_ASSOCIATIONS);
+        const matcher5 = "/api/v1/tokens/" + token.token_id
+        mock.onGet(matcher5).reply(200, token);
+
+        const wrapper = mount(TransactionDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionLoc: transaction.consensus_timestamp,
+                transactionId: transaction.transaction_id
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(transaction.transaction_id, true)))
+
+        expect(wrapper.get("#transactionTypeValue").text()).toBe("TOKEN ASSOCIATE")
+        expect(wrapper.get("#consensusAtValue").text()).toBe("6:51:52.1505 PMDec 21, 2022, UTC") // UTC because of HMSF.forceUTC
+        expect(wrapper.get("#transactionHashValue").text()).toBe("4786 0799 99df 169a 3834 9249 d3c9 a548 9a83 f1c7 c51b 6b1e deb8 1347 a496 d931 83e2 4a43 ad03 372e bc50 1528 a603 2debCopy to Clipboard")
+
+        expect(wrapper.get("#associatedTokenIdValue").text()).toBe("0.0.34332104HSuite")
+        expect(wrapper.get("#entityIdValue").text()).toBe("0.0.642949")
+
+        expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
+        expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
+        expect(wrapper.findComponent(NftTransferGraph).exists()).toBe(true)
+
+        expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe("Fee TransfersAccountHbar AmountAccountHbar Amount0.0.642949-1.15905210-$0.2852\n\n" +
+            "0.0.30.05805847$0.0143Hosted by Hedera | East Coast, USA\n\n" +
+            "0.0.981.10099363$0.2709Hedera fee collection account")
+        expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("Token TransfersNone")
+        expect(wrapper.findComponent(NftTransferGraph).text()).toBe("NFT TransfersNone")
+
     });
 });


### PR DESCRIPTION
**Description**:

With the following changes, the TransactionDetails view displays the ID of the token(s) associated to an account when the transaction type is TOKEN ASSOCIATE. The recent /api/v1/accounts/{id}/tokens API is used to retrieve all tokens associated with that account, and those with a created_timestamp matching the consensus_timestamp of the transaction are picked up.

**Related issue(s)**:

Fixes #136

**Notes for reviewer**:

This is a best effort approach. An account may have a very large number of tokens associated, so we only get the associated tokens up to 1000 to keep things reasonable.

Another limit to this approach is that /api/v1/accounts/{id}/tokens describes the current situation. If the TOKEN ASSOCIATE has been followed by a TOKEN DISSOCIATE before we try to display the content of the transaction, then we won't find the matching token(s) any more. This occurs in the table screenshot below.

<img width="1056" alt="Screenshot 2023-01-13 at 16 51 23" src="https://user-images.githubusercontent.com/16097111/212398847-d8d3fbb8-a85d-4655-9bf1-48ef9e1a32dc.png">
<img width="1054" alt="Screenshot 2023-01-13 at 16 46 19" src="https://user-images.githubusercontent.com/16097111/212398867-fe656f59-fb9c-4c1a-be3d-801e321ffc34.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
