### PR TITLE
00399 add auto renew account property to contracts

### DIFF
--- a/src/components/contract/ContractLoader.ts
+++ b/src/components/contract/ContractLoader.ts
@@ -37,6 +37,10 @@ export class ContractLoader extends EntityLoader<ContractResponse> {
         this.watchAndReload([this.contractLocator])
     }
 
+    public readonly autoRenewAccount = computed(() => {
+        return this.entity.value?.auto_renew_account ?? null
+    })
+
     public readonly contractId = computed(() => {
         return this.entity.value?.contract_id ?? null
     })

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -96,6 +96,12 @@
                 <AccountLink :account-id="autoRenewAccount" :show-none="true" null-label="None"/>
               </template>
             </Property>
+            <Property id="maxAutoAssociation">
+              <template v-slot:name>Max. Auto. Association</template>
+              <template v-slot:value>
+                <StringValue :string-value="contract?.max_automatic_token_associations?.toString()"/>
+              </template>
+            </Property>
             <Property id="code">
               <template v-slot:name>Initcode</template>
               <template v-slot:value>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -72,12 +72,6 @@
                 <BlobValue :blob-value="contract?.memo" :show-none="true" :base64="true" class="should-wrap"/>
               </template>
             </Property>
-            <Property id="alias">
-              <template v-slot:name>Alias</template>
-              <template v-slot:value>
-                <HexaValue v-bind:byte-string="aliasByteString" v-bind:show-none="true"/>
-              </template>
-            </Property>
             <Property id="expiresAt">
               <template v-slot:name>Expires at</template>
               <template v-slot:value>
@@ -311,7 +305,6 @@ export default defineComponent({
       obtainerId: contractLoader.obtainerId,
       proxyAccountId: contractLoader.proxyAccountId,
       normalizedContractId,
-      aliasByteString: accountLoader.aliasByteString,
       accountRoute
     }
   },

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -90,6 +90,12 @@
                 <DurationValue v-bind:number-value="contract?.auto_renew_period"/>
               </template>
             </Property>
+            <Property id="autoRenewAccount">
+              <template v-slot:name>Auto Renew Account</template>
+              <template v-slot:value>
+                <AccountLink :account-id="autoRenewAccount" :show-none="true" null-label="None"/>
+              </template>
+            </Property>
             <Property id="code">
               <template v-slot:name>Initcode</template>
               <template v-slot:value>
@@ -301,6 +307,7 @@ export default defineComponent({
       displayAllTokenLinks,
       transactionTableController,
       notification,
+      autoRenewAccount: contractLoader.autoRenewAccount,
       obtainerId: contractLoader.obtainerId,
       proxyAccountId: contractLoader.proxyAccountId,
       normalizedContractId,

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -72,6 +72,12 @@
                 <BlobValue :blob-value="contract?.memo" :show-none="true" :base64="true" class="should-wrap"/>
               </template>
             </Property>
+            <Property id="createTransaction">
+              <template v-slot:name>Create Transaction</template>
+              <template v-slot:value>
+                <TransactionLink :transactionLoc="contract?.created_timestamp"/>
+              </template>
+            </Property>
             <Property id="expiresAt">
               <template v-slot:name>Expires at</template>
               <template v-slot:value>
@@ -194,6 +200,7 @@ import {TransactionTableControllerXL} from "@/components/transaction/Transaction
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import router, {routeManager} from "@/router";
+import TransactionLink from "@/components/values/TransactionLink.vue";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -202,6 +209,7 @@ export default defineComponent({
   name: 'ContractDetails',
 
   components: {
+    TransactionLink,
     TransactionFilterSelect,
     ByteCodeValue,
     Property,

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -421,6 +421,7 @@ export interface ContractsResponse {
 export interface Contract {
 
     admin_key: Key | null | undefined
+    auto_renew_account: string | null | undefined   // Network entity ID in the format of shard.realm.num
     auto_renew_period: number | null | undefined
     contract_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     created_timestamp: string | null | undefined
@@ -428,15 +429,17 @@ export interface Contract {
     evm_address: string | undefined
     expiration_timestamp: string | null | undefined
     file_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
+    max_automatic_token_associations: number | null | undefined
     memo: string | undefined
     obtainer_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
+    permanent_removal: boolean | null | undefined
     proxy_account_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     timestamp: TimestampRange | undefined   // timestamp range the entity is valid for
-
 }
 
 export interface ContractResponse extends Contract {
     bytecode: string | null | undefined
+    runtime_bytecode: string | null | undefined
 }
 
 export interface TimestampRange {

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1676,6 +1676,7 @@ export const SAMPLE_CONTRACT = {
         "_type": "ED25519",
         "key": "421050820e1485acdd59726088e0e4a2130ebbbb70009f640ad95c78dd5a7b38"
     },
+    "auto_renew_account": "0.0.730632",
     "auto_renew_period": 7776000,
     "contract_id": "0.0.749775",
     "created_timestamp": "1646665755.947488266",

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1684,6 +1684,7 @@ export const SAMPLE_CONTRACT = {
     "evm_address": "0x00000000000000000000000000000000000b70cf",
     "expiration_timestamp": null,
     "file_id": "0.0.749773",
+    "max_automatic_token_associations": 0,
     "memo": "Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract",
     "obtainer_id": null,
     "proxy_account_id": null,

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -100,6 +100,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
         expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")
+        expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
         expect(wrapper.get("#obtainerValue").text()).toBe("None")
         expect(wrapper.get("#proxyAccountValue").text()).toBe("None")
         expect(wrapper.get("#validFromValue").text()).toBe("3:09:15.9474 PMMar 7, 2022, UTC")
@@ -165,6 +166,7 @@ describe("ContractDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Contract " + SAMPLE_CONTRACT_DUDE.contract_id))
         expect(wrapper.get("#keyValue").text()).toBe("None")
+        expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("None")
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.803267")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000c 41dfCopy to Clipboard")

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -27,6 +27,7 @@ import {
     SAMPLE_CONTRACT_AS_ACCOUNT,
     SAMPLE_CONTRACT_DELETED,
     SAMPLE_CONTRACT_DUDE,
+    SAMPLE_TRANSACTION,
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -34,6 +35,7 @@ import Oruga from "@oruga-ui/oruga-next";
 import ContractDetails from "@/pages/ContractDetails.vue";
 import {HMSF} from "@/utils/HMSF";
 import NotificationBanner from "@/components/NotificationBanner.vue";
+import {TransactionID} from "@/utils/TransactionID";
 
 /*
     Bookmarks
@@ -94,6 +96,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#balanceValue").text()).toBe("2.00000000$0.4921")
         expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
+        expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
         expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -94,7 +94,6 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#balanceValue").text()).toBe("2.00000000$0.4921")
         expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
-        expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
         expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")
@@ -144,7 +143,6 @@ describe("ContractDetails.vue", () => {
 
         expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
-        expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
         expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000b 70cfCopy to Clipboard")
@@ -165,7 +163,6 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Contract " + SAMPLE_CONTRACT_DUDE.contract_id))
         expect(wrapper.get("#keyValue").text()).toBe("None")
         expect(wrapper.get("#memoValue").text()).toBe("None")
-        expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.803267")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000c 41dfCopy to Clipboard")
 

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -97,6 +97,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")
         expect(wrapper.get("#obtainerValue").text()).toBe("None")
         expect(wrapper.get("#proxyAccountValue").text()).toBe("None")
         expect(wrapper.get("#validFromValue").text()).toBe("3:09:15.9474 PMMar 7, 2022, UTC")
@@ -144,6 +145,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
         expect(wrapper.get("#aliasValue").text()).toBe("1220 0000 fc06 34e2 ab45 5eff 393f 0481 9efa 262f e5e6 ab1c 7ed1 d4f8 5fbc d8e6 e296Copy to Clipboard")
+        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address0000 0000 0000 0000 0000 0000 0000 0000 000b 70cfCopy to Clipboard")
 


### PR DESCRIPTION
**Description**:

This PR brings the following changes to the ContractDetails view:
- add the display of these properties:
    - _Auto Renew Account_ (specific to contract)
    - _Create Transaction_ (aligning with AccountDetails view)
    - _Max. Auto. Association_ (aligning with AccountDetails view)
- remove the property _Alias_ (not a contract property)

**Related issue(s)**:

Fixes #399 

**Notes for reviewer**:

<img width="938" alt="Screenshot 2023-01-16 at 17 21 41" src="https://user-images.githubusercontent.com/16097111/212724727-33556408-b0a1-460f-b8a8-6f0ba8244201.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
