### PR TITLE
Display None when transaction duration value is null.

### DIFF
--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -152,7 +152,7 @@
         <Property id="duration">
           <template v-slot:name>Valid Duration</template>
           <template v-slot:value>
-            <DurationValue v-bind:string-value="transaction?.valid_duration_seconds"/>
+            <DurationValue v-bind:string-value="transaction?.valid_duration_seconds" :show-none="true"/>
           </template>
         </Property>
         <Property id="nonce">

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -599,7 +599,7 @@ export const SAMPLE_CONTRACTCALL_TRANSACTIONS = {
                     "amount": -95515604
                 }
             ],
-            "valid_duration_seconds": "120",
+            "valid_duration_seconds": null,
             "valid_start_timestamp": "1646665756.235554077"
         },
         {

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -175,6 +175,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(transactionId, true)))
         expect(wrapper.get("#transactionTypeValue").text()).toBe("CONTRACT CALL")
         expect(wrapper.get("#entityId").text()).toBe("Contract ID" + contractId)
+        expect(wrapper.get("#durationValue").text()).toBe("None")
 
         expect(wrapper.findComponent(ContractResult).exists()).toBe(true)
         expect(wrapper.findComponent(ContractResult).text()).toMatch(RegExp("^Contract Result"))


### PR DESCRIPTION
**Description**:

One-line fix to make sure DurationValue displays none when the value is null.

**Related issue(s)**:

Fixes #400

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
