### PR TITLE
Fix decimal conversion of contract result states slots and values

### DIFF
--- a/src/components/contract/ContractResultStates.vue
+++ b/src/components/contract/ContractResultStates.vue
@@ -201,23 +201,17 @@ export default defineComponent({
             index: result.length
           }
 
-          if (newItem.changes.value_read === '0x') {
-            newItem.changes.value_read = '0x0000000000000000000000000000000000000000000000000000000000000000'
-            newItem.valueReadDecimal = 0
-          }
           if (newItem.changes.value_written === '0x') {
             newItem.changes.value_written = null
             newItem.valueWrittenDecimal = null
           }
-          if (newItem.changes.slot === '0x') {
-            newItem.changes.slot = '0x0000000000000000000000000000000000000000000000000000000000000000'
-            newItem.slotDecimal = 0
-          }
+
           if (result.length > 0 && s.address === (result[result.length - 1].changes.address)) {
             newItem.header = false
           } else {
             newItem.balanceChange = transactionLoader.lookupTransfer(s.contract_id ?? "")
           }
+
           newItem.valueChange = newItem.valueReadDecimal && newItem.valueWrittenDecimal
               ? newItem.valueWrittenDecimal - newItem.valueReadDecimal
               : null
@@ -228,9 +222,15 @@ export default defineComponent({
       return result
     }
 
-    const makeDecimal = (hexa: string): number|null => {
-      hexa = hexa.replace(/^0x0+/, '');
-      return (hexa.length <= 8) ? Number("0x"+ hexa) : null
+    const makeDecimal = (hexa: string): number | null => {
+      let result
+      if (hexa) {
+        hexa = hexa.replace(/^0x0+/, '');
+        result = (hexa.length === 0) ? 0 : (hexa.length <= 13) ? Number("0x" + hexa) : null
+      } else {
+        result = null
+      }
+      return result
     }
 
     return {


### PR DESCRIPTION
**Description**:

This is a simple fix of the conversion of slot address and values (in Contract Result States) where 
`0x0000000000000000000000000000000000000000000000000000000000000000` values were previously displayed as NaN. 

We also no longer cope for getting `0x` value instead of `0x0000000000000000000000000000000000000000000000000000000000000000` from the API.

**Related issue(s)**:

Fixes #401 

**Notes for reviewer**:

<img width="1199" alt="Screenshot 2023-01-17 at 15 38 47" src="https://user-images.githubusercontent.com/16097111/212927713-01f99fb2-4cab-48ef-83ed-45aa7f858b1a.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
