### PR TITLE
Fix for #383 (Account tab displayed Recent Transactions table in paus…

### DIFF
--- a/src/components/staking/StakingRewardsTableController.ts
+++ b/src/components/staking/StakingRewardsTableController.ts
@@ -33,8 +33,10 @@ export class StakingRewardsTableController extends TableController<StakingReward
     // Public
     //
 
-    public constructor(router: Router, accountId: Ref<string | null>, pageSize: ComputedRef<number>) {
-        super(router, pageSize, 10 * pageSize.value, 5000, 0, 100);
+    public constructor(router: Router, accountId: Ref<string | null>, pageSize: ComputedRef<number>,
+                       pageParamName = "p", keyParamName= "k") {
+        super(router, pageSize, 10 * pageSize.value, 5000, 0, 100,
+            pageParamName, keyParamName);
         this.accountId = accountId
         this.watchAndReload([this.accountId])
         watch(this.accountId, this.updateAvailableAPI)

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -317,7 +317,8 @@ export default defineComponent({
     //
     const perPage = computed(() => isMediumScreen ? 10 : 5)
     const accountId = computed(() => accountLoader.entity.value?.account ?? null)
-    const transactionTableController = new TransactionTableControllerXL(router, accountId, perPage, true)
+    const transactionTableController = new TransactionTableControllerXL(
+      router, accountId, perPage, true, "p1", "k1")
 
     /*
           vue   \   accountId |       null       |      not null     |
@@ -398,7 +399,8 @@ export default defineComponent({
     //
     // Rewards Table Controller
     //
-    const rewardsTableController = new StakingRewardsTableController(router, accountLoader.accountId, perPage)
+    const rewardsTableController = new StakingRewardsTableController(
+        router, accountLoader.accountId, perPage, "p2", "k2")
     onMounted(() => rewardsTableController.mount())
     onBeforeUnmount(() => rewardsTableController.unmount())
 


### PR DESCRIPTION
…ed mode).

Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Root cause of this issue is a conflict between `TransactionTableControllerXL` and `StakingRewardsTableController`.
`AccountDetails` vue setup both class instances with `p` and `k` path parameters.
Thus when `StakingRewardsTableController` initializes itself in pause mode (by design), this also moves `TransactionTableControllerXL` in pause mode.

This is fixed by assigning `p1/k1` to `TransactionTableControllerXL` and `p2/k2` to `StakingRewardsTableController`.


**Related issue(s)**:

Fixes #383

**Notes for reviewer**:

See #383 for testing instructions.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
