### PR TITLE
Fix and tests for #412 (explorer should display contract id associate…

### DIFF
--- a/src/components/values/ComplexKeyValue.vue
+++ b/src/components/values/ComplexKeyValue.vue
@@ -31,6 +31,12 @@
             <HexaValue :byte-string="line.innerKeyBytes()"/>
             <div class="h-is-extra-text h-is-text-size-3">{{ line.innerKeyType() }}</div>
           </template>
+          <template v-else-if="line.contractId() !== null">
+            Contract: <ContractLink :contract-id="line.contractId()"/>
+          </template>
+          <template v-else-if="line.delegatableContractId() !== null">
+            Delegatable Contract: <ContractLink :contract-id="line.delegatableContractId()"/>
+          </template>
           <template v-else>
             <div>{{ lineText(line) }}</div>
           </template>
@@ -57,11 +63,12 @@ import {ComplexKeyLine} from "@/utils/ComplexKeyLine";
 import {hexToByte} from "@/utils/B64Utils";
 import hashgraph from "@hashgraph/proto/lib/proto";
 import HexaValue from "@/components/values/HexaValue.vue";
+import ContractLink from "@/components/values/ContractLink.vue";
 import {initialLoadingKey} from "@/AppKeys";
 
 export default defineComponent({
   name: "ComplexKeyValue",
-  components: {HexaValue},
+  components: {ContractLink, HexaValue},
   props: {
     keyBytes: String,
     showNone: {

--- a/src/utils/ComplexKeyLine.ts
+++ b/src/utils/ComplexKeyLine.ts
@@ -20,6 +20,8 @@
 
 import hashgraph from "@hashgraph/proto/lib/proto";
 import {byteToHex} from "@/utils/B64Utils";
+import IContractID = hashgraph.proto.IContractID;
+import {EntityID} from "@/utils/EntityID";
 
 export class ComplexKeyLine {
 
@@ -67,6 +69,14 @@ export class ComplexKeyLine {
         return result
     }
 
+    public contractId(): string|null {
+        return this.key.contractID ? ComplexKeyLine.makeContractId(this.key.contractID) : null
+    }
+
+    public delegatableContractId(): string|null {
+        return this.key.delegatableContractId ? ComplexKeyLine.makeContractId(this.key.delegatableContractId) : null
+    }
+
     public toString(): string {
         return "" + this.level + " " + this.key.key
     }
@@ -83,7 +93,7 @@ export class ComplexKeyLine {
     // Private
     //
 
-    public static flattenComplexKeyRec(key: hashgraph.proto.Key, level: number, result: ComplexKeyLine[]): void {
+    private static flattenComplexKeyRec(key: hashgraph.proto.Key, level: number, result: ComplexKeyLine[]): void {
 
         let newLine: ComplexKeyLine
         let childKeys: hashgraph.proto.Key[]
@@ -110,5 +120,13 @@ export class ComplexKeyLine {
         for (const childKey of childKeys) {
             this.flattenComplexKeyRec(childKey, level + 1, result)
         }
+    }
+
+    private static makeContractId(iContractID: IContractID): string {
+        const shard = Number(iContractID.shardNum ?? 0)
+        const realm = Number(iContractID.realmNum ?? 0)
+        const num = Number(iContractID.contractNum ?? 0)
+        const entityId = new EntityID(shard, realm, num)
+        return entityId.toString()
     }
 }

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -33,6 +33,12 @@ export class EntityID {
     // Public
     //
 
+    public constructor(shard: number, realm: number, num: number) {
+        this.shard = shard
+        this.realm = realm
+        this.num = num
+    }
+
     public static parse(s: string, autoComplete = false): EntityID|null {
         let result: EntityID|null
 
@@ -138,16 +144,6 @@ export class EntityID {
     public static parsePositiveInt(s: string): number|null {
         const n = s.match(/^[0-9]+$/) !== null ? parseInt(s) : EntityID.MAX_INT
         return (isNaN(n) || n >= EntityID.MAX_INT) ? null : n
-    }
-
-    //
-    // Private
-    //
-
-    private constructor(shard: number, realm: number, num: number) {
-        this.shard = shard
-        this.realm = realm
-        this.num = num
     }
 }
 

--- a/tests/unit/utils/ComplexKeyLine.spec.ts
+++ b/tests/unit/utils/ComplexKeyLine.spec.ts
@@ -23,7 +23,7 @@ import hashgraph from "@hashgraph/proto/lib/proto";
 import {hexToByte} from "@/utils/B64Utils";
 
 const COMPLEX_KEY = "0x2a880208021283020a562a54080112500a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390aa8012aa501080212a0010a2632240a221220c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e06340a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a2632240a221220daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
-
+const CONTRACT_KEY = "0a0418caba02" // Contract ID: 0.0.40266
 
 describe("ComplexKeyLine.ts", () => {
 
@@ -37,6 +37,19 @@ describe("ComplexKeyLine.ts", () => {
 
         const lines = ComplexKeyLine.flattenComplexKey(key)
         expect(lines.length).toBe(9)
+    })
+
+    test("Key with contract id", () => {
+
+        const keyBytes = hexToByte(CONTRACT_KEY)
+        expect(keyBytes).not.toBeNull()
+
+        const key = hashgraph.proto.Key.decode(keyBytes!)
+        expect(key).not.toBeNull()
+
+        const lines = ComplexKeyLine.flattenComplexKey(key)
+        expect(lines.length).toBe(1)
+        expect(lines[0].contractId()).toBe("0.0.40266")
     })
 
 })

--- a/tests/unit/values/ComplexKeyValue.spec.ts
+++ b/tests/unit/values/ComplexKeyValue.spec.ts
@@ -27,7 +27,7 @@ describe("ComplexKeyValue.vue", () => {
 
     const COMPLEX_KEY = "0x2a880208021283020a562a54080112500a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390aa8012aa501080212a0010a2632240a221220c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e06340a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a2632240a221220daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
 
-    it("props.keyBytes set", async () => {
+    it("props.keyBytes set with complex key", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -42,6 +42,25 @@ describe("ComplexKeyValue.vue", () => {
 
         expect(wrapper.text()).toBe("thresholdKey(2 of 2)thresholdKey(1 of 2)ef2d 877b 88b7 464d 9253 560b 8851 316f 5c2f 6ddf 935e b4ee c076 1a32 62b0 a48cCopy to ClipboardED25519a95d 54cf 49c1 d08c d16d 8908 f37d fad9 5637 134f faf5 28a1 d96d a7f2 8d45 f139Copy to ClipboardED25519thresholdKey(2 of 4)c44c 911f a451 66e3 56b4 9846 3184 459d d9ee 760b acc0 83de 3486 91d6 357e 0634Copy to ClipboardED25519ef2d 877b 88b7 464d 9253 560b 8851 316f 5c2f 6ddf 935e b4ee c076 1a32 62b0 a48cCopy to ClipboardED25519a95d 54cf 49c1 d08c d16d 8908 f37d fad9 5637 134f faf5 28a1 d96d a7f2 8d45 f139Copy to ClipboardED25519daa5 da86 6bf4 e990 c14e ff43 36f5 ab4b 416c 85a3 1289 c8cb 8ae1 b4a5 4ce8 c111Copy to ClipboardED25519")
     });
+
+    const CONTRACT_KEY = "0a0418caba02" // Contract ID: 0.0.40266
+
+    it("props.keyBytes set with contract key", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(ComplexKeyValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                keyBytes: CONTRACT_KEY
+            },
+        });
+
+        expect(wrapper.text()).toBe("Contract: 0.0.40266")
+    });
+
 
     it("props.keyBytes unset, showNone=false", async () => {
 


### PR DESCRIPTION
…d to complex keys).

Signed-off-by: Eric Le Ponner <eric.leponner@icloud.com>

**Description**:

Changes below enhances complex display : contract ID associated to a key is now displayed with a navigation link.
<img width="603" alt="image" src="https://user-images.githubusercontent.com/91124272/213244630-342389b8-0caf-4e9f-93b4-a18f2e1d787e.png">

**Related issue(s)**:

Fixes #412

**Notes for reviewer**:
Use 0.0.40265 fungible token on previewnet to see the result

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
