### PR TITLE
Remove undue v-bind for constant timestamp props.

### DIFF
--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -53,7 +53,7 @@
         <Property id="amountStaked">
           <template v-slot:name>Amount Staked</template>
           <template v-slot:value>
-            <HbarAmount v-if="account" :amount="account.balance.balance" :timestamp="'0'" :show-extra="true"/>
+            <HbarAmount v-if="account" :amount="account.balance.balance" timestamp="0" :show-extra="true"/>
           </template>
         </Property>
 
@@ -134,7 +134,7 @@
         <Property v-if="false" id="changeCost">
           <template v-slot:name>Change Transaction Cost</template>
           <template v-slot:value>
-            <HbarAmount v-if="account" :amount="10000000" :timestamp="'0'" :show-extra="true" :decimals="1"/>
+            <HbarAmount v-if="account" :amount="10000000" timestamp="0" :show-extra="true" :decimals="1"/>
           </template>
         </Property>
 

--- a/src/components/token/FixedFeeTable.vue
+++ b/src/components/token/FixedFeeTable.vue
@@ -39,7 +39,7 @@
 
     <o-table-column v-slot="props" field="amount" label="Amount">
       <PlainAmount v-if="props.row.denominating_token_id" :amount="props.row.amount"/>
-      <HbarAmount v-else :amount="props.row.amount" :timestamp="'0'" :show-extra="true"/>
+      <HbarAmount v-else :amount="props.row.amount" timestamp="0" :show-extra="true"/>
     </o-table-column>
 
     <o-table-column v-slot="props" field="amount" label="Token">

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -54,7 +54,7 @@
               <template v-slot:name>{{ tokenBalances?.length ? 'Balances' : 'Balance' }}</template>
               <template v-slot:value>
                 <div v-if="account" class="h-is-tertiary-text">
-                  <HbarAmount v-bind:amount="hbarBalance" v-bind:show-extra="true" v-bind:timestamp="'0'"/>
+                  <HbarAmount v-bind:amount="hbarBalance" v-bind:show-extra="true" timestamp="0"/>
                 </div>
                 <div v-if="displayAllTokenLinks">
                   <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
@@ -97,7 +97,7 @@
         <Property id="pendingReward">
           <template v-slot:name>Pending Reward</template>
           <template v-slot:value>
-            <HbarAmount :amount="account?.pending_reward" :show-extra="true" :timestamp="'0'"/>
+            <HbarAmount :amount="account?.pending_reward" :show-extra="true" timestamp="0"/>
             <div v-if="stakePeriodStart" class="h-is-extra-text h-is-text-size-2">
               {{ "Period Started " + stakePeriodStart }}
             </div>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -46,7 +46,7 @@
               <template v-slot:name>{{ tokens?.length ? 'Balances' : 'Balance' }}</template>
               <template v-slot:value>
                 <div class="has-flex-direction-column">
-                  <HbarAmount v-if="contract" :amount="balance" :show-extra="true" :timestamp="'0'"/>
+                  <HbarAmount v-if="contract" :amount="balance" :show-extra="true" timestamp="0"/>
                   <div v-if="displayAllTokenLinks">
                     <router-link :to="{name: 'AccountBalances', params: {accountId: contractId}}">
                       See all token balances


### PR DESCRIPTION
**Description**:

This µPR removes  a few undue v-bind used with constant timestamp props.

**Related issue(s)**:

None.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
