### PR TITLE
00366 auto renew period unit

### DIFF
--- a/src/components/values/DurationValue.vue
+++ b/src/components/values/DurationValue.vue
@@ -24,7 +24,10 @@
 
 <template>
 
-  <template v-if="formattedValue">
+  <template v-if="isInfinite">
+    <span class="has-text-grey">Infinite</span>
+  </template>
+  <template v-else-if="formattedValue">
     <span>{{ formattedValue }}</span>
   </template>
   <template v-else-if="showNone && !initialLoading">
@@ -72,10 +75,15 @@ export default defineComponent({
       return result
     })
 
+    const isInfinite = computed(() => {
+      const duration = props.numberValue ?? Number.parseInt(props.stringValue ?? "")
+      return duration >= 31556888202959784
+    })
+
     const initialLoading = inject(initialLoadingKey, ref(false))
 
     return {
-      formattedValue, initialLoading,
+      isInfinite, formattedValue, initialLoading,
     }
   }
 });

--- a/src/components/values/DurationValue.vue
+++ b/src/components/values/DurationValue.vue
@@ -48,6 +48,7 @@
 import {computed, defineComponent, inject, ref} from "vue";
 import {formatSeconds} from "@/utils/Duration";
 import {initialLoadingKey} from "@/AppKeys";
+import {infiniteDuration} from "@/schemas/HederaSchemas";
 
 export default defineComponent({
   name: "DurationValue",
@@ -77,7 +78,7 @@ export default defineComponent({
 
     const isInfinite = computed(() => {
       const duration = props.numberValue ?? Number.parseInt(props.stringValue ?? "")
-      return duration >= 31556888202959784
+      return duration >= infiniteDuration
     })
 
     const initialLoading = inject(initialLoadingKey, ref(false))

--- a/src/components/values/TimestampValue.vue
+++ b/src/components/values/TimestampValue.vue
@@ -62,6 +62,7 @@
 import {computed, defineComponent, inject, ref} from "vue";
 import {HMSF} from "@/utils/HMSF";
 import {initialLoadingKey} from "@/AppKeys";
+import {infiniteDuration} from "@/schemas/HederaSchemas";
 
 export default defineComponent({
   name: "TimestampValue",
@@ -86,7 +87,7 @@ export default defineComponent({
       return props.timestamp ? parseSeconds(normalizedTimestamp(props.timestamp, props.nano)) : null
     })
 
-    const isNever = computed( () => seconds.value && seconds.value >= 31556888202959784)
+    const isNever = computed( () => seconds.value && seconds.value >= infiniteDuration)
 
     const dateOptions = {
       weekDay: "short",

--- a/src/components/values/TimestampValue.vue
+++ b/src/components/values/TimestampValue.vue
@@ -25,9 +25,12 @@
 <template>
 
   <template v-if="timestamp">
-    <template v-if="seconds != null">
+    <template v-if="isNever">
+      <span class="has-text-grey">Never</span>
+    </template>
+    <template v-else-if="seconds != null">
       <span>
-        <span class="mr-3 is-numeric">
+        <span v-if="timePart" class="mr-3 is-numeric">
           <span>{{ timePart.hour }}:{{ timePart.minute }}</span>
           <span class="h-is-text-size-3 has-text-grey">:{{ timePart.second }}.{{ timePart.fractionalSecond }}&nbsp;{{ timePart.dayPeriod }}</span>
         </span>
@@ -83,6 +86,8 @@ export default defineComponent({
       return props.timestamp ? parseSeconds(normalizedTimestamp(props.timestamp, props.nano)) : null
     })
 
+    const isNever = computed( () => seconds.value && seconds.value >= 31556888202959784)
+
     const dateOptions = {
       weekDay: "short",
       day: "numeric",
@@ -93,16 +98,17 @@ export default defineComponent({
     }
     const dateFormat = new Intl.DateTimeFormat(locale, dateOptions)
     const datePart = computed(() => {
-      return seconds.value != null ? dateFormat.format(seconds.value * 1000) : "?"
+      return (seconds.value != null && !isNever.value) ? dateFormat.format(seconds.value * 1000) : "?"
     })
 
     const timePart = computed(() => {
-      return seconds.value ? HMSF.extract(seconds.value, locale) : null
+      return (seconds.value && !isNever.value) ? HMSF.extract(seconds.value, locale) : null
     })
 
     const initialLoading = inject(initialLoadingKey, ref(false))
 
     return {
+      isNever,
       seconds,
       datePart,
       timePart,

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -698,6 +698,7 @@ export interface Links {
     next: string | null | undefined
 }
 
+export const infiniteDuration = 31556888202959784
 
 // ---------------------------------------------------------------------------------------------------------------------
 //                                                      Private

--- a/src/utils/Duration.ts
+++ b/src/utils/Duration.ts
@@ -20,12 +20,14 @@
 
 export class Duration {
 
+    public readonly years: number
     public readonly days: number
     public readonly hours: number
     public readonly minutes: number
     public readonly seconds: number
 
-    public constructor(days: number, hours: number, minutes: number, seconds: number) {
+    public constructor(years: number, days: number, hours: number, minutes: number, seconds: number) {
+        this.years = years
         this.days = days
         this.hours = hours
         this.minutes = minutes
@@ -33,6 +35,9 @@ export class Duration {
     }
 
     public static decompose(seconds: number): Duration {
+
+        const years = Math.floor(seconds / 31536000)
+        seconds -= years * 31536000
 
         const days = Math.floor(seconds / 86400)
         seconds -= days * 86400
@@ -43,7 +48,7 @@ export class Duration {
         const minutes = Math.floor(seconds / 60)
         seconds -= minutes * 60
 
-        return new Duration(days, hours, minutes, seconds)
+        return new Duration(years, days, hours, minutes, seconds)
     }
 }
 
@@ -57,26 +62,26 @@ export function formatSeconds(secondCount: number|string|undefined): string {
         } else {
             const duration = Duration.decompose(seconds)
             result = ""
+            if (duration.years >= 2) {
+                const yearUnit = (!duration.days && !duration.hours && !duration.minutes && !duration.seconds) ? " years" : "y "
+                result = duration.years + yearUnit
+            } else if (duration.years == 1) {
+                result = (!duration.days && !duration.hours && !duration.minutes && !duration.seconds) ? "365 days" : "1y "
+            }
             if (duration.days >= 2) {
-                const dayUnit = (!duration.hours && !duration.minutes && !duration.seconds) ? " days" : "d "
+                const dayUnit = (!duration.years && !duration.hours && !duration.minutes && !duration.seconds) ? " days" : "d "
                 result += duration.days + dayUnit
             } else if (duration.days == 1) {
-                result = (!duration.hours && !duration.minutes && !duration.seconds) ? "24h" : "1d "
+                result = (!duration.years && !duration.hours && !duration.minutes && !duration.seconds) ? "24h" : "1d "
             }
-            if (duration.hours >= 2) {
+            if (duration.hours) {
                 result += duration.hours + "h "
-            } else if (duration.hours == 1) {
-                result += "1h "
             }
-            if (duration.minutes >= 2) {
+            if (duration.minutes) {
                 result += duration.minutes + "min "
-            } else if (duration.minutes == 1) {
-                result += "1min "
             }
-            if (duration.seconds >= 2) {
+            if (duration.seconds) {
                 result += duration.seconds + "s "
-            } else if (duration.seconds == 1) {
-                result += "1s "
             }
             result = result.trim()
         }

--- a/tests/unit/values/DurationValue.spec.ts
+++ b/tests/unit/values/DurationValue.spec.ts
@@ -82,6 +82,8 @@ describe("DurationValue.vue", () => {
 
         await testBody(wrapper, 12, "12s")
         await testBody(wrapper, 1, "1s")
+
+        await testBody(wrapper, 31556888202959784, "Infinite")
     })
 
     test("stringValue defined", async () => {

--- a/tests/unit/values/DurationValue.spec.ts
+++ b/tests/unit/values/DurationValue.spec.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {flushPromises, mount} from "@vue/test-utils"
+import {flushPromises, mount, VueWrapper} from "@vue/test-utils"
 import router from "@/router";
 import DurationValue from "@/components/values/DurationValue.vue";
 
@@ -28,7 +28,7 @@ describe("DurationValue.vue", () => {
     // timestamp undefined
     //
 
-    it("numberValue / stringValue undefined", async () => {
+    test("numberValue / stringValue undefined", async () => {
 
         const wrapper = mount(DurationValue, {
             global: {
@@ -47,21 +47,58 @@ describe("DurationValue.vue", () => {
         })
 
         expect(wrapper.text()).toBe("None")
+    })
 
-        const D = 3600 * 3 + 60 * 2 + 42
-        const S = "3h 2min 42s"
-        await wrapper.setProps({
-            numberValue: D,
-            loading: true
-        })
-        expect(wrapper.text()).toBe(S)
+    test("various cases of numberValue defined", async () => {
+
+        const wrapper = mount(DurationValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+            }
+        });
+
+        const year = 31536000
+        const day = 86400
+        const hour = 3600
+        const min = 60
+
+        await testBody(wrapper, 170 * year, "170 years")
+        await testBody(wrapper, 1 * year, "365 days")
+        await testBody(wrapper, 1 * year + 35 * day + 4 * hour + 52 * min + 12, "1y 35d 4h 52min 12s")
+
+        await testBody(wrapper, 35 * day, "35 days")
+        await testBody(wrapper, 1 * day, "24h")
+        await testBody(wrapper, 1 * day + 4 * hour + 52 * min + 12, "1d 4h 52min 12s")
+
+        await testBody(wrapper, 4 * hour, "4h")
+        await testBody(wrapper, 1 * hour, "1h")
+        await testBody(wrapper, 1 * hour + 52 * min + 12, "1h 52min 12s")
+
+        await testBody(wrapper, 52 * min, "52min")
+        await testBody(wrapper, 1 * min, "1min")
+        await testBody(wrapper, 1 * min + 12, "1min 12s")
+
+        await testBody(wrapper, 12, "12s")
+        await testBody(wrapper, 1, "1s")
+    })
+
+    test("stringValue defined", async () => {
 
         const D1 = 3600 * 5 + 60 + 42
         const S1 = "5h 1min 42s"
-        await wrapper.setProps({
-            numberValue: undefined,
-            stringValue: D1.toString(),
-        })
+        const wrapper = mount(DurationValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                numberValue: undefined,
+                stringValue: D1.toString(),
+            }
+        });
+        await flushPromises()
+
         expect(wrapper.text()).toBe(S1)
 
         const S2 = "dummy"
@@ -69,10 +106,30 @@ describe("DurationValue.vue", () => {
             stringValue: S2,
         })
         expect(wrapper.text()).toBe(S2)
-
-
     })
 
+    test("NaN stringValue", async () => {
 
+        const S1 = "dummy"
+        const wrapper = mount(DurationValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                stringValue: S1,
+            }
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(S1)
+    })
 })
+
+const testBody = async (w: VueWrapper, d: number, s: string) => {
+    await w.setProps({
+        numberValue: d,
+    })
+    await flushPromises()
+    expect(w.text()).toBe(s)
+}
 

--- a/tests/unit/values/TimestampValue.spec.ts
+++ b/tests/unit/values/TimestampValue.spec.ts
@@ -31,7 +31,7 @@ describe("TimestampValue.vue", () => {
     // timestamp undefined
     //
 
-    it("blobValue undefined, showNone == false", async () => {
+    test("timestamp undefined, showNone == false", async () => {
 
         const wrapper = mount(TimestampValue, {
             global: {
@@ -46,7 +46,7 @@ describe("TimestampValue.vue", () => {
         expect(wrapper.text()).toBe("")
     })
 
-    it("blobValue undefined, showNone == true", async () => {
+    test("timestamp undefined, showNone == true", async () => {
 
         const wrapper = mount(TimestampValue, {
             global: {
@@ -72,7 +72,7 @@ describe("TimestampValue.vue", () => {
 
     const TIMESTAMP_STRING = "12:44:13.1650 AMFeb 22, 2021, UTC"
 
-    it("blobValue undefined, nano == false", async () => {
+    test("timestamp expressed in seconds", async () => {
 
         const wrapper = mount(TimestampValue, {
             global: {
@@ -94,7 +94,7 @@ describe("TimestampValue.vue", () => {
 
     const TIMESTAMP_NANOS = "1613954653165071000"
 
-    it("blobValue undefined, nano == true", async () => {
+    test("timestamp expressed in nanoseconds", async () => {
 
         const wrapper = mount(TimestampValue, {
             global: {
@@ -111,6 +111,27 @@ describe("TimestampValue.vue", () => {
         expect(wrapper.text()).toBe(TIMESTAMP_STRING)
     })
 
+    //
+    // 'Infinite' timestamp
+    //
 
+    const INFINITE_TIMESTAMP = "31556889864403199.196946953"
+    const INFINITE_STRING = "Never"
+
+    test("infinite timestamp", async () => {
+
+        const wrapper = mount(TimestampValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                timestamp: INFINITE_TIMESTAMP
+            },
+        });
+
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(INFINITE_STRING)
+    })
 })
 


### PR DESCRIPTION
**Description**:

With the following changes:
- We specify the number of years for very large durations.
- We interpret very large durations as _infinite_ and very remote timestamp as _never_

**Related issue(s)**:

Fixes #366 

**Notes for reviewer**:

Currently deploying on staging server.

Example of account with large `auto-renew-period` (in years): `{server}/mainnet/account/0.0.200`
Example of account with infinite `auto-renew-period` and `expiry-timestamp`: `{server}/mainnet/account/0.0.400`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
