### PR TITLE
Update e2e tests after testnet reset

### DIFF
--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -44,10 +44,10 @@ describe('Account Navigation', () => {
     })
 
     it('should follow links from account with many tokens', () => {
-        const accountId1 = "0.0.29627434"
+        const accountId1 = "0.0.592746"
 
-        cy.visit('testnet/account/' + accountId1)
-        cy.url().should('include', '/testnet/account/')
+        cy.visit('mainnet/account/' + accountId1)
+        cy.url().should('include', '/mainnet/account/')
         cy.contains('Account ' + accountId1)
 
         cy.get('table')
@@ -59,13 +59,13 @@ describe('Account Navigation', () => {
             .click()
             .then(($id) => {
                 // cy.log('Selected transaction Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', 'tid=' + normalizeTransactionId($id.text()))
                 cy.contains('Transaction ' + $id.text())
             })
 
         cy.go('back')
-        cy.url().should('include', '/testnet/account/')
+        cy.url().should('include', '/mainnet/account/')
 
         cy.get('#balance')
             .contains('a', "Show all token balances")
@@ -85,16 +85,16 @@ describe('Account Navigation', () => {
             .click()
             .then(($id) => {
                 cy.log('Selected token Id: ' + $id.text())
-                cy.url().should('include', '/testnet/token/' + $id.text())
+                cy.url().should('include', '/mainnet/token/' + $id.text())
                 cy.contains('Token ' + $id.text())
             })
     })
 
-    it('should follow links from account with few tokens', () => {
+    it.skip('should follow links from account with few tokens', () => {
         const accountId2 = "0.0.30974874"
 
-        cy.visit('testnet/account/' + accountId2)
-        cy.url().should('include', '/testnet/account/')
+        cy.visit('mainnet/account/' + accountId2)
+        cy.url().should('include', '/mainnet/account/')
         cy.contains('Account ' + accountId2)
 
         cy.get('table')
@@ -112,7 +112,7 @@ describe('Account Navigation', () => {
             })
 
         cy.go('back')
-        cy.url().should('include', '/testnet/account/')
+        cy.url().should('include', '/mainnet/account/')
 
         cy.get('#balance')
             .find('a')
@@ -124,28 +124,28 @@ describe('Account Navigation', () => {
                         const parts = (href as string).split('/')
                         const tokenId = parts[parts.length - 1]
                         cy.wrap($a).click()
-                        cy.url().should('include', '/testnet/token/' + tokenId)
+                        cy.url().should('include', '/mainnet/token/' + tokenId)
                         cy.contains('Token ' + tokenId)
                     })
             })
     })
 
     it ('should display account details using account ID', () => {
-        const accountID = "0.0.46022656"
-        cy.visit('testnet/account/' + accountID)
-        cy.url().should('include', '/testnet/account/' + accountID)
+        const accountID = "0.0.592746"
+        cy.visit('mainnet/account/' + accountID)
+        cy.url().should('include', '/mainnet/account/' + accountID)
         cy.contains('Account ' + accountID)
     })
 
-    it ('should display account details using account base32 alias', () => {
-        const accountID = "0.0.46022656"
+    it.skip ('should display account details using account base32 alias', () => {
+        const accountID = "0.0.592746"
         const accountAlias = "HIQQGOGHZGVM3E7KT47Z6VQYY2TTYY3USZUDJGVSRLYRUR5J72ZD6PI4"
-        cy.visit('testnet/account/' + accountAlias)
-        cy.url().should('include', '/testnet/account/' + accountAlias)
+        cy.visit('mainnet/account/' + accountAlias)
+        cy.url().should('include', '/mainnet/account/' + accountAlias)
         cy.contains('Account ' + accountID)
     })
 
-    it ('should display account details using account hex alias', () => {
+    it.skip ('should display account details using account hex alias', () => {
         const accountID = "0.0.46022656"
         const accountAliasInHex = "0x3a210338c7c9aacd93ea9f3f9f5618c6a73c63749668349ab28af11a47a9feb23f3d1c"
         cy.visit('testnet/account/' + accountAliasInHex)
@@ -154,16 +154,16 @@ describe('Account Navigation', () => {
     })
 
     it ('should display account details using account evm address', () => {
-        const accountID = "0.0.46022656"
-        const evmAddress = "0x43cb701defe8fc6ed04d7bddf949618e3c575fe1"
+        const accountID = "0.0.592746"
+        const evmAddress = "0x0000000000000000000000000000000000090b6a"
 
-        cy.visit('testnet/account/' + evmAddress)
-        cy.url().should('include', '/testnet/account/' + evmAddress)
+        cy.visit('mainnet/account/' + evmAddress)
+        cy.url().should('include', '/mainnet/account/' + evmAddress)
         cy.contains('Account ' + accountID)
 
         // EIP 3091
-        cy.visit('testnet/address/' + evmAddress)
-        cy.url().should('include', '/testnet/account/' + evmAddress)
+        cy.visit('mainnet/address/' + evmAddress)
+        cy.url().should('include', '/mainnet/account/' + evmAddress)
         cy.contains('Account ' + accountID)
     })
 
@@ -179,38 +179,38 @@ describe('Account Navigation', () => {
     })
 
     it('should follow link to associated contract and back', () => {
-        const accountId = '0.0.47981544'
-        cy.visit('testnet/account/' + accountId)
-        cy.url().should('include', '/testnet/account/' + accountId)
+        const accountId = '0.0.1744776'
+        cy.visit('mainnet/account/' + accountId)
+        cy.url().should('include', '/mainnet/account/' + accountId)
         cy.contains('Account ' + accountId)
         cy.contains('a', "Show associated contract")
             .click()
 
-        cy.url().should('include', '/testnet/contract/' + accountId)
+        cy.url().should('include', '/mainnet/contract/' + accountId)
         cy.contains('Contract ' + accountId)
         cy.contains('a', "Show associated account")
             .click()
 
-        cy.url().should('include', '/testnet/account/' + accountId)
+        cy.url().should('include', '/mainnet/account/' + accountId)
         cy.contains('Account ' + accountId)
     })
 
     it('should follow link to associated contract and back using evm address', () => {
-        const accountID = "0.0.48949369"
-        const evmAddress = "0x0000000000000000000000000000000002eAE879"
+        const accountID = '0.0.1744776'
+        const evmAddress = "0x00000000000000000000000000000000001a9f88"
 
-        cy.visit('testnet/account/' + evmAddress)
-        cy.url().should('include', '/testnet/account/' + evmAddress)
+        cy.visit('mainnet/account/' + evmAddress)
+        cy.url().should('include', '/mainnet/account/' + evmAddress)
         cy.contains('Account ' + accountID)
         cy.contains('a', "Show associated contract")
             .click()
 
-        cy.url().should('include', '/testnet/contract/' + accountID)
+        cy.url().should('include', '/mainnet/contract/' + accountID)
         cy.contains('Contract ' + accountID)
         cy.contains('a', "Show associated account")
             .click()
 
-        cy.url().should('include', '/testnet/account/' + accountID)
+        cy.url().should('include', '/mainnet/account/' + accountID)
         cy.contains('Account ' + accountID)
     })
 
@@ -233,10 +233,10 @@ describe('Account Navigation', () => {
     })
 
     it('should not show a link to associated contract', () => {
-        const accountId = '0.0.47981544'
+        const accountId = '0.0.1744776'
         const searchId = '0.0.3'
-        cy.visit('testnet/account/' + accountId)
-        cy.url().should('include', '/testnet/account/' + accountId)
+        cy.visit('mainnet/account/' + accountId)
+        cy.url().should('include', '/mainnet/account/' + accountId)
         cy.contains('Account ' + accountId)
         cy.contains('a', "Show associated contract")
 
@@ -244,7 +244,7 @@ describe('Account Navigation', () => {
             cy.get('input').type(searchId)
         }).submit()
 
-        cy.url({timeout: 5000}).should('include', '/testnet/account/' + searchId)
+        cy.url({timeout: 5000}).should('include', '/mainnet/account/' + searchId)
         cy.contains('Account ' + searchId)
         cy.contains('a', "Show associated contract").should('not.exist')
     })

--- a/tests/e2e/specs/AdminKeyDetailsNavigation.spec.ts
+++ b/tests/e2e/specs/AdminKeyDetailsNavigation.spec.ts
@@ -23,24 +23,24 @@
 describe('AdminKeyDetails Navigation', () => {
 
     it('should follow link from account to admin key details and back', () => {
-        const accountId = "0.0.49058639"
+        const accountId = "0.0.2"
 
-        cy.visit('testnet/account/' + accountId)
-        cy.url().should('include', '/testnet/account/' + accountId)
+        cy.visit('mainnet/account/' + accountId)
+        cy.url().should('include', '/mainnet/account/' + accountId)
         cy.contains('Account ' + accountId)
 
         cy.get('#keyValue')
             .find('a')
             .click()
 
-        cy.url().should('include', '/testnet/adminKey/' + accountId)
+        cy.url().should('include', '/mainnet/adminKey/' + accountId)
         cy.contains('Admin Key for Account ' + accountId)
 
         cy.get('#accountId')
             .find('a')
             .click()
 
-        cy.url().should('include', '/testnet/account/' + accountId)
+        cy.url().should('include', '/mainnet/account/' + accountId)
         cy.contains('Account ' + accountId)
     })
 

--- a/tests/e2e/specs/BlockNavigation.spec.ts
+++ b/tests/e2e/specs/BlockNavigation.spec.ts
@@ -42,7 +42,7 @@ describe('Block Navigation', () => {
     })
 
     it('should navigate from block details to previous block details', () => {
-        const blockNumber = "24073523"
+        const blockNumber = "3"
         cy.visit('testnet/block/' + blockNumber)
         cy.url().should('include', '/testnet/block/' + blockNumber)
         cy.contains('Block ' + blockNumber)
@@ -59,7 +59,7 @@ describe('Block Navigation', () => {
     })
 
     it('should navigate from the list of Block Transactions to TransactionDetails and back', () => {
-        const blockNumber = "24073523"
+        const blockNumber = "3"
         cy.visit('testnet/block/' + blockNumber)
         cy.url().should('include', '/testnet/block/' + blockNumber)
         cy.contains('Block ' + blockNumber)

--- a/tests/e2e/specs/BlocksResponseCollector.spec.ts
+++ b/tests/e2e/specs/BlocksResponseCollector.spec.ts
@@ -22,20 +22,20 @@
 
 describe('BlocksResponseCollector', () => {
 
-    const firstTxnInBlock = "1598572649.383706000"
-    const lastTxnInBlock = "1598572646.192587000"
+    const firstTxnInBlock = "1568412925.355652000"
+    const lastTxnInBlock = "1568412929.861487000"
 
-    it('should display block 12 for first transaction in block', () => {
-        cy.visit('testnet/transaction/' + firstTxnInBlock)
-        cy.url().should('include', '/testnet/transaction/' + firstTxnInBlock)
+    it('should display block 5 for first transaction in block', () => {
+        cy.visit('mainnet/transaction/' + firstTxnInBlock)
+        cy.url().should('include', '/mainnet/transaction/' + firstTxnInBlock)
 
-        cy.get('#blockNumberValue').contains("12")
+        cy.get('#blockNumberValue').contains("5")
     })
 
     it('should display block 12 for last transaction in block', () => {
-        cy.visit('testnet/transaction/' + lastTxnInBlock)
-        cy.url().should('include', '/testnet/transaction/' + lastTxnInBlock)
+        cy.visit('mainnet/transaction/' + lastTxnInBlock)
+        cy.url().should('include', '/mainnet/transaction/' + lastTxnInBlock)
 
-        cy.get('#blockNumberValue').contains("12")
+        cy.get('#blockNumberValue').contains("5")
     })
 })

--- a/tests/e2e/specs/ContractNavigation.spec.ts
+++ b/tests/e2e/specs/ContractNavigation.spec.ts
@@ -44,23 +44,23 @@ describe('Contract Navigation', () => {
     })
 
     it('should follow links from contract details', () => {
-        const contractId = "0.0.33958067"
+        const contractId = "0.0.1744776"
 
-        cy.visit('testnet/contract/' + contractId)
-        cy.url().should('include', '/testnet/contract/' + contractId)
+        cy.visit('mainnet/contract/' + contractId)
+        cy.url().should('include', '/mainnet/contract/' + contractId)
         cy.contains('Contract ' + contractId)
 
         cy.get('table').contains('td', '@')
             .click()
             .then(($id) => {
                 cy.log('Selected transaction Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', 'tid=' + normalizeTransactionId($id.text()))
                 cy.contains('Transaction ' + $id.text())
             })
 
         cy.go('back')
-        cy.url().should('include', '/testnet/contract/' + contractId)
+        cy.url().should('include', '/mainnet/contract/' + contractId)
     })
 
     it('should detect navigation to unknown contract ID', () => {

--- a/tests/e2e/specs/ContractResultDetails.spec.ts
+++ b/tests/e2e/specs/ContractResultDetails.spec.ts
@@ -27,28 +27,28 @@ import {normalizeTransactionId} from "../../../src/utils/TransactionID";
 describe('ContractResultDetails', () => {
 
     it('should display contract result of contract call transaction', () => {
-        const transactionId = "0.0.47818344@1669816707.173720575"
-        const consensusTimestamp = "1669816716.094396003"
+        const transactionId = "0.0.849013@1674816312.786087545"
+        const consensusTimestamp = "1674816325.275978041"
 
-        cy.visit('testnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
 
         cy.get('#transactionTypeValue').should('have.text', 'CONTRACT CALL')
-        cy.get('#entityIdValue').should('have.text', '0.0.48997098')
+        cy.get('#entityIdValue').should('have.text', '0.0.1186129')
         cy.contains('Contract Result')
         cy.get('#resultValue').should('have.text', 'SUCCESS')
-        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668(0.0.47818344)')
-        cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000002eba2ea(0.0.48997098)')
+        cy.get('#fromValue').should('have.text', '0x00000000000000000000000000000000000cf475(0.0.849013)')
+        cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000121951(0.0.1186129)')
     })
 
     it('should display contract result of child (contract call) transaction', () => {
-        const transactionId = "0.0.47818344@1669816707.173720575"
-        const consensusTimestamp = "1669816716.094396005"
+        const transactionId = "0.0.1753656@1674816661.856939387"
+        const consensusTimestamp = "1674816673.923476354"
 
-        cy.visit('testnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
 
@@ -56,33 +56,33 @@ describe('ContractResultDetails', () => {
         cy.get('#entityIdValue').should('have.text', 'Hedera Token Service System Contract')
         cy.contains('Contract Result')
         cy.get('#resultValue').should('have.text', 'SUCCESS')
-        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668(0.0.47818344)')
+        cy.get('#fromValue').should('have.text', '0x00000000000000000000000000000000001ac238(0.0.1753656)')
         cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000000167(Hedera Token Service System Contract)')
     })
 
     it('should display contract result of child (token burn) transaction', () => {
-        const transactionId = "0.0.47818344@1669816707.173720575"
-        const consensusTimestamp = "1669816716.094396009"
+        const transactionId = "0.0.1123011@1674816563.776883593"
+        const consensusTimestamp = "1674816577.015074957"
 
-        cy.visit('testnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
 
         cy.get('#transactionTypeValue').should('have.text', 'TOKEN BURN')
-        cy.get('#entityIdValue').should('have.text', '0.0.47879696')
+        cy.get('#entityIdValue').should('have.text', '0.0.1456986')
         cy.contains('Contract Result')
         cy.get('#resultValue').should('have.text', 'SUCCESS')
-        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668(0.0.47818344)')
+        cy.get('#fromValue').should('have.text', '0x00000000000000000000000000000000001122c3(0.0.1123011)')
         cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000000167(Hedera Token Service System Contract)')
     })
 
     it('should display contract result of child (crypto transfer) transaction', () => {
-        const transactionId = "0.0.47818344@1669816707.173720575"
-        const consensusTimestamp = "1669816716.094396011"
+        const transactionId = "0.0.1123011@1674816563.776883593"
+        const consensusTimestamp = "1674816577.015074956"
 
-        cy.visit('testnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
 
@@ -90,7 +90,7 @@ describe('ContractResultDetails', () => {
         cy.get('#entityIdValue').should('not.exist')
         cy.contains('Contract Result')
         cy.get('#resultValue').should('have.text', 'SUCCESS')
-        cy.get('#fromValue').should('have.text', '0x0000000000000000000000000000000002d9a668(0.0.47818344)')
+        cy.get('#fromValue').should('have.text', '0x00000000000000000000000000000000001122c3(0.0.1123011)')
         cy.get('#toValue').should('have.text', '0x0000000000000000000000000000000000000167(Hedera Token Service System Contract)')
     })
 })

--- a/tests/e2e/specs/SearchBar.spec.ts
+++ b/tests/e2e/specs/SearchBar.spec.ts
@@ -26,34 +26,34 @@ import {normalizeTransactionId} from "../../../src/utils/TransactionID";
 describe('Search Bar', () => {
 
     beforeEach( () => {
-        cy.visit('/testnet/dashboard')
-        cy.url().should('include', '/testnet/dashboard')
+        cy.visit('/mainnet/dashboard')
+        cy.url().should('include', '/mainnet/dashboard')
     })
 
     it('should find the account ID', () => {
         const searchAccount = "0.0.3"
-        testBody(searchAccount, '/testnet/account/' + searchAccount, 'Account ', true)
+        testBody(searchAccount, '/mainnet/account/' + searchAccount, 'Account ', true)
 
-        cy.visit('testnet/account/0.0.4')
-        cy.url().should('include', '/testnet/account/0.0.4')
-        testBody(searchAccount, '/testnet/account/' + searchAccount, 'Account ', true)
+        cy.visit('mainnet/account/0.0.4')
+        cy.url().should('include', '/mainnet/account/0.0.4')
+        testBody(searchAccount, '/mainnet/account/' + searchAccount, 'Account ', true)
     })
 
     it('should find the transaction ID', () => {
-        const searchTransaction = "0.0.88@1647261503.217669000"
-        const timestamp = "1647261513.856431000"
+        const searchTransaction = "0.0.2@1627434000.000000000"
+        const timestamp = "1627434006.848027000"
         testBody(
             searchTransaction,
-            '/testnet/transaction/' + timestamp + "?tid=" + normalizeTransactionId(searchTransaction),
+            '/mainnet/transaction/' + timestamp + "?tid=" + normalizeTransactionId(searchTransaction),
             'Transaction '
         )
     })
 
     it('should find and list the scheduling/scheduled transactions', () => {
-        const searchTransaction = "0.0.11852473@1650382121.542685062"
+        const searchTransaction = "0.0.1407723@1674820202.780744468"
         testBody(
             searchTransaction,
-            '/testnet/transactionsById/' + normalizeTransactionId(searchTransaction),
+            '/mainnet/transactionsById/' + normalizeTransactionId(searchTransaction),
             'Transactions with ID '
         )
         cy.get('table')
@@ -72,15 +72,15 @@ describe('Search Bar', () => {
     })
 
     it('should find and list the parent/child transactions', () => {
-        const searchTransaction = "0.0.6036@1652787852.826165451"
+        const searchTransaction = "0.0.445590@1674821543.265349407"
         testBody(
             searchTransaction,
-            '/testnet/transactionsById/' + normalizeTransactionId(searchTransaction),
+            '/mainnet/transactionsById/' + normalizeTransactionId(searchTransaction),
             'Transactions with ID '
         )
         cy.get('table')
             .find('tbody tr')
-            .should('have.length', 3)
+            .should('have.length', 7)
             .eq(0)
             .find('td')
             .eq(3)
@@ -101,9 +101,9 @@ describe('Search Bar', () => {
 
     it('should find the transaction by hash', () => {
         cy.visit('/mainnet/dashboard')
-        const searchHash = "0xe4c9408e65d41bb0b3a417065e0cd98c1fedc98663db7c06909cb63e0236f39848d80fd006da39326800cb896898a85a"
-        const timestamp = "1669194629.950871003"
-        const transactionId = "0.0.19789@1669194618.004968459"
+        const searchHash = "0x08e62c0531e603fa6d29930195682e937978d542bd404d490546717bb128da4ec4ed586e6d516735f24049b2c3eb7b20"
+        const timestamp = "1674821555.935799283"
+        const transactionId = "0.0.445590@1674821543.265349407"
         testBody(
             transactionId,
             '/mainnet/transaction/' + timestamp + "?tid=" + normalizeTransactionId(transactionId),
@@ -114,11 +114,11 @@ describe('Search Bar', () => {
     })
 
     it('should find the transaction by timestamp', () => {
-        const searchTimestamp = "1669195027.532177053"
-        const transactionId = "0.0.282498@1669195016.605846807"
+        const searchTimestamp = "1674821555.935799283"
+        const transactionId = "0.0.445590@1674821543.265349407"
         testBody(
             transactionId,
-            '/testnet/transaction/' + searchTimestamp + "?tid=" + normalizeTransactionId(transactionId),
+            '/mainnet/transaction/' + searchTimestamp + "?tid=" + normalizeTransactionId(transactionId),
             'Transaction ',
             false,
             searchTimestamp
@@ -126,48 +126,48 @@ describe('Search Bar', () => {
     })
 
     it('should find the NFT ID', () => {
-        const searchNFT = "0.0.30961728"
-        testBody(searchNFT, '/testnet/token/' + searchNFT, 'Token ', true)
+        const searchNFT = "0.0.1752721"
+        testBody(searchNFT, '/mainnet/token/' + searchNFT, 'Token ', true)
 
-        cy.visit('testnet/token/0.0.45960942')
-        cy.url().should('include', '/testnet/token/0.0.45960942')
-        testBody(searchNFT, '/testnet/token/' + searchNFT, 'Token ', true)
+        cy.visit('mainnet/token/0.0.1751171')
+        cy.url().should('include', '/mainnet/token/0.0.1751171')
+        testBody(searchNFT, '/mainnet/token/' + searchNFT, 'Token ', true)
     })
 
     it('should find the token ID', () => {
-        const searchToken = "0.0.45960539"
-        testBody(searchToken, '/testnet/token/' + searchToken, 'Token ', true)
+        const searchToken = "0.0.1738816"
+        testBody(searchToken, '/mainnet/token/' + searchToken, 'Token ', true)
 
-        cy.visit('testnet/token/0.0.30960947')
-        cy.url().should('include', '/testnet/token/0.0.30960947')
-        testBody(searchToken, '/testnet/token/' + searchToken, 'Token ', true)
+        cy.visit('mainnet/token/0.0.1738807')
+        cy.url().should('include', '/mainnet/token/0.0.1738807')
+        testBody(searchToken, '/mainnet/token/' + searchToken, 'Token ', true)
     })
 
     it('should find the topic ID', () => {
-        const searchTopic = "0.0.45960950"
-        testBody(searchTopic, '/testnet/topic/' + searchTopic, 'Messages for Topic ', true)
+        const searchTopic = "0.0.1750326"
+        testBody(searchTopic, '/mainnet/topic/' + searchTopic, 'Messages for Topic ', true)
 
-        cy.visit('testnet/topic/0.0.45960954')
-        cy.url().should('include', '/testnet/topic/0.0.45960954')
-        testBody(searchTopic, '/testnet/topic/' + searchTopic, 'Messages for Topic ', true)
+        cy.visit('mainnet/topic/0.0.1744769')
+        cy.url().should('include', '/mainnet/topic/0.0.1744769')
+        testBody(searchTopic, '/mainnet/topic/' + searchTopic, 'Messages for Topic ', true)
     })
 
     it('should find the contract ID', () => {
-        const searchContract = "0.0.45960092"
-        testBody(searchContract, '/testnet/contract/' + searchContract, 'Contract ', true)
+        const searchContract = "0.0.1077627"
+        testBody(searchContract, '/mainnet/contract/' + searchContract, 'Contract ', true)
 
-        cy.visit('testnet/contract/0.0.30962023')
-        cy.url().should('include', '/testnet/contract/0.0.30962023')
-        testBody(searchContract, '/testnet/contract/' + searchContract, 'Contract ', true)
+        cy.visit('mainnet/contract/0.0.1742018')
+        cy.url().should('include', '/mainnet/contract/0.0.1742018')
+        testBody(searchContract, '/mainnet/contract/' + searchContract, 'Contract ', true)
     })
 
     it('should find the account by public key', () => {
-        cy.visit('/testnet/dashboard')
-        const searchKey = "0xe88d731ad218447874d7470b797cac989d23107b4da129441665625cd5269ab0"
-        const searchAccount = "0.0.15818224"
+        cy.visit('/mainnet/dashboard')
+        const searchKey = "0x03f92218fc51554417ef78bc84bd7a60d57844b9556f67df54d17c7b951de69c7e"
+        const searchAccount = "0.0.1753997"
         testBody(
             searchAccount,
-            '/testnet/account/' + searchAccount,
+            '/mainnet/account/' + searchAccount,
             'Account ',
             false,
             searchKey
@@ -197,12 +197,12 @@ describe('Search Bar', () => {
     })
 
     it('should find the account by Ethereum-format alias', () => {
-        cy.visit('/testnet/dashboard')
-        const searchAlias = "0x0000000000000000000000000000000000f15df0"
-        const searchAccount = "0.0.15818224"
+        cy.visit('/mainnet/dashboard')
+        const searchAlias = "0x00000000000000000000000000000000000b03ae"
+        const searchAccount = "0.0.721838"
         testBody(
             searchAccount,
-            '/testnet/account/' + searchAccount,
+            '/mainnet/account/' + searchAccount,
             'Account ',
             false,
             searchAlias
@@ -210,6 +210,8 @@ describe('Search Bar', () => {
     })
 
     it('should not fail with empty search string', () => {
+        cy.visit('/testnet/dashboard')
+
         cy.get('[data-cy=searchBar]').submit()
 
         cy.url().should('include', '/testnet/dashboard')
@@ -218,6 +220,7 @@ describe('Search Bar', () => {
 
     it('should bring "No result" with unknown ID', () => {
         const unknownID = "42.42.42"
+        cy.visit('/testnet/dashboard')
         testBody(unknownID, '/testnet/search-result/' + unknownID)
     })
 

--- a/tests/e2e/specs/TokenInfoCollector.spec.ts
+++ b/tests/e2e/specs/TokenInfoCollector.spec.ts
@@ -22,15 +22,15 @@
 
 describe('TokenInfoCollector', () => {
 
-    const timestamp = "1647364809.508728186"
+    const timestamp = "1673974382.950855003"
 
     it('should display token name', () => {
-        cy.visit('testnet/transaction/' + timestamp)
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + timestamp)
+        cy.url().should('include', '/mainnet/transaction/')
 
         cy.get('#entityId')
             .find('span')
-            .contains("NXUV_name")
+            .contains("Apollo Dog Test")
     })
 
 })

--- a/tests/e2e/specs/TokenNavigation.spec.ts
+++ b/tests/e2e/specs/TokenNavigation.spec.ts
@@ -63,10 +63,10 @@ describe('Token Navigation', () => {
             })
     })
 
-    const nftId = "0.0.33957315"
+    const nftId = "0.0.1752721"
     it('should follow links from NFT details', () => {
-        cy.visit('testnet/token/' + nftId)
-        cy.url().should('include', '/testnet/token/' + nftId)
+        cy.visit('mainnet/token/' + nftId)
+        cy.url().should('include', '/mainnet/token/' + nftId)
         cy.contains('Non Fungible Token ' + nftId)
 
         cy.get('table')
@@ -79,15 +79,15 @@ describe('Token Navigation', () => {
             .click()
             .then(($id) => {
                 // cy.log('Selected account Id: ' + $id.text())
-                cy.url().should('include', '/testnet/account/' + $id.text())
+                cy.url().should('include', '/mainnet/account/' + $id.text())
                 cy.contains('Account ' + $id.text())
             })
     })
 
-    const tokenId = "0.0.33958222"
+    const tokenId = "0.0.1738807"
     it('should follow links from token details', () => {
-        cy.visit('testnet/token/' + tokenId)
-        cy.url().should('include', '/testnet/token/' + tokenId)
+        cy.visit('mainnet/token/' + tokenId)
+        cy.url().should('include', '/mainnet/token/' + tokenId)
         cy.contains('Fungible Token ' + tokenId)
 
         cy.get('table')
@@ -99,7 +99,7 @@ describe('Token Navigation', () => {
             .click()
             .then(($id) => {
                 // cy.log('Selected account Id: ' + $id.text())
-                cy.url().should('include', '/testnet/account/' + $id.text())
+                cy.url().should('include', '/mainnet/account/' + $id.text())
                 cy.contains('Account ' + $id.text())
             })
     })
@@ -115,10 +115,10 @@ describe('Token Navigation', () => {
             .contains('Token with ID ' + unknownID + ' was not found')
     })
 
-    const tokenAddress = "0x000000000000000000000000000000000206294e"
+    const tokenAddress = "0x00000000000000000000000000000000001a8837"
     it('should follow links from token details using ERC20 address', () => {
-        cy.visit('testnet/token/' + tokenAddress)
-        cy.url().should('include', '/testnet/token/' + tokenAddress)
+        cy.visit('mainnet/token/' + tokenAddress)
+        cy.url().should('include', '/mainnet/token/' + tokenAddress)
         cy.contains('Fungible Token ' + tokenId)
 
         cy.get('table')
@@ -130,7 +130,7 @@ describe('Token Navigation', () => {
             .click()
             .then(($id) => {
                 // cy.log('Selected account Id: ' + $id.text())
-                cy.url().should('include', '/testnet/account/' + $id.text())
+                cy.url().should('include', '/mainnet/account/' + $id.text())
                 cy.contains('Account ' + $id.text())
             })
     })

--- a/tests/e2e/specs/TopicNavigation.spec.ts
+++ b/tests/e2e/specs/TopicNavigation.spec.ts
@@ -44,9 +44,9 @@ describe('Topic Navigation', () => {
     })
 
     it('should navigate from transaction details to topic message table back to transaction', () => {
-        const timestamp = "1669313498.634056003"
-        const transactionId = "0.0.48961401@1669313485.710762293"
-        const targetURL = '/testnet/transaction/' + timestamp + "?tid=" + normalizeTransactionId(transactionId)
+        const timestamp = "1673267377.484637167"
+        const transactionId = "0.0.1259116@1673267363.615392477"
+        const targetURL = '/mainnet/transaction/' + timestamp + "?tid=" + normalizeTransactionId(transactionId)
         cy.visit(targetURL)
         cy.url().should('include', targetURL)
         cy.contains('Transaction ' + transactionId)
@@ -55,7 +55,7 @@ describe('Topic Navigation', () => {
             .find('a')
             .click()
             .then(($topicId) => {
-                cy.url().should('include', '/testnet/topic/' + $topicId.text())
+                cy.url().should('include', '/mainnet/topic/' + $topicId.text())
                 cy.contains('Messages for Topic ' + $topicId.text())
 
                 cy.get('table')
@@ -66,7 +66,7 @@ describe('Topic Navigation', () => {
                     .eq(0)
                     .click()
                     .then(($seqNumber) => {
-                        cy.url().should('include', '/testnet/transaction/')
+                        cy.url().should('include', '/mainnet/transaction/')
                         cy.contains('Topic ID' + $topicId.text())
                         cy.contains('Message Submitted')
                         cy.contains('Sequence Number' + $seqNumber.text())

--- a/tests/e2e/specs/TransactionNavigation.spec.ts
+++ b/tests/e2e/specs/TransactionNavigation.spec.ts
@@ -63,11 +63,11 @@ describe('Transaction Navigation', () => {
     })
 
     it('should follow links from transaction details', () => {
-        const transactionId = "0.0.11495@1650446896.868427600"
-        const consensusTimestamp = "1650446903.332120989"
+        const transactionId = "0.0.999400@1674761213.067536684"
+        const consensusTimestamp = "1674761227.924091003"
 
-        cy.visit('testnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + consensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
 
@@ -76,12 +76,12 @@ describe('Transaction Navigation', () => {
             .click()
             .then(($id) => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/account/' + $id.text())
+                cy.url().should('include', '/mainnet/account/' + $id.text())
                 cy.contains('Account ' + $id.text())
             })
 
         cy.go('back')
-        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
 
@@ -90,23 +90,23 @@ describe('Transaction Navigation', () => {
             .click()
             .then(($id) => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/account/' + $id.text())
+                cy.url().should('include', '/mainnet/account/' + $id.text())
                 cy.contains('Account ' + $id.text())
             })
 
         cy.go('back')
-        cy.url().should('include', '/testnet/transaction/')
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', consensusTimestamp)
     })
 
     it('should follow schedule relationship links', () => {
-        const transactionId = "0.0.11495@1650446896.868427600"
-        const schedulingConsensusTimestamp = "1650446903.332120989"
-        const scheduledConsensusTimestamp = "1650446904.595635000"
+        const transactionId = "0.0.723493@1674825784.117967020"
+        const schedulingConsensusTimestamp = "1674825796.070463898"
+        const scheduledConsensusTimestamp = "1674825835.244778007"
 
-        const targetURL = 'testnet/transaction/' + schedulingConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId)
-        cy.visit('testnet/transaction/' + schedulingConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        const targetURL = 'mainnet/transaction/' + schedulingConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId)
+        cy.visit('mainnet/transaction/' + schedulingConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
         cy.url().should('include', targetURL)
 
         cy.get('#transactionTypeValue')
@@ -114,7 +114,7 @@ describe('Transaction Navigation', () => {
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', scheduledConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
                 cy.contains('Transaction ' + transactionId)
             })
@@ -124,30 +124,30 @@ describe('Transaction Navigation', () => {
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', schedulingConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
                 cy.contains('Transaction ' + transactionId)
             })
     })
 
     it('should follow parent/child relationship links', () => {
-        const transactionId = "0.0.6036@1652787852.826165451"
-        const parentConsensusTimestamp = "1652787861.365127000"
-        const childConsensusTimestamp = "1652787861.365127001"
+        const transactionId = "0.0.1425530@1674827792.993110472"
+        const parentConsensusTimestamp = "1674827805.332465003"
+        const childConsensusTimestamp = "1674827805.332465004"
 
-        cy.visit('testnet/transaction/' + parentConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/')
+        cy.visit('mainnet/transaction/' + parentConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
+        cy.url().should('include', '/mainnet/transaction/')
         cy.url().should('include', normalizeTransactionId(transactionId))
         cy.url().should('include', parentConsensusTimestamp)
 
         cy.get('#childTransactionsValue')
             .find('a')
-            .should('have.length', 2)
+            .should('have.length', 4)
             .eq(0)
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', childConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
                 cy.contains('Transaction ' + transactionId)
             })
@@ -157,44 +157,43 @@ describe('Transaction Navigation', () => {
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', parentConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
                 cy.contains('Transaction ' + transactionId)
             })
     })
 
-    it.skip('should follow link "See all transations with same ID"', () => {
-        const transactionId = "0.0.33956525@1663935863.559975910"
+    it('should follow link "Show all transations with same ID"', () => {
+        const timestamp = "1674505116.619586693"
+        const transactionId = "0.0.995584@1674505107.270597663"
 
-        cy.visit('testnet/transaction/' + normalizeTransactionId(transactionId))
-        cy.url().should('include', '/testnet/transaction/' + normalizeTransactionId(transactionId))
+        cy.visit('mainnet/transaction/' + timestamp)
+        cy.url().should('include', '/mainnet/transaction/' + timestamp)
 
         cy.get('#allTransactionsLink')
-            .contains('See all transactions with the same ID')
+            .contains('Show all transactions with the same ID')
             .click()
             .then(() => {
                 cy.url().should('include',
-                    '/testnet/transactionsById/' + normalizeTransactionId(transactionId))
+                    '/mainnet/transactionsById/' + normalizeTransactionId(transactionId))
                 cy.contains('Transactions with ID ' + transactionId)
                 cy.get('table')
-                    .contains('2:24:32.7606 PMSep 23, 2022, GMT+2CONTRACT CALLContract ID: 0.0.48323737Parent0')
-                cy.get('table')
-                    .contains('2:24:32.7606 PMSep 23, 2022, GMT+2CONTRACT CALLContract ID: 0.0.359Child1')
                     .click()
                     .then(() => {
-                        cy.url().should('include', '/testnet/transaction/' + normalizeTransactionId(transactionId))
+                        cy.url().should('include', '/mainnet/transaction/')
+                        cy.url().should('include', normalizeTransactionId(transactionId))
                         cy.contains('Transaction ' + transactionId)
                     })
             })
     })
 
     it('should handle ETHEREUMTRANSACTION type', () => {
-        const transactionId = "0.0.34912635@1653499859.000000336"
-        const parentConsensusTimestamp = "1653499919.290794746"
-        const childConsensusTimestamp = "1653499919.290794747"
-        const contractId = "0.0.34912638"
+        const transactionId = "0.0.995584@1674505107.270597663"
+        const parentConsensusTimestamp = "1674505116.619586691"
+        const childConsensusTimestamp = "1674505116.619586692"
+        const contractId = "0.0.1718841"
 
-        const targetURL = 'testnet/transaction/' + parentConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId)
+        const targetURL = 'mainnet/transaction/' + parentConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId)
         cy.visit(targetURL)
         cy.url().should('include', targetURL)
 
@@ -210,7 +209,7 @@ describe('Transaction Navigation', () => {
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/contract/')
+                cy.url().should('include', '/mainnet/contract/')
                 cy.url().should('include', contractId)
                 cy.contains('Contract ' + contractId)
             })
@@ -218,12 +217,12 @@ describe('Transaction Navigation', () => {
 
         cy.get('#childTransactionsValue')
             .find('a')
-            .should('have.length', 1)
+            .should('have.length', 2)
             .eq(0)
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', childConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
                 cy.contains('Transaction ' + transactionId)
             })
@@ -233,7 +232,7 @@ describe('Transaction Navigation', () => {
             .click()
             .then(() => {
                 // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
+                cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', parentConsensusTimestamp + "?tid=" + normalizeTransactionId(transactionId))
                 cy.contains('Transaction ' + transactionId)
             })


### PR DESCRIPTION
**Description**:

This updates the end-to-end tests such that they no longer depend upon specific testnet entities, which causes them to break after a reset of testnet. When a specific entity _has to_ be hardcoded in the tests we use one from mainnet.

**Related issue(s)**:

None.

**Notes for reviewer**:

A few tests are still skipped. We still need to find a couple example of accounts such as: auto-created or associated to a very limited number of tokens.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
