### PR TITLE
00439 custom network configuration

### DIFF
--- a/.env
+++ b/.env
@@ -2,11 +2,6 @@
 ### The variables set in this file will be taken into account at build time.
 ###
 
-### When set, these variables will cause the insertion of a custom menu item
-### in the network selector of the TopNavBar
-# VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME=LOCALNET
-# VUE_APP_LOCAL_MIRROR_NODE_URL=http://localhost:5551/
-
 ### When set to 'true', this variable will enable the 'Staking' page
 VUE_APP_ENABLE_STAKING=true
 

--- a/.env.docker
+++ b/.env.docker
@@ -3,5 +3,5 @@
 ### Any variable documented in the .env file may be overriden here.
 ###
 
-# VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME=LOCALNET
-# VUE_APP_LOCAL_MIRROR_NODE_URL=http://localhost:5551/
+### When set to 'true', this variable will enable the 'Staking' page
+# VUE_APP_ENABLE_STAKING=true

--- a/README.md
+++ b/README.md
@@ -45,18 +45,19 @@ npm run test:e2e
 npm run test:e2e:headless
 ```
 
-### Run the Explorer from a pre-built Docker image
+### Run the Explorer in Docker
 
 ```shell
-docker compose up -d
-# then open http://localhost:8080 in your web browser
-```
+# Build the Docker image locally
+npm run docker:build
 
-### Run the Explorer in Docker from an image built locally
+# Start the Docker container
+# (if not built locally, this will get a pre-built image from Google Container Registry)
+npm run docker:start
 
-```shell
-npm run build:docker
-npm run docker
+# Stop the Docker container
+npm run docker:stop
+
 # then open http://localhost:8080 in your web browser
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,44 @@ npm run docker
 # then open http://localhost:8080 in your web browser
 ```
 
-### Customize configuration
+### Configure the Explorer
 
+#### Customize the available networks
+
+The list of networks available in the network selector (top navigation bar)
+can be configured in the file `/public/networks-config.json`.
+This JSON file contains an array of entries with the following syntax:
+
+```shell
+[
+  ...
+  {
+    "name": "mainnet",
+    "displayName": "MAINNET",
+    "url": "https://mainnet-public.mirrornode.hedera.com/",
+    "ledgerID": "00"
+  },
+  ...
+]
+```
+
+This file initially contains the configuration allowing to connect to the
+_mainnet/testnet/previewnet_ networks. This configuration may be augmented, altered or
+replaced as needed.
+Note:
+- When this file is missing, is empty, or does not have the expected syntax, 
+  the configuration falls back to _mainnet/testnet/previewnet_.
+- The `name` of the network has to be unique
+- The `displayName` is the string inserted in the network selector. 
+  It will default to the network `name` in uppercase. A `displayName`
+  exceeding 15 characters will be truncated.
+- The `ledgerID` is required to process the ID checksums shown in the UI.
+- The maximum number of networks taken into account is 15. The rest will be ignored.
+
+#### Customize the UI
+
+A few aspects of the Explorer UI, such as the product name displayed at the bottom of the pages,
+are controlled by environment variables, as follows:
 - Variables defined in the *.env* file (located at the root of the repository) will be taken
   into account at build time. 
 - Variables defined in the *.env.docker* file will be taken into account at start time of 
@@ -69,16 +105,6 @@ npm run docker
   the *.env.docker* file. The variables in *.env.docker* are passed to the container either:
   - via the *--env-file* option of the *docker run* command, or
   - via the *env_file:* clause of the *docker-compose.yml* file.
-
-#### Running the Explorer with a local mirror node
-
-Defining the following variables will add a custom menu item to the network selector of 
-the top navigation bar. For instance:
-
-```shell
-VUE_APP_LOCAL_MIRROR_NODE_URL=http://localhost:5551/
-VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME=LOCALNET
-```
 
 #### Enabling the Staking page
 
@@ -94,7 +120,7 @@ VUE_APP_ENABLE_STAKING=true
 
 #### Branding
 
-In addition to the configuration variables above,
+In addition to the configuration variables described above,
 the Hedera Mirror Node Explorer UI can be customized by adding a branding
 directory which path can be provided by the environment variable *$BRANDING_LOCATION*.
 If this variable is not defined a directory *./branding* will be looked for

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "test:e2e:headless": "vue-cli-service test:e2e --headless --browser chrome --url http://localhost:38920",
     "lint": "vue-cli-service lint",
     "install:branding": ". ./src/assets/branding/install-branding.sh",
-    "build:docker": "npm run build && docker build . --tag ${npm_package_name} --file ./CI.Dockerfile",
-    "docker": "docker run --env-file ./.env.docker -it --rm -p 8080:8080 --name hedera-explorer ${npm_package_name}:latest"
+    "docker:build": "npm run build && docker build . --tag gcr.io/hedera-registry/hedera-mirror-node-explorer --file ./CI.Dockerfile",
+    "docker:start": "docker-compose up -d",
+    "docker:stop": "docker-compose down"
   },
   "dependencies": {
     "@bladelabs/blade-web3.js": "^0.9.11",

--- a/public/networks-config.json
+++ b/public/networks-config.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "mainnet",
+    "displayName": "MAINNET",
+    "url": "https://mainnet-public.mirrornode.hedera.com/",
+    "ledgerID": "00"
+  },
+  {
+    "name": "testnet",
+    "displayName": "TESTNET",
+    "url": "https://testnet.mirrornode.hedera.com/",
+    "ledgerID": "01"
+  },
+  {
+    "name": "previewnet",
+    "displayName": "PREVIEWNET",
+    "url": "https://previewnet.mirrornode.hedera.com/",
+    "ledgerID": "02"
+  }
+]

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,7 @@ import TopNavBar from "@/components/TopNavBar.vue";
 import {errorKey, explanationKey, initialLoadingKey, loadingKey, suggestionKey} from "@/AppKeys"
 import {AxiosMonitor} from "@/utils/AxiosMonitor"
 import {useRoute} from "vue-router";
+import {networkRegistry} from "@/schemas/NetworkRegistry";
 
 export const XLARGE_BREAKPOINT = 1450
 export const LARGE_BREAKPOINT = 1280
@@ -91,6 +92,7 @@ export default defineComponent({
     onMounted(() => {
       windowWidth.value = window.innerWidth
       window.addEventListener('resize', onResizeHandler);
+      networkRegistry.readCustomConfig()
     })
 
     onBeforeUnmount(() => {

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -64,7 +64,7 @@
         <div id="drop-down-menu">
           <o-field>
             <o-select v-model="selectedNetwork" class="h-is-navbar-item">
-              <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">
+              <option v-for="network in networkEntries" :key="network.name" :value="network.name">
                 {{ network.displayName }}
               </option>
 
@@ -145,7 +145,7 @@ export default defineComponent({
       productName,
       isStakingEnabled,
       isMobileMenuOpen,
-      networkRegistry,
+      networkEntries: networkRegistry.entries,
       selectedNetwork: routeManager.selectedNetwork,
       name: routeManager.currentRoute,
       isDashboardRoute: routeManager.isDashboardRoute,

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -154,6 +154,9 @@ export default defineComponent({
       cryptoTableController.reset()
       messageTableController.reset()
       contractTableController.reset()
+      cryptoTableController.startAutoRefresh()
+      messageTableController.startAutoRefresh()
+      contractTableController.startAutoRefresh()
     })
 
     return {

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -32,7 +32,7 @@
         <div id="mobile-drop-down-menu" class="ml-1 mb-5 ">
           <o-field>
             <o-select v-model="selectedNetwork" class="h-is-navbar-item">
-              <option v-for="network in networkRegistry.getEntries()" :key="network.name" :value="network.name">
+              <option v-for="network in networkEntries" :key="network.name" :value="network.name">
                 {{ network.displayName }}
               </option>
             </o-select>
@@ -129,7 +129,7 @@ export default defineComponent({
       isNodeRoute: routeManager.testNodeRoute,
       isStakingRoute: routeManager.testStakingRoute,
       isBlocksRoute: routeManager.testBlocksRoute,
-      networkRegistry,
+      networkEntries: networkRegistry.entries,
       routeManager
     }
   }

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -115,6 +115,10 @@ export class NetworkRegistry {
                 const localNodeURL = getEnv('VUE_APP_LOCAL_MIRROR_NODE_URL')
                 const localNodeMenuName = getEnv('VUE_APP_LOCAL_MIRROR_NODE_MENU_NAME')
                 if (localNodeURL) {
+                    console.warn(
+                        "Use of VUE_APP_LOCAL_MIRROR_NODE_URL environment variable is deprecated.\n" +
+                        "Please use /public/networks-config.json configuration file instead")
+
                     this.entries.value.push(new NetworkEntry(
                         'devnet', localNodeMenuName ?? "DEVNET", localNodeURL, 'FF'
                     ))

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -40,7 +40,7 @@ export class NetworkEntry {
 
 export class NetworkRegistry {
 
-    public static readonly NETWORKS_CONFIG_PATH = '/networks-config.json'
+    public static readonly NETWORKS_CONFIG_URL = window.location.origin + '/networks-config.json'
     public static readonly MAX_NETWORK_NUMBER = 15
     public static readonly NETWORK_NAME_MAX_LENGTH = 15
 
@@ -74,8 +74,10 @@ export class NetworkRegistry {
 
     constructor() {
         this.defaultEntry = this.lookup(NetworkRegistry.DEFAULT_NETWORK) ?? this.entries.value[0]
+    }
 
-        axios.get<Array<NetworkEntry>>(NetworkRegistry.NETWORKS_CONFIG_PATH)
+    public readCustomConfig(): void {
+        axios.get<Array<NetworkEntry>>(NetworkRegistry.NETWORKS_CONFIG_URL)
             .then((response) => {
                 const jsonContent = JSON.parse(JSON.stringify(response.data))
 
@@ -86,10 +88,8 @@ export class NetworkRegistry {
                         if (customEntries.length < NetworkRegistry.MAX_NETWORK_NUMBER) {
                             if (!customEntries.find(element => element.name === n.name)) {
                                 let displayName = n.displayName ?? n.name.toUpperCase()
-                                console.log("displayName: " + displayName)
                                 if (displayName.length > NetworkRegistry.NETWORK_NAME_MAX_LENGTH) {
                                     displayName = displayName.slice(0,NetworkRegistry.NETWORK_NAME_MAX_LENGTH) + '…'
-                                    console.log("displayName: " + displayName)
                                 }
                                 customEntries.push(
                                     new NetworkEntry(
@@ -120,6 +120,7 @@ export class NetworkRegistry {
                     ))
                 }
             })
+            .catch((reason) => console.warn(`Failed to get ${NetworkRegistry.NETWORKS_CONFIG_URL}: ${reason}`))
     }
 
     public getDefaultEntry(): NetworkEntry {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -83,6 +83,13 @@ describe("App.vue", () => {
         const matcher4 = "/api/v1/network/exchangerate"
         mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
 
+        const matcher10 = window.location.origin + '/networks-config.json'
+        mock.onGet(matcher10).reply(200, [
+            {name: "customnet1", url: "/testurl1", ledgerID: "01"},
+            {name: "customnet2", url: "/testurl2", ledgerID: "02"},
+            {name: "customnet3", url: "/testurl3", ledgerID: "03"}
+        ]);
+
         const wrapper = mount(App, {
             global: {
                 plugins: [router, Oruga]
@@ -100,7 +107,7 @@ describe("App.vue", () => {
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
         expect(navBar.text()).toBe(
-            "MAINNETTESTNETPREVIEWNETDashboardTransactionsTokensTopicsContractsAccountsNodesBlocks")
+            "CUSTOMNET1CUSTOMNET2CUSTOMNET3DashboardTransactionsTokensTopicsContractsAccountsNodesBlocks")
 
         expect(wrapper.findComponent(HbarMarketDashboard).exists()).toBe(true)
 


### PR DESCRIPTION
**Description**:

With the following changes, the configuration of the available networks is now provided by the `networks-config.json` configuration file located at the root of the distribution (next to index.html). This file contains by default the configuration for using mainnet/testnet/previewnet, which can be completed/replaced as needed.

The `VUE_APP_LOCAL_MIRROR_NODE_URL/VUE_APP_LOCAL_MIRROR_NODE_NAME` environment variables are still supported but their use is deprecated.

**Related issue(s)**:

Fixes #439 

**Notes for reviewer**:

Details of the behaviour/limitations in the README.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
