### PR TITLE
00446 switching network when Dashboard tab is displayed does not update tables correctly 

### DIFF
--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -154,6 +154,9 @@ export default defineComponent({
       cryptoTableController.reset()
       messageTableController.reset()
       contractTableController.reset()
+      cryptoTableController.startAutoRefresh()
+      messageTableController.startAutoRefresh()
+      contractTableController.startAutoRefresh()
     })
 
     return {


### PR DESCRIPTION
**Description**:

Changes below make sure that Dashboard tab re-enables auto-refresh after network switch.

**Related issue(s)**:

Fixes #446

**Notes for reviewer**:

See instructions to reproduce issue in #446.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
