### PR TITLE
00451 change and Stop Staking actions should not invoke api/v1/transactions/{transactionHash}

### DIFF
--- a/src/components/staking/ProgressDialog.vue
+++ b/src/components/staking/ProgressDialog.vue
@@ -52,7 +52,7 @@
         <div class="is-flex is-align-items-baseline mt-4" style="line-height: 21px">
           <span v-if="extraMessage" class="h-is-property-text"> {{ extraMessage }} </span>
           <span v-else class="h-is-property-text" style="visibility: hidden">Filler</span>
-          <TransactionLink v-if="extraTransactionHash" :transaction-loc="extraTransactionHash" class="ml-2"/>
+          <div v-if="formattedTransactionId" class="ml-2">{{ formattedTransactionId }}</div>
         </div>
 
         <div class="is-flex is-justify-content-flex-end">
@@ -71,13 +71,12 @@
 <script lang="ts">
 
 import {computed, defineComponent, PropType} from "vue";
-import TransactionLink from "@/components/values/TransactionLink.vue";
+import {TransactionID} from "@/utils/TransactionID";
 
 export enum Mode { Busy = 1, Success = 2, Error = 3 }
 
 export default defineComponent({
   name: "ProgressDialog",
-  components: {TransactionLink},
   props: {
     showDialog: {
       type: Boolean,
@@ -89,7 +88,7 @@ export default defineComponent({
     },
     mainMessage: String,
     extraMessage: String,
-    extraTransactionHash: String,
+    extraTransactionId: String,
     showSpinner: Boolean
   },
 
@@ -101,9 +100,13 @@ export default defineComponent({
 
     const closeDisabled = computed(() => props.mode == Mode.Busy)
 
+    const formattedTransactionId = computed(
+        () => props.extraTransactionId ? TransactionID.normalize(props.extraTransactionId, true) : null)
+
     return {
       handleClose,
       closeDisabled,
+      formattedTransactionId,
       Mode,
     }
   }

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -42,7 +42,7 @@
                   :mode="progressDialogMode"
                   :main-message="progressMainMessage"
                   :extra-message="progressExtraMessage"
-                  :extra-transaction-hash="progressExtraTransactionHash"
+                  :extra-transaction-id="progressExtraTransactionId"
                   :show-spinner="showProgressSpinner"
   >
     <template v-slot:dialogTitle>
@@ -267,7 +267,7 @@ export default defineComponent({
     const progressDialogTitle = ref<string|null>(null)
     const progressMainMessage = ref<string|null>(null)
     const progressExtraMessage = ref<string|null>(null)
-    const progressExtraTransactionHash = ref<string|null>(null)
+    const progressExtraTransactionId = ref<string|null>(null)
     const showProgressSpinner = ref(false)
     const showDownloadDialog = ref(false)
 
@@ -291,7 +291,7 @@ export default defineComponent({
             progressDialogMode.value = Mode.Error
             progressDialogTitle.value = "Could not connect wallet"
             showProgressSpinner.value = false
-            progressExtraTransactionHash.value = null
+            progressExtraTransactionId.value = null
 
             if (reason instanceof WalletDriverError) {
               progressMainMessage.value = reason.message
@@ -385,19 +385,19 @@ export default defineComponent({
         progressDialogTitle.value = (nodeId == null && accountId == null && !declineReward) ? "Stopping staking" : "Updating staking"
         progressMainMessage.value = "Connecting to Hedera Network using your wallet…"
         progressExtraMessage.value = "Check your wallet for any approval request"
-        progressExtraTransactionHash.value = null
+        progressExtraTransactionId.value = null
         showProgressSpinner.value = false
-        const transactionHash = normalizeTransactionId(await walletManager.changeStaking(nodeId, accountId, declineReward))
+        const transactionId = normalizeTransactionId(await walletManager.changeStaking(nodeId, accountId, declineReward))
         progressMainMessage.value = "Completing operation…"
         progressExtraMessage.value = "This may take a few seconds"
         showProgressSpinner.value = true
-        await waitForTransactionRefresh(transactionHash, 10)
+        await waitForTransactionRefresh(transactionId, 10)
 
         progressDialogMode.value = Mode.Success
         progressMainMessage.value = "Operation completed"
         showProgressSpinner.value = false
         progressExtraMessage.value = "with transaction ID:"
-        progressExtraTransactionHash.value = transactionHash
+        progressExtraTransactionId.value = transactionId
 
       } catch(error) {
 
@@ -409,7 +409,7 @@ export default defineComponent({
           progressMainMessage.value = "Operation did not complete"
           progressExtraMessage.value = JSON.stringify(error.message)
         }
-        progressExtraTransactionHash.value = null
+        progressExtraTransactionId.value = null
         showProgressSpinner.value = false
 
       } finally {
@@ -419,20 +419,20 @@ export default defineComponent({
 
     }
 
-    const waitForTransactionRefresh = async (transactionHash: string, attemptIndex: number) => {
+    const waitForTransactionRefresh = async (transactionId: string, attemptIndex: number) => {
       let result: Promise<Transaction | string>
 
       if (attemptIndex >= 0) {
         await waitFor(props.polling)
         try {
-          const response = await axios.get<TransactionByIdResponse>("api/v1/transactions/" + transactionHash )
+          const response = await axios.get<TransactionByIdResponse>("api/v1/transactions/" + transactionId )
           const transactions = response.data.transactions ?? []
-          result = Promise.resolve(transactions.length >= 1 ? transactions[0] : transactionHash)
+          result = Promise.resolve(transactions.length >= 1 ? transactions[0] : transactionId)
         } catch {
-          result = waitForTransactionRefresh(transactionHash, attemptIndex - 1)
+          result = waitForTransactionRefresh(transactionId, attemptIndex - 1)
         }
       } else {
-        result = Promise.resolve(transactionHash)
+        result = Promise.resolve(transactionId)
       }
 
       return result
@@ -489,7 +489,7 @@ export default defineComponent({
       progressDialogTitle,
       progressMainMessage,
       progressExtraMessage,
-      progressExtraTransactionHash,
+      progressExtraTransactionId,
       showProgressSpinner,
       transactionTableController,
       downloader

--- a/src/utils/wallet/WalletDriver_Blade.ts
+++ b/src/utils/wallet/WalletDriver_Blade.ts
@@ -24,7 +24,7 @@ import {HederaNetwork} from "@bladelabs/blade-web3.js/lib/src/models/blade";
 import {WalletDriver} from "@/utils/wallet/WalletDriver";
 import {WalletDriverError} from "@/utils/wallet/WalletDriverError";
 import {AccountUpdateTransaction} from "@hashgraph/sdk";
-import {byteToHex} from "@/utils/B64Utils";
+import {TransactionID} from "@/utils/TransactionID";
 
 export class WalletDriver_Blade extends WalletDriver {
 
@@ -76,8 +76,8 @@ export class WalletDriver_Blade extends WalletDriver {
         if (this.signer !== null) {
             try {
                 const response = await this.signer.call(request)
-                const transactionHash = "0x" + byteToHex(response.transactionHash)
-                result = Promise.resolve(transactionHash)
+                const transactionId = TransactionID.normalize(response.transactionId.toString(), false);
+                result = Promise.resolve(transactionId)
             } catch(reason) {
                 throw this.callFailure(reason.message)
             }

--- a/src/utils/wallet/WalletDriver_Hashpack.ts
+++ b/src/utils/wallet/WalletDriver_Hashpack.ts
@@ -26,7 +26,7 @@ import {WalletDriverError} from "@/utils/wallet/WalletDriverError";
 import {HashConnectSigner} from "hashconnect/dist/provider/signer";
 import {AccountUpdateTransaction, Executable, Transaction} from "@hashgraph/sdk";
 import {timeGuard, TimeGuardError} from "@/utils/TimerUtils";
-import {byteToHex} from "@/utils/B64Utils";
+import {TransactionID} from "@/utils/TransactionID";
 
 export class WalletDriver_Hashpack extends WalletDriver {
 
@@ -63,7 +63,7 @@ export class WalletDriver_Hashpack extends WalletDriver {
     public async updateAccount(request: AccountUpdateTransaction): Promise<string> {
         try {
             const response = await this.performCall(request)
-            return "0x" + byteToHex(response.transactionHash)
+            return TransactionID.normalize(response.transactionId.toString(), false);
         } catch(error) {
             if (error instanceof WalletDriverError) {
                 throw error

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -40,7 +42,6 @@ import ProgressDialog from "@/components/staking/ProgressDialog.vue";
 import {waitFor} from "@/utils/TimerUtils";
 import StakingDialog from "@/components/staking/StakingDialog.vue";
 import {nextTick} from "vue";
-import {TransactionHash} from "@/utils/TransactionHash";
 import {NodeRegistry} from "@/components/node/NodeRegistry";
 
 /*
@@ -83,10 +84,10 @@ describe("Staking.vue", () => {
         // Transaction used to represent stake update operation
         const STAKE_UPDATE_TRANSACTION = SAMPLE_TRANSACTION
         const STAKE_UPDATE_TRANSACTIONS = SAMPLE_TRANSACTIONS
-        const STAKE_UPDATE_TRANSACTION_HASH = TransactionHash.parseBase64(STAKE_UPDATE_TRANSACTION.transaction_hash)!.toString()
+        const STAKE_UPDATE_TRANSACTION_ID = STAKE_UPDATE_TRANSACTION.transaction_id
 
         // Adds test driver to WalletManager
-        const testDriver = new WalletDriver_Mock(TARGET_ACCOUNT, STAKE_UPDATE_TRANSACTION_HASH)
+        const testDriver = new WalletDriver_Mock(TARGET_ACCOUNT, STAKE_UPDATE_TRANSACTION_ID)
         walletManager.getDrivers().push(testDriver)
 
         // Mocks axios
@@ -105,7 +106,7 @@ describe("Staking.vue", () => {
         NodeRegistry.instance.reload()
         const matcher3 = "/api/v1/network/exchangerate"
         mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
-        const matcher4 = "/api/v1/transactions/" + STAKE_UPDATE_TRANSACTION_HASH
+        const matcher4 = "/api/v1/transactions/" + STAKE_UPDATE_TRANSACTION_ID
         mock.onGet(matcher4).reply(200, STAKE_UPDATE_TRANSACTIONS)
         const matcher5 = "/api/v1/transactions"
         mock.onGet(matcher5).reply(200, SAMPLE_TRANSACTIONS)

--- a/tests/unit/staking/WalletDriver_Mock.ts
+++ b/tests/unit/staking/WalletDriver_Mock.ts
@@ -27,7 +27,7 @@ export class WalletDriver_Mock extends WalletDriver {
     private static WALLET_NAME = "WalletMock"
 
     public readonly account: AccountBalanceTransactions
-    public readonly transactionHash: string
+    public readonly transactionId: string
 
     private connected = false
     private network: string|null = null
@@ -38,10 +38,10 @@ export class WalletDriver_Mock extends WalletDriver {
     // Public
     //
 
-    public constructor(account: AccountBalanceTransactions, transactionHash: string) {
+    public constructor(account: AccountBalanceTransactions, transactionId: string) {
         super(WalletDriver_Mock.WALLET_NAME, null)
         this.account = account
-        this.transactionHash = transactionHash
+        this.transactionId = transactionId
     }
 
 
@@ -87,7 +87,7 @@ export class WalletDriver_Mock extends WalletDriver {
                 if (request.declineStakingRewards !== null) {
                     this.account.decline_reward = request.declineStakingRewards
                 }
-                result = this.transactionHash
+                result = this.transactionId
             } else {
                 throw this.callFailure("Unexpected account id: " + targetAccountID)
             }


### PR DESCRIPTION

**Description**:
With changes below, **Change/Stop Staking** actions now use `api/v1/transactions/{transactionId}` to poll mirror node.

**Related issue(s)**:

Fixes #451 

**Notes for reviewer**:

See #451

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
