### PR TITLE
00233 community nodes

### DIFF
--- a/src/components/node/NetworkDashboardItem.vue
+++ b/src/components/node/NetworkDashboardItem.vue
@@ -54,11 +54,10 @@
 <script lang="ts">
 
 import {defineComponent, inject} from 'vue';
-import DashboardItem from "@/components/dashboard/DashboardItem.vue";
 
 export default defineComponent({
   name: 'NetworkDashboardItem',
-  components: {DashboardItem},
+  components: {},
   props: {
     title: String,
     name: String,

--- a/src/components/node/NetworkDashboardItem.vue
+++ b/src/components/node/NetworkDashboardItem.vue
@@ -27,7 +27,22 @@
   <div class="is-flex is-flex-direction-column is-align-items-flex-start">
     <p v-if="isMediumScreen" class="h-is-property-text mb-1">{{ title }}</p>
     <p v-else class="h-is-text-size-3 mb-1">{{ title }}</p>
-    <DashboardItem :is-numeric="false" :name="name" :value="value" :variation="variation"/>
+
+    <div class="is-flex is-align-items-center">
+      <div class="is-flex has-text-white is-align-items-baseline">
+        <p class="dashboard-value has-text-white mr-2">
+          <span v-if="value !== null">{{ value }}</span>
+          <span v-else class="has-text-grey">None</span>
+          <slot name="value"></slot>
+        </p>
+        <div class="is-flex-is-vertical"
+             :class="{'h-is-text-size-3':isMediumScreen, 'h-is-text-size-1':!isMediumScreen, 'pt-1':isMediumScreen}"
+             style="line-height: 1">
+          <p class="h-is-text-size-1">{{ name }}</p>
+        </div>
+      </div>
+    </div>
+
   </div>
 
 </template>
@@ -65,4 +80,34 @@ export default defineComponent({
 <!--                                                       STYLE                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style/>
+<style scoped>
+
+.dashboard-value {
+  font-style: normal;
+  font-weight: 300;
+  font-size: 22px;
+  line-height: 28px;
+  letter-spacing: -0.05em;
+}
+
+@media (min-width: 1080px) {
+  .dashboard-value {
+    font-style: normal;
+    font-weight: 300;
+    font-size: 28px;
+    line-height: 34px;
+    letter-spacing: -0.05em;
+  }
+}
+
+@media (min-width: 1450px) {
+  .dashboard-value {
+    font-style: normal;
+    font-weight: 300;
+    font-size: 34px;
+    line-height: 41px;
+    letter-spacing: -0.05em;
+  }
+}
+
+</style>

--- a/src/components/node/NodeCursor.ts
+++ b/src/components/node/NodeCursor.ts
@@ -51,7 +51,7 @@ export class NodeCursor {
     })
 
     public readonly isCouncilNode:  ComputedRef<boolean> = computed(() => {
-        return this.nodeDescription.value?.includes("Hosted by") ?? false
+        return true
     })
 
     public readonly nodeDescription: ComputedRef<string|null> = computed(() => {

--- a/src/components/node/NodeCursor.ts
+++ b/src/components/node/NodeCursor.ts
@@ -50,6 +50,10 @@ export class NodeCursor {
         return result
     })
 
+    public readonly isCouncilNode:  ComputedRef<boolean> = computed(() => {
+        return this.nodeDescription.value?.includes("Hosted by") ?? false
+    })
+
     public readonly nodeDescription: ComputedRef<string|null> = computed(() => {
         let result: string|null
         if (this.node.value !== null) {

--- a/src/components/node/NodeCursor.ts
+++ b/src/components/node/NodeCursor.ts
@@ -22,6 +22,7 @@ import {makeShortNodeDescription, NetworkNode} from "@/schemas/HederaSchemas";
 import {computed, ComputedRef, ref, Ref} from "vue";
 import {NodeRegistry} from "@/components/node/NodeRegistry";
 import {makeDefaultNodeDescription} from "@/schemas/HederaUtils";
+import {EntityID} from "@/utils/EntityID";
 
 export class NodeCursor {
 
@@ -51,7 +52,10 @@ export class NodeCursor {
     })
 
     public readonly isCouncilNode:  ComputedRef<boolean> = computed(() => {
-        return true
+        // TEMPORARY IMPLEMENTATION
+        // This will need to rely on a new specific flag to be provided by REST API
+        const accountNum = EntityID.parse(this.node.value?.node_account_id ?? "")?.num
+        return accountNum ? accountNum < 1000 : true
     })
 
     public readonly nodeDescription: ComputedRef<string|null> = computed(() => {

--- a/src/components/node/NodeCursor.ts
+++ b/src/components/node/NodeCursor.ts
@@ -92,6 +92,7 @@ export class NodeCursor {
     public readonly stake = computed(() => this.node.value?.stake ?? 0)
     public readonly minStake = computed(() => this.node.value?.min_stake ?? 0)
     public readonly maxStake = computed(() => this.node.value?.max_stake ?? 0)
+    public readonly unclampedStake = computed(() => this.stakeRewarded.value + this.stakeUnrewarded.value)
     public readonly stakeRewarded = computed(() => this.node.value?.stake_rewarded ?? 0)
     public readonly stakeUnrewarded = computed(() => this.node.value?.stake_not_rewarded ?? 0)
 }

--- a/src/components/node/NodeRegistry.ts
+++ b/src/components/node/NodeRegistry.ts
@@ -77,6 +77,15 @@ export class NodeRegistry {
         return result
     })
 
+    public readonly stakeScaleEnd: ComputedRef<number> = computed(() => {
+        let result = 0
+        for (const n of this.nodes.value) {
+            const thisMax = Math.max(n.max_stake ?? 0, n.stake ?? 0)
+            result = Math.max(result, thisMax)
+        }
+        return result
+    })
+
     public reload(): void {
         this.loader.clear()
         this.loader.requestLoad()

--- a/src/components/node/NodeRegistry.ts
+++ b/src/components/node/NodeRegistry.ts
@@ -87,6 +87,11 @@ export class NodeRegistry {
         return new NodeCursor(nodeId, nodeAccountId)
     }
 
+    public static isCouncilNode(nodeId: Ref<number|null> = ref(null),
+                                nodeAccountId: Ref<string|null> = ref(null)): boolean {
+        return NodeRegistry.getCursor(nodeId, nodeAccountId).isCouncilNode.value
+    }
+
     public static getDescription(nodeId: Ref<number|null> = ref(null),
                           nodeAccountId: Ref<string|null> = ref(null)): string|null {
         return NodeRegistry.getCursor(nodeId, nodeAccountId).nodeDescription.value

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -34,6 +34,14 @@
         default-sort="node_id"
         @click="handleClick"
     >
+
+      <o-table-column v-slot="props" field="nature" label="">
+        <span class="icon has-text-info" style="font-size: 16px">
+          <i v-if="isCouncilNode(props.row)" class="fas fa-building"></i>
+          <i v-else class="fas fa-users"></i>
+        </span>
+      </o-table-column>
+
       <o-table-column v-slot="props" field="node_id" label="Node">
         <div class="is-numeric regular-node-column">
           {{ props.row.node_id }}
@@ -46,9 +54,9 @@
         </div>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="description" label="Description">
-        <div class="should-wrap regular-node-column">
-          <BlobValue v-bind:blob-value="makeDescription(props.row)" v-bind:show-none="true"/>
+      <o-table-column v-slot="props" field="description" label="     Description">
+        <div class="should-wrap regular-node-column is-inline-block">
+          <StringValue :string-value="makeDescription(props.row)"/>
         </div>
       </o-table-column>
 
@@ -106,13 +114,13 @@
 
 import {defineComponent, inject, PropType, ref} from 'vue';
 import {NetworkNode} from "@/schemas/HederaSchemas";
-import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import StakeRange from "@/components/node/StakeRange.vue";
 import {routeManager} from "@/router";
 import {NodeRegistry} from "@/components/node/NodeRegistry";
+import StringValue from "@/components/values/StringValue.vue";
 
 
 //
@@ -122,7 +130,7 @@ import {NodeRegistry} from "@/components/node/NodeRegistry";
 export default defineComponent({
   name: 'NodeTable',
 
-  components: {StakeRange, HbarAmount, EmptyTable, BlobValue},
+  components: {StringValue, StakeRange, HbarAmount, EmptyTable},
 
   props: {
     nodes: Object as PropType<Array<NetworkNode> | undefined>,
@@ -142,6 +150,7 @@ export default defineComponent({
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
 
+    const isCouncilNode = (node: NetworkNode) => NodeRegistry.isCouncilNode(ref(node.node_id ?? null), ref(null))
     const makeDescription = (node: NetworkNode) => NodeRegistry.getDescription(ref(node.node_id ?? null), ref(null))
     const makeUnclampedStake = (node: NetworkNode) => (node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0)
     const makeWeightPercentage = (node: NetworkNode) => {
@@ -174,6 +183,7 @@ export default defineComponent({
       tooltipRewardRate,
       isTouchDevice,
       isMediumScreen,
+      isCouncilNode,
       makeDescription,
       makeUnclampedStake,
       makeWeightPercentage,

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -48,13 +48,13 @@
         </div>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="node_account_id" label="Account">
+      <o-table-column v-if="false" v-slot="props" field="node_account_id" label="Account">
         <div class="is-numeric regular-node-column">
           {{ props.row.node_account_id }}
         </div>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="description" label="     Description">
+      <o-table-column v-slot="props" field="description" label="Description">
         <div class="should-wrap regular-node-column is-inline-block">
           <StringValue :string-value="makeDescription(props.row)"/>
         </div>
@@ -73,16 +73,28 @@
         </o-tooltip>
       </o-table-column>
 
-       <o-table-column v-slot="props" field="stake_not_rewarded" label="Stake Not Rewarded" position="right">
-         <o-tooltip :label="tooltipNotRewarded"
-                    multiline
-                    :delay="tooltipDelay"
-                    class="h-tooltip">
+      <o-table-column v-slot="props" field="stake_not_rewarded" label="Stake Not Rewarded" position="right">
+        <o-tooltip :delay="tooltipDelay"
+                   :label="tooltipNotRewarded"
+                   class="h-tooltip"
+                   multiline>
            <span class="regular-node-column">
              <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
           </span>
-         </o-tooltip>
-       </o-table-column>
+        </o-tooltip>
+      </o-table-column>
+
+      <o-table-column v-slot="props" field="min_stake" label="Min Stake" position="right">
+           <span class="regular-node-column">
+             <HbarAmount :amount="props.row.min_stake ?? 0" :decimals="0"/>
+          </span>
+      </o-table-column>
+
+      <o-table-column v-slot="props" field="max_stake" label="Max Stake" position="right">
+           <span class="regular-node-column">
+             <HbarAmount :amount="props.row.max_stake ?? 0" :decimals="0"/>
+          </span>
+      </o-table-column>
 
       <o-table-column v-slot="props" field="last_reward_rate" label="Last Reward Rate" position="right">
         <o-tooltip :label="tooltipRewardRate"

--- a/src/components/node/StakeRange.vue
+++ b/src/components/node/StakeRange.vue
@@ -51,6 +51,7 @@
 
 import {computed, defineComponent, PropType} from "vue";
 import {NetworkNode} from "@/schemas/HederaSchemas";
+import {NodeRegistry} from "@/components/node/NodeRegistry";
 
 export default defineComponent({
   name: 'StakeRange',
@@ -74,7 +75,7 @@ export default defineComponent({
         () => (props.node?.stake_rewarded ?? 0) + (props.node?.stake_not_rewarded ?? 0))
 
     const progressScale = computed(
-        () => maxStake.value ? maxStake.value * 1.2 : 0)
+        () => NodeRegistry.instance.stakeScaleEnd.value)
 
     const stakeProgress = computed(
         () => progressScale.value ? unclampedStake.value  / progressScale.value * 100 : 0)

--- a/src/components/node/StakeRange.vue
+++ b/src/components/node/StakeRange.vue
@@ -51,7 +51,6 @@
 
 import {computed, defineComponent, PropType} from "vue";
 import {NetworkNode} from "@/schemas/HederaSchemas";
-import {NodeRegistry} from "@/components/node/NodeRegistry";
 
 export default defineComponent({
   name: 'StakeRange',
@@ -64,8 +63,6 @@ export default defineComponent({
 
   setup(props) {
 
-    const stake = computed(
-        () => props.node?.stake ?? null)
     const minStake = computed(
         () => props.node?.min_stake ?? null)
     const maxStake = computed(
@@ -74,16 +71,20 @@ export default defineComponent({
     const unclampedStake = computed(
         () => (props.node?.stake_rewarded ?? 0) + (props.node?.stake_not_rewarded ?? 0))
 
+    // Alternative implementation for absolute stake range
+    // const progressScale = computed(
+    //     () => NodeRegistry.instance.stakeScaleEnd.value)
+
     const progressScale = computed(
-        () => NodeRegistry.instance.stakeScaleEnd.value)
+        () => maxStake.value ? maxStake.value * 1.2 : 0)
 
     const stakeProgress = computed(
         () => progressScale.value ? unclampedStake.value  / progressScale.value * 100 : 0)
 
     const isStakeInRange = computed(() => {
       let result: boolean
-      if (stake.value && minStake.value && maxStake.value) {
-        result = stake.value >= minStake.value && stake.value < maxStake.value
+      if (unclampedStake.value && minStake.value && maxStake.value) {
+        result = unclampedStake.value >= minStake.value && unclampedStake.value < maxStake.value
       }
       else {
         result = false

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -128,7 +128,8 @@ export default defineComponent({
 
     const makeNodeDescription = (node: NetworkNode) => {
       let description = node.description ?? NodeRegistry.getDescription(ref(node.node_id??null))
-      return description ? makeShortNodeDescription(description) : null
+      let councilNode = NodeRegistry.isCouncilNode(ref(node.node_id ?? null)) ? " (Council node)" : ""
+      return description ? makeShortNodeDescription(description) + councilNode : null
     }
 
     const handleInput = (value: string) => {

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -36,11 +36,21 @@
             <p v-if="isMediumScreen" class="h-is-property-text mb-3">Choose a node to stake to</p>
             <p v-else class="h-is-text-size-3 mb-1">Choose a node to stake to</p>
             <o-field style="width: 100%">
-              <o-select v-model="selectedNodeId" class="h-is-text-size-1" style="border-radius: 4px">
-                <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
-                        style="background-color: var(--h-theme-box-background-color)">
+              <o-select v-model="selectedNodeId" class="h-is-text-size-1" style="border-radius: 4px" :icon="nodeIcon">
+                <optgroup label="Hedera council nodes">
+                  <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
+                          style="background-color: var(--h-theme-box-background-color)"
+                          v-show="isCouncilNode(n)">
                   {{ n.node_id }} - {{ makeNodeDescription(n) }} - {{ makeNodeStakeDescription(n) }}
-                </option>
+                  </option>
+                </optgroup>
+                <optgroup label="Community nodes">
+                    <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
+                            style="background-color: var(--h-theme-box-background-color)"
+                            v-show="!isCouncilNode(n)">
+                        {{ n.node_id }} - {{ makeNodeDescription(n) }} - {{ makeNodeStakeDescription(n) }}
+                    </option>
+                </optgroup>
               </o-select>
             </o-field>
           </div>
@@ -113,6 +123,9 @@ export default defineComponent({
     // Node
     //
     const nodeCursor = computed(() => NodeRegistry.getCursor(selectedNodeId))
+    const nodeIcon = computed(() => {
+      return NodeRegistry.isCouncilNode(selectedNodeId) ? "building" : "users"
+    })
 
     const amountStaked = ref<number>( 100)
     const updateAmountStaked = () => {
@@ -128,9 +141,10 @@ export default defineComponent({
 
     const makeNodeDescription = (node: NetworkNode) => {
       let description = node.description ?? NodeRegistry.getDescription(ref(node.node_id??null))
-      let councilNode = NodeRegistry.isCouncilNode(ref(node.node_id ?? null)) ? " (Council node)" : ""
-      return description ? makeShortNodeDescription(description) + councilNode : null
+      return description ? makeShortNodeDescription(description) : null
     }
+
+    const isCouncilNode = (node: NetworkNode) => NodeRegistry.isCouncilNode(ref(node.node_id ?? 0))
 
     const handleInput = (value: string) => {
       const previousAmount = amountStaked.value
@@ -149,6 +163,7 @@ export default defineComponent({
       isMediumScreen,
       isTouchDevice,
       selectedNodeId,
+      nodeIcon,
       amountStaked,
       rewardRate,
       currentReward,
@@ -158,6 +173,7 @@ export default defineComponent({
       nodes: NodeRegistry.instance.nodes,
       makeNodeDescription,
       makeNodeStakeDescription,
+      isCouncilNode,
       handleInput
     }
   }

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -80,14 +80,14 @@
               </div>
               <div class="column">
                 <o-field>
-                <o-select v-model="selectedNode" :class="{'has-text-grey': !isNodeSelected}"
-                          class="h-is-text-size-1" style="border-radius: 4px"  @focus="stakeChoice='node'">
-                  <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
-                          style="background-color: var(--h-theme-box-background-color)">
-                    {{ makeNodeDescription(n) }} - {{ makeNodeStakeDescription(n) }}
-                  </option>
-                </o-select>
-              </o-field>
+                  <o-select v-model="selectedNode" :class="{'has-text-grey': !isNodeSelected}"
+                            class="h-is-text-size-1" style="border-radius: 4px" @focus="stakeChoice='node'">
+                    <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
+                            style="background-color: var(--h-theme-box-background-color)">
+                       {{ makeNodeDescription(n) }} - {{ makeNodeStakeDescription(n) }}
+                    </option>
+                  </o-select>
+                </o-field>
               </div>
             </div>
             <div class="columns">
@@ -290,7 +290,8 @@ export default defineComponent({
 
     const makeNodeDescription = (node: NetworkNode) => {
       let description = node.description ?? makeDefaultNodeDescription(node.node_id ?? null)
-      return description ? (node.node_id + " - " + makeShortNodeDescription(description)) : null
+      let councilNode = NodeRegistry.isCouncilNode(ref(node.node_id ?? null)) ? " (Council node)" : ""
+      return description ? (node.node_id + " - " + makeShortNodeDescription(description)) + councilNode : null
     }
 
     const handleInput = (value: string) => {

--- a/src/components/values/HbarAmount.vue
+++ b/src/components/values/HbarAmount.vue
@@ -94,8 +94,8 @@ export default defineComponent({
 
     const formattedAmount = computed(() => {
       const amountFormatter = new Intl.NumberFormat('en-US', {
-        minimumFractionDigits: props.decimals,
-        maximumFractionDigits: 8
+        minimumFractionDigits: props.decimals ?? 0,
+        maximumFractionDigits: props.decimals ?? 8
       })
       return amountFormatter.format(hbarAmount.value)
     })

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -109,6 +109,11 @@
           }}% of total</p>
         <p v-else class="h-is-property-text h-is-extra-text mt-1">(&lt;Min)</p>
         <br/><br/>
+        <div v-if="stake === 0">
+          <NetworkDashboardItem id="currentStake" :value="makeFloorHbarAmount(unclampedStake)"
+                                name="HBAR" title="Current Stake"/>
+          <br/><br/>
+        </div>
         <NetworkDashboardItem id="minStake" :value="makeFloorHbarAmount(minStake)" name="HBAR" title="Min Stake"/>
         <br/><br/>
         <NetworkDashboardItem id="maxStake" :value="makeFloorHbarAmount(maxStake)" name="HBAR" title="Max Stake"/>
@@ -233,6 +238,7 @@ export default defineComponent({
       minStake: nodeCursor.minStake,
       maxStake: nodeCursor.maxStake,
       stakePercentage,
+      unclampedStake: nodeCursor.unclampedStake,
       stakeRewarded: nodeCursor.stakeRewarded,
       stakeRewardedPercentage,
       stakeUnrewarded: nodeCursor.stakeUnrewarded,

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -28,8 +28,18 @@
 
     <DashboardCard>
       <template v-slot:title>
-        <span class="h-is-primary-title">Node </span>
-        <span class="h-is-secondary-text is-numeric mr-3">{{ nodeIdNb }}</span>
+        <div class="is-flex is-align-items-center">
+          <span class="h-is-primary-title mr-2">Node </span>
+          <span class="h-is-secondary-text is-numeric mr-3">{{ nodeIdNb }}</span>
+        </div>
+        <div v-if="isCouncilNode">
+          <span class="icon has-text-info mr-2"><i class="fas fa-building"></i></span>
+          <span class="h-is-tertiary-text has-text-grey">Hedera Council Node</span>
+        </div>
+        <div v-else>
+          <span class="icon has-text-info mr-2"><i class="fas fa-users"></i></span>
+          <span class="h-is-tertiary-text has-text-grey">Community Node</span>
+        </div>
       </template>
 
       <template v-slot:content>
@@ -228,6 +238,7 @@ export default defineComponent({
       stakeUnrewarded: nodeCursor.stakeUnrewarded,
       stakeUnrewardedPercentage,
       notification,
+      isCouncilNode: nodeCursor.isCouncilNode,
       nodeDescription: nodeCursor.nodeDescription,
       formatHash,
       makeFloorHbarAmount

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -75,9 +75,17 @@
         <template v-if="accountId">
           <div v-if="isSmallScreen">
             <div class="is-flex is-justify-content-space-between">
-              <NetworkDashboardItem :name="stakePeriodStart ? ('since ' + stakePeriodStart) : null"
-                                    title="Staked to"
-                                    :value="stakedTo"/>
+              <NetworkDashboardItem :name="stakePeriodStart ? ('since ' + stakePeriodStart) : null" title="Staked to">
+                <template v-slot:value>
+                  <div class="is-inline-block">
+                    <span v-if="isStakedToNode"  class="icon has-text-info mr-2" style="font-size: 20px">
+                      <i v-if="isCouncilNode" class="fas fa-building"></i>
+                      <i v-else class="fas fa-users"></i>
+                    </span>
+                    <span>{{ stakedTo }}</span>
+                  </div>
+                </template>
+              </NetworkDashboardItem>
 
               <NetworkDashboardItem class="ml-4"
                                     :name="stakedAmount ? 'HBAR' : ''"
@@ -169,7 +177,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard v-if="accountId" :class="{'h-has-opacity-40': isIndirectStaking}">
+    <DashboardCard v-if="accountId" :class="{'h-has-opacity-40': !isStakedToNode}">
       <template v-slot:title>
         <span class="h-is-secondary-title">Recent Staking Rewards</span>
       </template>
@@ -320,14 +328,15 @@ export default defineComponent({
     const accountLoader = new AccountLoader(walletManager.accountId)
     onMounted(() => accountLoader.requestLoad())
 
-    const isStaked = computed(() => accountLoader.stakedNodeId.value !== null || accountLoader.stakedAccountId.value)
-    const isIndirectStaking = computed(() => accountLoader.stakedAccountId.value)
+    const isStakedToNode = computed(() => accountLoader.stakedNodeId.value !== null)
+    const isStakedToAccount = computed(() => accountLoader.stakedAccountId.value)
+    const isStaked = computed(() => isStakedToNode.value || isStakedToAccount.value)
 
     const stakedTo = computed(() => {
       let result: string|null
-      if (accountLoader.stakedAccountId.value) {
+      if (isStakedToAccount.value) {
         result = "Account " + accountLoader.stakedAccountId.value
-      } else if (accountLoader.stakedNodeId.value !== null) {
+      } else if (isStakedToNode.value) {
         result = "Node " + accountLoader.stakedNodeId.value + " - " + stakedNodeLoader.shortNodeDescription.value
       } else {
         result = null
@@ -471,9 +480,11 @@ export default defineComponent({
       showWalletChooser,
       showErrorDialog,
       showDownloadDialog,
-      isIndirectStaking,
+      isStakedToNode,
+      isStakedToAccount,
       stakedTo,
       stakedNode: stakedNodeLoader.node,
+      isCouncilNode: stakedNodeLoader.isCouncilNode,
       balanceInHbar,
       stakedAmount,
       pendingReward,

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -82,7 +82,8 @@
                       <i v-if="isCouncilNode" class="fas fa-building"></i>
                       <i v-else class="fas fa-users"></i>
                     </span>
-                    <span>{{ stakedTo }}</span>
+                    <span v-if="stakedTo">{{ stakedTo }}</span>
+                    <span v-else class="has-text-grey">None</span>
                   </div>
                 </template>
               </NetworkDashboardItem>

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -91,12 +91,12 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Account Description Stake Stake Not Rewarded Last Reward Rate Stake Range")
+        expect(wrapper.get('thead').text()).toBe("Node Description Stake Stake Not Rewarded Min Stake Max Stake Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
-            "1" + "0.0.4" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
-            "2" + "0.0.5" + "Hosted by Hedera | Central, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
+            "0" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + "1,000,000" + "30,000,000" + tooltipRewardRate + "1%" +
+            "1" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "1,000,000" + "30,000,000" + tooltipRewardRate + "2%" +
+            "2" + "Hosted by Hedera | Central, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "1,000,000" + "30,000,000" + tooltipRewardRate + "3%"
         )
 
         wrapper.unmount()

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -103,11 +103,11 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Account Description Stake Stake Not Rewarded Last Reward Rate Stake Range")
+        expect(table.get('thead').text()).toBe("Node Description Stake Stake Not Rewarded Min Stake Max Stake Last Reward Rate Stake Range")
         expect(wrapper.get('tbody').text()).toBe(
-            "0" + "0.0.3" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + tooltipRewardRate + "1%" +
-            "1" + "0.0.4" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "2%" +
-            "2" + "0.0.5" + "Hosted by Hedera | Central, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + tooltipRewardRate + "3%"
+            "0" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "6,000,000(25%)" + tooltipNotRewarded + "1,000,000" + "1,000,000" + "30,000,000" + tooltipRewardRate + "1%" +
+            "1" + "Hosted by Hedera | East Coast, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "1,000,000" + "30,000,000" + tooltipRewardRate + "2%" +
+            "2" + "Hosted by Hedera | Central, USA" + tooltipStake + "9,000,000(37.5%)" + tooltipNotRewarded + "2,000,000" + "1,000,000" + "30,000,000" + tooltipRewardRate + "3%"
         )
     });
 

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -86,7 +86,7 @@ describe("Staking.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Rewards Estimator"))
 
         const options = wrapper.find('select').findAll('option')
-        expect(options.length).toBe(3)
+        expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length * 2)
         expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max), of which 1,000,000ℏ declined reward')
         expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
         expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
@@ -136,7 +136,7 @@ describe("Staking.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Rewards Estimator"))
 
         const options = wrapper.find('select').findAll('option')
-        expect(options.length).toBe(3)
+        expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length * 2)
         expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max), of which 1,000,000ℏ declined reward')
         expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
         expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
@@ -184,7 +184,7 @@ describe("Staking.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Rewards Estimator"))
 
         const options = wrapper.find('select').findAll('option')
-        expect(options.length).toBe(3)
+        expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length * 2)
         expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera - 6,000,000ℏ staked (20% of Max), of which 1,000,000ℏ declined reward')
         expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')
         expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera - 9,000,000ℏ staked (30% of Max), of which 2,000,000ℏ declined reward')

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -253,7 +253,7 @@ describe("Staking.vue", () => {
         // 3.4) Choose node #2
         const stakeToNodeSelect = stakingModal.get<HTMLSelectElement>("select")
         const stakeToNodeOptions = stakeToNodeSelect.findAll("option")
-        expect(stakeToNodeOptions.length).toBe(3)
+        expect(stakeToNodeOptions.length).toBe(SAMPLE_NETWORK_NODES.nodes.length * 2)
         for (let i = 0; i < 3; i += 1) {
             expect(stakeToNodeOptions[i].element.value).toBe(i.toString())
         }


### PR DESCRIPTION
**Description**:

This PR adds support for upcoming community nodes. Essentially, these changes:
- make sure we are ready to deal with different values for min-stake and max-stake per node
- differentiate visually between council nodes and community nodes in various parts of the UI where nodes are involved. See issue #233 for details of the UI changes.

**Related issue(s)**:

Fixes #233

**Notes for reviewer**:

This is just a draft PR, waiting for initial feedback on the visuals.
Implementation currently relies on node account number (< 1000) to recognize Hedera council nodes.
It will have to evolve once the `/api/v1/network/nodes` API is enhanced with a specific flag indicating the type of operator.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
