### PR TITLE
Fix for #454 (compatibility with MetaMask).

### DIFF
--- a/src/pages/AddressDetails.vue
+++ b/src/pages/AddressDetails.vue
@@ -1,0 +1,76 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <div/>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, onMounted} from 'vue';
+import axios, {AxiosResponse} from "axios";
+import router, {routeManager} from "@/router";
+import {PathParam} from "@/utils/PathParam";
+import {ContractResponse} from "@/schemas/HederaSchemas";
+
+export default defineComponent({
+
+  name: 'AccountDetails',
+
+  components: {},
+
+  props: {
+    accountAddress: String,
+    network: String
+  },
+
+  setup(props) {
+
+    const dispatch = () => {
+      const evmAddress = PathParam.parseEvmAddress(props.accountAddress)
+      if (evmAddress !== null) {
+        axios.get<ContractResponse>("api/v1/contracts/" + evmAddress)
+            .then((r: AxiosResponse<ContractResponse>) => {
+              const contractId = r.data.contract_id ?? "0.0.0"
+              router.replace(routeManager.makeRouteToContract(contractId))
+            })
+            .catch(() => {
+              router.replace(routeManager.makeRouteToAccount(evmAddress))
+            })
+      } else {
+        router.replace(routeManager.pageNotFoundRoute)
+      }
+    }
+
+    onMounted(dispatch)
+  }
+})
+
+</script>
+
+<style/>

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -276,7 +276,7 @@ export default defineComponent({
     const notification = computed(() => {
       let result: string|null
 
-      const expiration = contractLoader.entity.value?.expiration_timestamp
+      // const expiration = contractLoader.entity.value?.expiration_timestamp
       if (!validEntityId.value) {
         result = "Invalid contract ID: " + props.contractId
       } else if (contractLoader.got404.value) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,6 +49,7 @@ import Blocks from "@/pages/Blocks.vue";
 import {getEnv} from "@/utils/getEnv";
 import AccountsWithKey from "@/pages/AccountsWithKey.vue";
 import AdminKeyDetails from "@/pages/AdminKeyDetails.vue";
+import AddressDetails from "@/pages/AddressDetails.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -119,7 +120,9 @@ const routes: Array<RouteRecordRaw> = [
   {
     // EIP 3091 Support
     path: '/:network/address/:accountAddress',
-    redirect: to => '/' + to.params.network + '/account/' + to.params.accountAddress
+    name: 'AddressDetails',
+    component: AddressDetails,
+    props: true
   },
   {
     path: '/:network/accountbalances/:accountId',

--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -115,4 +115,19 @@ export class PathParam { // Block Hash or Number
     public static parseTransactionLoc(s: string): Timestamp | TransactionHash | EthereumHash | null {
         return Timestamp.parse(s) ?? TransactionHash.parse(s) ?? EthereumHash.parse(s)
     }
+
+    public static parseEvmAddress(s: string|undefined): string|null {
+        let result: string|null
+        if (s) {
+            const hex = hexToByte(s)
+            if (hex !== null && hex.length == 20) {
+                result = "0x" + byteToHex(hex)
+            } else {
+                result = null
+            }
+        } else {
+            result = null
+        }
+        return result
+    }
 }

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -311,6 +311,7 @@ export class RouteManager {
     public readonly stakingRoute:       RouteLocationRaw = {name: 'Staking'}
     public readonly blocksRoute:        RouteLocationRaw = {name: 'Blocks'}
     public readonly mobileSearchRoute:  RouteLocationRaw = {name: 'MobileSearch'}
+    public readonly pageNotFoundRoute:  RouteLocationRaw = {name: 'PageNotFound'}
 
     public makeRouteToMobileMenu(name: unknown): RouteLocationRaw {
         return {name: 'MobileMenu', query: {from: name as string}}

--- a/tests/e2e/specs/AccountNavigation.spec.ts
+++ b/tests/e2e/specs/AccountNavigation.spec.ts
@@ -163,7 +163,7 @@ describe('Account Navigation', () => {
 
         // EIP 3091
         cy.visit('mainnet/address/' + evmAddress)
-        cy.url().should('include', '/mainnet/account/' + evmAddress)
+        cy.url().should('include', '/mainnet/account/' + accountID)
         cy.contains('Account ' + accountID)
     })
 


### PR DESCRIPTION
**Description**:

Changes below modify Explorer behavior when interpreting `{network}/address/{evmAddress}` URL (see [EIP 3091](https://eips.ethereum.org/EIPS/eip-3091)).
Explorer now first checks if `evmAddress` matches a contract and routes to `Contract Details` page in priority.

**Related issue(s)**:

Fixes #454

**Notes for reviewer**:

Uses the following URL:
https://localhost:8080/mainnet/address/0x00000000000000000000000000000000001e1b47

Without changes below, it displays `Account Details` for 0.0.1973063.
With the changes, it shows `Contract Details` for 0.0.1973063.

