### PR TITLE
426 search blocks by hash

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -150,6 +150,11 @@ export default defineComponent({
                 routeManager.routeToToken(r.tokenInfo.token_id)
               }
               searchDidEnd(true)
+            } else if (r.block != null) {
+              if (r.block.number) {
+                routeManager.routeToBlock(r.block.number)
+              }
+              searchDidEnd(true)
             } else if (r.topicMessages.length >= 1) {
               const topicId = r.topicMessages[0].topic_id
               if (topicId) {

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -83,7 +83,7 @@
                 </div>
               </div>
               <div>
-                &bull; a public-key-format alias (string in base 32 or hexadecimal notation)<br/>
+                &bull; a key alias (string in base 32 or hexadecimal notation)<br/>
                 <div class="should-wrap h-help-item">
                   Example:&nbsp;CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ
                 </div>
@@ -92,9 +92,18 @@
                 </div>
               </div>
               <div>
-                &bull; an Ethereum-format alias (40 characters in hexadecimal notation)<br/>
+                &bull; an evm address alias or account num alias (40 characters in hexadecimal notation)<br/>
                 <div class="should-wrap h-help-item">
                   Example:&nbsp;0x00000000000000000000000000000000000b03ae
+                </div>
+              </div>
+              <div>
+                &bull; a block hash or hash prefix (resp. 96 or 64 characters in hexadecimal notation)<br/>
+                <div class="should-wrap h-help-item">
+                  Example:&nbsp;0xd84193b8a421cee8035fccbce280c89f79509aa86969c1a425337b7218e9474121254ce71aa3952fc909ac240bec2e5f
+                </div>
+                <div class="should-wrap h-help-item">
+                  or: 0xd84193b8a421cee8035fccbce280c89f79509aa86969c1a425337b7218e94741
                 </div>
               </div>
             </div>

--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -32,7 +32,7 @@ export class PathParam { // Block Hash or Number
 
         if (s) {
             const bytes = hexToByte(s)
-            if (bytes != null && bytes.length == 48 ) { // SHA384 byte count
+            if (bytes != null && (bytes.length == 48 || bytes.length == 32) ) { // SHA384 byte count
                 result = byteToHex(bytes)
             } else {
                 const n = parseInt(s)

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -25,6 +25,7 @@ import axios from "axios";
 import {
     SAMPLE_ACCOUNT,
     SAMPLE_ACCOUNTS,
+    SAMPLE_BLOCKSRESPONSE,
     SAMPLE_CONTRACT,
     SAMPLE_TOKEN,
     SAMPLE_TOPIC_MESSAGES,
@@ -32,7 +33,7 @@ import {
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import {SearchRequest} from "@/utils/SearchRequest";
-import {base32ToAlias, base64DecToArr, byteToHex} from "@/utils/B64Utils";
+import {base32ToAlias, base64DecToArr, byteToHex, hexToByte} from "@/utils/B64Utils";
 import {EntityID} from "@/utils/EntityID";
 
 const mock = new MockAdapter(axios)
@@ -62,6 +63,15 @@ mock.onGet(matcher_transaction).reply(200, SAMPLE_TRANSACTIONS)
 const TRANSACTION_HASH = byteToHex(base64DecToArr(SAMPLE_TRANSACTION.transaction_hash))
 const matcher_transaction_with_hash = "/api/v1/transactions/" + TRANSACTION_HASH
 mock.onGet(matcher_transaction_with_hash).reply(200, SAMPLE_TRANSACTIONS)
+
+// Block
+
+const BLOCK_HASH = byteToHex(hexToByte(SAMPLE_BLOCKSRESPONSE.blocks[0].hash) ?? new Uint8Array(0))
+const matcher_block_with_hash = "/api/v1/blocks/" + BLOCK_HASH
+mock.onGet(matcher_block_with_hash).reply(200, SAMPLE_BLOCKSRESPONSE.blocks[0])
+const BLOCK_HASH_PREFIX = byteToHex(hexToByte(SAMPLE_BLOCKSRESPONSE.blocks[0].hash)?.slice(0, 32) ?? new Uint8Array(0))
+const matcher_block_with_hash_prefix = "/api/v1/blocks/" + BLOCK_HASH_PREFIX
+mock.onGet(matcher_block_with_hash_prefix).reply(200, SAMPLE_BLOCKSRESPONSE.blocks[0])
 
 // Token
 
@@ -101,6 +111,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -116,6 +127,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -131,6 +143,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -146,6 +159,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -162,6 +176,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -181,6 +196,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -196,6 +212,43 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
+        expect(r.getErrorCount()).toBe(0)
+
+    })
+
+    //
+    // Block
+    //
+
+    test("block (with hash)", async () => {
+        const r = new SearchRequest(BLOCK_HASH)
+        await r.run()
+
+        expect(r.searchedId).toBe(BLOCK_HASH)
+        expect(r.account).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+        expect(r.block).toStrictEqual(SAMPLE_BLOCKSRESPONSE.blocks[0])
+        expect(r.getErrorCount()).toBe(0)
+
+    })
+
+    test("block (with hash prefix)", async () => {
+        const r = new SearchRequest(BLOCK_HASH_PREFIX)
+        await r.run()
+
+        expect(r.searchedId).toBe(BLOCK_HASH_PREFIX)
+        expect(r.account).toBeNull()
+        expect(r.accountsWithKey).toStrictEqual([])
+        expect(r.transactions).toStrictEqual([])
+        expect(r.tokenInfo).toBeNull()
+        expect(r.topicMessages).toStrictEqual([])
+        expect(r.contract).toBeNull()
+        expect(r.block).toStrictEqual(SAMPLE_BLOCKSRESPONSE.blocks[0])
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -215,6 +268,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toStrictEqual(SAMPLE_TOKEN)
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -230,6 +284,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toStrictEqual(SAMPLE_TOKEN)
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -249,6 +304,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual(SAMPLE_TOPIC_MESSAGES.messages)
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -268,6 +324,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -283,6 +340,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -299,6 +357,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -314,6 +373,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
         const aliasHex2 = "0x" + INVALID_EVM_ADDRESS
@@ -327,6 +387,7 @@ describe("SearchRequest.ts", () => {
         expect(r2.tokenInfo).toBeNull()
         expect(r2.topicMessages).toStrictEqual([])
         expect(r2.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -343,6 +404,7 @@ describe("SearchRequest.ts", () => {
         expect(r.tokenInfo).toBeNull()
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
+        expect(r.block).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })


### PR DESCRIPTION
**Description**:

The changes below add support for:
- navigating to `:network/blocks/:32-byte-hash-prefix`
- searching blocks by block hash (48 bytes) or block hash prefix (32 bytes)

**Related issue(s)**:

Fixes #426

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
