### PR TITLE
00434 decode contract error message if string

### DIFF
--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -44,7 +44,7 @@
         <Property id="errorMessage">
           <template v-slot:name>Error Message</template>
           <template v-slot:value>
-            <StringValue :string-value ="contractResult?.error_message"/>
+            <StringValue :string-value ="errorMessage"/>
           </template>
         </Property>
         <Property id="from">
@@ -257,6 +257,7 @@ export default defineComponent({
       maxFeePerGas,
       maxPriorityFeePerGas,
       contractResult: contractResultDetailsLoader.entity,
+      errorMessage: contractResultDetailsLoader.errorMessage,
       analyzer: functionCallAnalyzer,
       functionHash: functionCallAnalyzer.functionHash,
       signature: functionCallAnalyzer.signature,

--- a/src/components/contract/ContractResultDetailsLoader.ts
+++ b/src/components/contract/ContractResultDetailsLoader.ts
@@ -23,6 +23,7 @@ import {EntityLoader} from "@/utils/loader/EntityLoader";
 import axios, {AxiosResponse} from "axios";
 import {computed, Ref} from "vue";
 import {EntityID} from "@/utils/EntityID";
+import {ethers} from "ethers";
 
 export class ContractResultDetailsLoader extends EntityLoader<ContractResultDetails> {
 
@@ -61,6 +62,20 @@ export class ContractResultDetailsLoader extends EntityLoader<ContractResultDeta
 
     public callResult = computed(() => {
         return this.entity.value?.call_result ?? null
+    })
+
+    public errorMessage = computed(() => {
+        const stringTypePrefix = '0x08c379a'
+        let message = this.entity.value?.error_message ?? null
+
+        if (message && message.startsWith(stringTypePrefix)) {
+            const reason = ethers.utils.defaultAbiCoder.decode(
+                ['string'],
+                ethers.utils.hexDataSlice(message, 4)
+            )
+            message = reason.toString() ?? message
+        }
+        return message
     })
 
     //

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -777,6 +777,80 @@ export const SAMPLE_CONTRACT_RESULT_DETAILS = {
     "nonce": null
 }
 
+export const SAMPLE_REVERT_CONTRACT_RESULT_DETAILS = {
+    "address": "0x0000000000000000000000000000000000362667",
+    "amount": 0,
+    "bloom": "0x",
+    "call_result": "0x",
+    "contract_id": "0.0.3548775",
+    "created_contract_ids": [],
+    "error_message": "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000024496e73756666696369656e7420746f6b656e2062616c616e636520666f7220776970656400000000000000000000000000000000000000000000000000000000",
+    "from": "0x00000000000000000000000000000000000005ba",
+    "function_parameters": "0x49257b42000000000000000000000000b7ba29e0554025e632d7db18d65d80c130f5ee940000000000000000000000000000000000000000000000000000000000007531",
+    "gas_limit": 4000000,
+    "gas_used": 3200000,
+    "timestamp": "1677085141.263832358",
+    "to": "0x0000000000000000000000000000000000362667",
+    "hash": "0xcbfcdad696696893d15eefa3ea71e889cabe8e652e54f611543b5035386bc675",
+    "block_hash": "0x16725d87e23dae63b20234861ccfe66874aa7e91bdd6bb8bc8e53b87d88c7499954dadce9b05c5032bcc239a31474708",
+    "block_number": 1224584,
+    "logs": [],
+    "result": "CONTRACT_REVERT_EXECUTED",
+    "transaction_index": 10,
+    "state_changes": [
+        {
+            "address": "0x0000000000000000000000000000000000362667",
+            "contract_id": "0.0.3548775",
+            "slot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "value_read": "0x0000000000000000000000000000000000000000000000000000003626680001",
+            "value_written": null
+        }, {
+            "address": "0x0000000000000000000000000000000000362667",
+            "contract_id": "0.0.3548775",
+            "slot": "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+            "value_read": "0x00000000000000000000000000000000000000000000000000000000002f9ff9",
+            "value_written": null
+        }, {
+            "address": "0x0000000000000000000000000000000000362667",
+            "contract_id": "0.0.3548775",
+            "slot": "0x6e6aaf3664af5268422aafc6f282e31102cd3653bc26111cdbbe2430cc92130f",
+            "value_read": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "value_written": null
+        }, {
+            "address": "0x0000000000000000000000000000000000362667",
+            "contract_id": "0.0.3548775",
+            "slot": "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103",
+            "value_read": "0x0000000000000000000000000000000000000000000000000000000000362666",
+            "value_written": null
+        }, {
+            "address": "0x0000000000000000000000000000000000362667",
+            "contract_id": "0.0.3548775",
+            "slot": "0x00000000000000000000000000000000000000000000000000000000000000c8",
+            "value_read": "0x0000000000000000000000000000000000000000000000000000000000000009",
+            "value_written": null
+        }, {
+            "address": "0x0000000000000000000000000000000000362667",
+            "contract_id": "0.0.3548775",
+            "slot": "0xe71fac6fb785942cc6c6404a423f94f32a28ae66d69ff41494c38bfd4788b2fb",
+            "value_read": "0x515f99f4e5a381c770462a8d9879a01f0fd4a414a168a2404dab62a62e1af0c3",
+            "value_written": null
+        }
+    ],
+    "status": "0x0",
+    "failed_initcode": null,
+    "access_list": null,
+    "block_gas_used": 3248000,
+    "chain_id": null,
+    "gas_price": null,
+    "max_fee_per_gas": null,
+    "max_priority_fee_per_gas": null,
+    "r": null,
+    "s": null,
+    "type": null,
+    "v": null,
+    "nonce": null
+}
+
 // https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=2&transactiontype=CRYPTOTRANSFER
 
 export const SAMPLE_CRYPTO_TRANSACTIONS = {

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -21,7 +21,7 @@
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
-import {SAMPLE_CONTRACT_RESULT_DETAILS} from "../Mocks";
+import {SAMPLE_CONTRACT_RESULT_DETAILS, SAMPLE_REVERT_CONTRACT_RESULT_DETAILS} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import {HMSF} from "@/utils/HMSF";
 import ContractResult from "@/components/contract/ContractResult.vue";
@@ -92,4 +92,37 @@ describe("ContractResult.vue", () => {
 
         expect(wrapper.findAll("#logIndexValue").length).toBe(3)
     });
+
+    it("Should display the reverted contract result and decode the error message", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const transactionId = "0.0.1466-1677085130-338772063"
+        const contractId = SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id
+        const timestamp = SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.timestamp
+
+        const mock = new MockAdapter(axios);
+        const matcher1 = "/api/v1/contracts/results/" + transactionId
+        mock.onGet(matcher1).reply(200, SAMPLE_REVERT_CONTRACT_RESULT_DETAILS)
+
+        const wrapper = mount(ContractResult, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionIdOrHash: transactionId,
+                topLevel: true
+            },
+        });
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("^Contract Result for " + contractId + " at " + timestamp))
+        expect(wrapper.get("#resultValue").text()).toBe("CONTRACT_REVERT_EXECUTED")
+        expect(wrapper.get("#errorMessageValue").text()).toBe("Insufficient token balance for wiped")
+
+        expect(wrapper.findAll("#logIndexValue").length).toBe(0)
+    });
+
 });


### PR DESCRIPTION
**Description**:

With the following changes, the error message returned by a contract that reverts is decoded and displayed in a human readable manner when it contains a string.

**Related issue(s)**:

Fixes #434 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
