### PR TITLE
00434 Decode error message in contract call trace.

### DIFF
--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -140,6 +140,7 @@ import EVMAddress from "@/components/values/EVMAddress.vue";
 import {FunctionCallAnalyzer} from "@/utils/FunctionCallAnalyzer";
 import FunctionInput from "@/components/values/FunctionInput.vue";
 import FunctionResult from "@/components/values/FunctionResult.vue";
+import {decodeSolidityErrorMessage} from "@/schemas/HederaUtils";
 
 export default defineComponent({
   name: 'ContractActionDetails',
@@ -162,7 +163,7 @@ export default defineComponent({
     const errorMessage = computed(() => {
       let result
       if (props.action?.result_data_type != ResultDataType.OUTPUT) {
-        result = props.action?.result_data
+        result = decodeSolidityErrorMessage(props.action?.result_data ?? null)
       } else {
         result = null
       }

--- a/src/components/contract/ContractResultDetailsLoader.ts
+++ b/src/components/contract/ContractResultDetailsLoader.ts
@@ -23,7 +23,7 @@ import {EntityLoader} from "@/utils/loader/EntityLoader";
 import axios, {AxiosResponse} from "axios";
 import {computed, Ref} from "vue";
 import {EntityID} from "@/utils/EntityID";
-import {ethers} from "ethers";
+import {decodeSolidityErrorMessage} from "@/schemas/HederaUtils";
 
 export class ContractResultDetailsLoader extends EntityLoader<ContractResultDetails> {
 
@@ -64,19 +64,8 @@ export class ContractResultDetailsLoader extends EntityLoader<ContractResultDeta
         return this.entity.value?.call_result ?? null
     })
 
-    public errorMessage = computed(() => {
-        const errorStringSelector = '0x08c379a0'
-        let message = this.entity.value?.error_message ?? null
-
-        if (message && message.startsWith(errorStringSelector)) {
-            const reason = ethers.utils.defaultAbiCoder.decode(
-                ['string'],
-                ethers.utils.hexDataSlice(message, 4)
-            )
-            message = reason.toString() ?? message
-        }
-        return message
-    })
+    public errorMessage = computed(
+        () => decodeSolidityErrorMessage(this.entity.value?.error_message ?? null))
 
     //
     // EntityLoader

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -73,3 +73,26 @@ export function makeOperatorDescription(accountId: string): string | null {
         : NodeRegistry.getDescription(ref(null), ref(accountId))
 }
 
+export function decodeSolidityErrorMessage(message: string | null): string | null {
+    const errorStringSelector = '0x08c379a0'
+    const panicUint256Selector = '0x4e487b71'
+
+    let result = message
+
+    if (result && result.startsWith(errorStringSelector)) {
+        const reason = ethers.utils.defaultAbiCoder.decode(
+            ['string'],
+            ethers.utils.hexDataSlice(result, 4)
+        )
+        result = reason.toString() ?? result
+    } else if (result && result.startsWith(panicUint256Selector)) {
+        const code = ethers.utils.defaultAbiCoder.decode(
+            ['uint256'],
+            ethers.utils.hexDataSlice(result, 4)
+        )
+        result = code.toString() ?? result
+    }
+
+    return result
+}
+


### PR DESCRIPTION
**Description**:

Follow-up to the fix for #434:
- we apply the same decoding to the nested contract calls shown in the contract stack trace
- we decode Panic(uint256) as well as Error(string) return message.

**Related issue(s)**:

Fixes #434

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
