### PR TITLE
00471 show an account page for not yet created accounts

### DIFF
--- a/src/pages/AddressDetails.vue
+++ b/src/pages/AddressDetails.vue
@@ -89,7 +89,7 @@ export default defineComponent({
           if (accountId !== null) {
             result = routeManager.makeRouteToAccount(accountId)
           } else {
-            result = routeManager.pageNotFoundRoute
+            result = routeManager.makeRouteToAccount(evmAddress)
           }
         }
 


### PR DESCRIPTION
**Description**:

Changes below modify logic in AddressDetails so that AccountDetails is displayed even if account does not exist.
Then the following page is displayed:


![](https://user-images.githubusercontent.com/91124272/222516541-9834c20c-61cf-4f64-a0b5-2e11d923266e.png)


**Related issue(s)**:
Fixes #478 471

**Notes for reviewer**:
Sample URL:
https://localhost:8080/testnet/account/0xcd6c43084c8b9db93545213ae24f1d51e2b1e878
