### PR TITLE
00490 misleading stake percentage

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -86,34 +86,22 @@
 
       <o-table-column id="stake-range-column" v-slot="props" field="stake-range" label="Stake Range" position="right"
                       style="padding-bottom: 2px; padding-top: 12px;">
-        <o-tooltip multiline
-                   :delay="tooltipDelay"
-                   class="h-tooltip">
+        <o-tooltip :delay="tooltipDelay" class="h-tooltip">
           <StakeRange :node="props.row"/>
           <template #content>
-            <div class="is-flex is-justify-content-space-between" style="width: 200px">
-              <p>Rewarded:</p>
-              <div class="has-text-weight-normal">
-                <HbarAmount :amount="props.row.stake_rewarded ?? 0" :decimals="0"/>
-              </div>
-            </div>
-            <div class="is-flex is-justify-content-space-between" style="width: 200px">
-              <p>Not Rewarded:</p>
-              <div class="has-text-weight-normal">
-                <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
-              </div>
-            </div>
-            <div class="is-flex is-justify-content-space-between" style="width: 200px">
-              <p>Min:</p>
-              <div class="has-text-weight-normal">
-                <HbarAmount :amount="props.row.min_stake ?? 0" :decimals="0"/>
-              </div>
-            </div>
-            <div class="is-flex is-justify-content-space-between" style="width: 200px">
-              <p>Max:</p>
-              <div class="has-text-weight-normal">
-                <HbarAmount :amount="props.row.max_stake ?? 0" :decimals="0"/>
-              </div>
+            <div class="reward-range-tooltip">
+              <div class="caption has-background-success has-text-right"></div>
+              <p class="has-text-left">Rewarded:</p>
+              <div class="has-text-weight-normal has-text-right"><HbarAmount :amount="props.row.stake_rewarded ?? 0" :decimals="0"/></div>
+              <div class="caption has-background-info"></div>
+              <p class="has-text-left">Not Rewarded:</p>
+              <div class="has-text-weight-normal has-text-right"><HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/></div>
+              <div/>
+              <p class="has-text-left">Min:</p>
+              <div class="has-text-weight-normal has-text-right"><HbarAmount :amount="props.row.min_stake ?? 0" :decimals="0"/></div>
+              <div/>
+              <p class="has-text-left">Max:</p>
+              <div class="has-text-weight-normal has-text-right"><HbarAmount :amount="props.row.max_stake ?? 0" :decimals="0"/></div>
             </div>
           </template>
         </o-tooltip>
@@ -226,4 +214,18 @@ export default defineComponent({
   padding-top: 8px;
   padding-bottom: 8px;
 }
+
+.caption {
+  height: 0.8rem;
+  width: 0.8rem;
+  border: 1px solid white;
+}
+
+.reward-range-tooltip {
+  display: grid;
+  grid-template-columns: 1fr 4fr 3fr;
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+}
+
 </style>

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -586,18 +586,18 @@ export function makeNodeSelectorDescription(node: NetworkNode): string {
         style: 'percent',
         maximumFractionDigits: 1
     })
-    const unclampedStakeAmount = ((node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0))/100000000
-    const percentMin = node.min_stake ? unclampedStakeAmount / (node.min_stake / 100000000) : 0
-    const percentMax = node.max_stake ? unclampedStakeAmount / (node.max_stake / 100000000) : 0
+    const unclampedStakeAmount = (node.stake_rewarded ?? 0) + (node.stake_not_rewarded ?? 0)
+    const percentMin = node.min_stake ? unclampedStakeAmount / node.min_stake : 0
+    const percentMax = node.max_stake ? (node.stake_rewarded ?? 0) / node.max_stake : 0
 
     let result = node.node_id
         + ' - '
         + (node.description ?? makeDefaultNodeDescription(node.node_id ?? null))
 
-    if (percentMin != 0 && percentMin < 1) {
-        result += " (" + percentFormatter.format(percentMin) + " of Min Stake)"
+    if (percentMin !== 0 && percentMin < 1) {
+        result += " - Not Rewarding (total stake is " + percentFormatter.format(percentMin) + " of min)"
     } else if (percentMax !== 0) {
-        result += " (" + percentFormatter.format(percentMax) + " of Max Stake)"
+        result += " - Rewarding (stake rewarded is " + percentFormatter.format(percentMax) + " of max)"
     }
     return result
 }

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -87,9 +87,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA (20% of Max Stake)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA (30% of Max Stake)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA (30% of Max Stake)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 16.7% of max)')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 23.3% of max)')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (stake rewarded is 23.3% of max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)
@@ -137,9 +137,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA (20% of Max Stake)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA (30% of Max Stake)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA (30% of Max Stake)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 16.7% of max)')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 23.3% of max)')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (stake rewarded is 23.3% of max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(true)
@@ -186,9 +186,9 @@ describe("Staking.vue", () => {
         const options = wrapper.find('select').findAll('option')
 
         expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA (20% of Max Stake)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA (30% of Max Stake)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA (30% of Max Stake)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 16.7% of max)')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 23.3% of max)')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (stake rewarded is 23.3% of max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)


### PR DESCRIPTION
**Description**:

This fixes the % of stake displayed in the node selector.
- if total-stake < min we display `Not Rewarding (total stake is X% of min)` with X = total-stake/min*100
- otherwise we display  `Rewarding (stake rewarded is Y% of max)` with Y = rewarded-stake/max*100

**Related issue(s)**:

Fixes #490 

**Notes for reviewer**:

<img width="592" alt="Screenshot 2023-03-15 at 22 55 47" src="https://user-images.githubusercontent.com/16097111/225452795-4f635b3f-a165-487b-a6e1-4f9b89c25d66.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
