### PR TITLE
00442 remove auto renew where not yet enabled

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -159,7 +159,8 @@
         <Property id="autoRenewPeriod">
           <template v-slot:name>Auto Renew Period</template>
           <template v-slot:value>
-            <DurationValue v-bind:number-value="account?.auto_renew_period"/>
+            <DurationValue v-if="false" v-bind:number-value="account?.auto_renew_period"/>
+            <span v-else class="has-text-grey">Not yet enabled</span>
           </template>
         </Property>
         <Property id="maxAutoAssociation">

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -99,13 +99,15 @@
         <Property id="autoRenewPeriod">
           <template v-slot:name>Auto Renew Period</template>
           <template v-slot:value>
-            <DurationValue v-bind:string-value="tokenInfo?.auto_renew_period?.toString()"/>
+            <DurationValue v-if="false" v-bind:string-value="tokenInfo?.auto_renew_period?.toString()"/>
+            <span v-else class="has-text-grey">Not yet enabled</span>
           </template>
         </Property>
         <Property id="autoRenewAccount">
           <template v-slot:name>Auto Renew Account</template>
           <template v-slot:value>
-            <AccountLink :account-id="tokenInfo?.auto_renew_account" :show-none="true"/>
+            <AccountLink v-if="false" :account-id="tokenInfo?.auto_renew_account" :show-none="true"/>
+            <span v-else class="has-text-grey">Not yet enabled</span>
           </template>
         </Property>
         <Property id="freezeDefault">

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -130,7 +130,7 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
 
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("false")
 
@@ -228,7 +228,7 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
         expect(wrapper.find("#aliasValue").exists()).toBe(false)
         expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
 

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -184,7 +184,7 @@ describe("NodeDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
         expect(wrapper.find("#aliasValue").exists()).toBe(false)
         expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
     });

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -99,8 +99,8 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.find("#adminKey").text()).toBe("Admin KeyNoneToken is immutable")
         expect(wrapper.get("#memoValue").text()).toBe("234234")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
-        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.29612329")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
+        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("Not yet enabled")
         expect(wrapper.get("#freezeDefaultValue").text()).toBe("false")
         expect(wrapper.get("#pauseStatusValue").text()).toBe("Not applicable")
 
@@ -160,7 +160,7 @@ describe("TokenDetails.vue", () => {
         )
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
 
         expect(wrapper.get("#createdAtValue").text()).toBe("3:29:27.7128 PMMar 6, 2022, UTC")
         expect(wrapper.get("#modifiedAtValue").text()).toBe("8:56:33.5203 PMMar 6, 2022, UTC")


### PR DESCRIPTION
**Description**:

For entities (Token, Account) which do not yet have the auto-renew feature enabled, we replace the values of properties _Auto Renew Period_ & _Auto Renew Account_ by the mention `Not yet enabled`.

**Related issue(s)**:

Fixes #442

**Notes for reviewer**:

See screenshots in issue #442

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
