### PR TITLE
Housekeeping: Transaction vs TransactionDetail

### DIFF
--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -25,7 +25,7 @@
 <template>
   <template v-if="transaction">
     <TransferGraphSection v-if="shouldGraph"
-        v-bind:transaction="transaction"
+        v-bind:transaction="transactionDetail"
         v-bind:compact="true"/>
     <div v-else-if="isTokenAssociation">
       {{ transaction?.entity_id }}
@@ -54,7 +54,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, onMounted, PropType, ref} from "vue";
-import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
+import {Transaction, TransactionDetail, TransactionType} from "@/schemas/HederaSchemas";
 import {makeSummaryLabel} from "@/utils/TransactionTools";
 import TransferGraphSection from "@/components/transfer_graphs/TransferGraphSection.vue";
 import {TokenRelationshipLoader} from "@/components/token/TokenRelationshipLoader";
@@ -107,6 +107,10 @@ export default defineComponent({
       return result
     })
 
+    const transactionDetail = computed(() => {
+      return props.transaction as TransactionDetail|undefined
+    })
+
     return {
       shouldGraph,
       isTokenAssociation,
@@ -116,7 +120,8 @@ export default defineComponent({
       ethereumSummary,
       // From TransactionTools
       makeSummaryLabel,
-      TransactionType
+      TransactionType,
+      transactionDetail
     }
   }
 })

--- a/src/components/transfer_graphs/NftTransferGraph.vue
+++ b/src/components/transfer_graphs/NftTransferGraph.vue
@@ -113,13 +113,13 @@ import AccountLink from "@/components/values/AccountLink.vue";
 import TokenLink from "@/components/values/TokenLink.vue";
 import ArrowSegment from "@/components/transfer_graphs/ArrowSegment.vue";
 import {NFTTransferLayout} from "@/components/transfer_graphs/layout/NFTTransferLayout";
-import {Transaction} from "@/schemas/HederaSchemas";
+import {TransactionDetail} from "@/schemas/HederaSchemas";
 
 export default defineComponent({
   name: "NftTransferGraph",
   components: {TokenLink, AccountLink, ArrowSegment},
   props: {
-    transaction: Object as PropType<Transaction>,
+    transaction: Object as PropType<TransactionDetail>,
     compact: {
       type: Boolean,
       default: false

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -70,7 +70,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, PropType} from "vue";
-import {Transaction} from "@/schemas/HederaSchemas";
+import {TransactionDetail} from "@/schemas/HederaSchemas";
 import HbarTransferGraphC from "@/components/transfer_graphs/HbarTransferGraphC.vue";
 import HbarTransferGraphF from "@/components/transfer_graphs/HbarTransferGraphF.vue";
 import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue";
@@ -88,7 +88,7 @@ export default defineComponent({
     HbarTransferGraphF,
   },
   props: {
-    transaction: Object as PropType<Transaction>,
+    transaction: Object as PropType<TransactionDetail>,
     compact: {
       type: Boolean,
       default: false

--- a/src/components/transfer_graphs/layout/NFTTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/NFTTransferLayout.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {compareNftTransfer, NftTransfer, Transaction} from "@/schemas/HederaSchemas";
+import {compareNftTransfer, NftTransfer, TransactionDetail} from "@/schemas/HederaSchemas";
 
 export class NFTTransferLayout {
 
@@ -32,7 +32,7 @@ export class NFTTransferLayout {
     // Public
     //
 
-    public static make(transaction: Transaction|undefined): Array<NFTTransferLayout> {
+    public static make(transaction: TransactionDetail|undefined): Array<NFTTransferLayout> {
 
         const transfers = transaction?.nft_transfers ?? []
         transfers.sort(compareNftTransfer)

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -112,33 +112,39 @@ export interface TransactionResponse {
 }
 
 export interface TransactionByIdResponse {
-    transactions: Array<Transaction> | undefined
+    transactions: Array<TransactionDetail> | undefined
 }
-
 export interface Transaction {
 
+    bytes: string | null | undefined
+    charged_tx_fee: number | undefined
     consensus_timestamp: string | undefined
     entity_id: string |null | undefined             // Network entity ID in the format of shard.realm.num
-    bytes: string | null | undefined
-    transaction_hash: string | undefined
-    valid_start_timestamp: string | undefined
-    charged_tx_fee: number | undefined
-    memo_base64: string | undefined                 // To be checked
-    nonce: number | undefined
-    result: string | undefined
-    name: TransactionType | undefined
-    nft_transfers: NftTransfer[] | undefined
     max_fee: string | undefined
-    valid_duration_seconds: string | undefined
+    memo_base64: string | undefined                 // To be checked
+    name: TransactionType | undefined
     node: string | null |  undefined                // Network entity ID in the format of shard.realm.num
+    nonce: number | undefined
+    parent_consensus_timestamp: string | null | undefined
+    result: string | undefined
     scheduled: boolean | undefined
+    // staking_reward_transfers: ...
+    token_transfers: TokenTransfer[] | undefined
+    transaction_hash: string | undefined
     transaction_id: string | undefined
     transfers: Transfer[] | undefined
-    token_transfers: TokenTransfer[] | undefined
-    assessed_custom_fees: CustomFee[] | undefined
-    parent_consensus_timestamp: string | null | undefined
+    valid_duration_seconds: string | undefined
+    valid_start_timestamp: string | undefined
 
 }
+
+export interface TransactionDetail extends Transaction {
+
+    nft_transfers: NftTransfer[] | undefined
+    assessed_custom_fees: CustomFee[] | undefined
+
+}
+
 
 export interface NftTransfer {
     receiver_account_id: string | null | undefined  // Network entity ID in the format of shard.realm.num

--- a/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
@@ -21,7 +21,7 @@
 import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue";
-import {Transaction} from "@/schemas/HederaSchemas";
+import {TransactionDetail} from "@/schemas/HederaSchemas";
 import {SAMPLE_NONFUNGIBLE, SAMPLE_NONFUNGIBLE_DUDE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
@@ -74,7 +74,7 @@ describe("NftTransferGraph.vue", () => {
                 plugins: [router]
             },
             props: {
-                transaction: transaction as Transaction
+                transaction: transaction as TransactionDetail
             },
         })
 
@@ -123,7 +123,7 @@ describe("NftTransferGraph.vue", () => {
                 }
             },
             props: {
-                transaction: transaction as Transaction
+                transaction: transaction as TransactionDetail
             },
         })
 
@@ -162,7 +162,7 @@ describe("NftTransferGraph.vue", () => {
                 plugins: [router]
             },
             props: {
-                transaction: transaction as Transaction
+                transaction: transaction as TransactionDetail
             },
         })
 
@@ -200,7 +200,7 @@ describe("NftTransferGraph.vue", () => {
                 plugins: [router]
             },
             props: {
-                transaction: transaction as Transaction
+                transaction: transaction as TransactionDetail
             },
         })
 
@@ -241,7 +241,7 @@ describe("NftTransferGraph.vue", () => {
                 plugins: [router]
             },
             props: {
-                transaction: transaction as Transaction
+                transaction: transaction as TransactionDetail
             },
         })
 
@@ -279,7 +279,7 @@ describe("NftTransferGraph.vue", () => {
                 plugins: [router]
             },
             props: {
-                transaction: transaction as Transaction
+                transaction: transaction as TransactionDetail
             },
         })
 


### PR DESCRIPTION

**Description**:

Following changes are housekeeping.

`Transaction` declaration in `HederaSchema.ts` does actually match `TransactionDetail` declaration from [Mirror Node API](https://previewnet.mirrornode.hedera.com/api/v1/docs/).

This PR splits `Transaction` into `Transaction` and `TransactionDetail` and makes `TransactionDetail` extends `Transaction`.
