### PR TITLE
Fix account link

### DIFF
--- a/tests/e2e/specs/NodeNavigation.spec.ts
+++ b/tests/e2e/specs/NodeNavigation.spec.ts
@@ -51,6 +51,7 @@ describe('Node Navigation', () => {
         cy.contains('Node ' + nodeId)
 
         cy.get('#nodeAccount')
+            .find('a')
             .contains(nodeAccount)
             .click()
 


### PR DESCRIPTION
**Description**:

This is a fix for AccountLink -- props.accountId not always defined at mount, so it must be watched.
E2E tests also need a fix since AccountLink has async logic.

**Related issue(s)**:

None.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
