### PR TITLE
00494  Entity ID in Contract Call transactions is in certain cases a token ID

### DIFF
--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -217,7 +217,15 @@ import {EntityID} from "@/utils/EntityID";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import axios from "axios";
-import {CryptoAllowance, Nfts, TokenAllowance, TokenRelationshipResponse, Transaction, TransactionByIdResponse} from "@/schemas/HederaSchemas";
+import {
+  CryptoAllowance,
+  Nfts,
+  TokenAllowance,
+  TokenInfo,
+  TokenRelationshipResponse,
+  Transaction,
+  TransactionByIdResponse
+} from "@/schemas/HederaSchemas";
 import ProgressDialog, {Mode} from "@/components/staking/ProgressDialog.vue";
 import {normalizeTransactionId} from "@/utils/TransactionID";
 import {waitFor} from "@/utils/TimerUtils";
@@ -719,8 +727,8 @@ export default defineComponent({
                 if (tokens && tokens.length > 0) {
                   if (type !== null) {
                     TokenInfoCache.instance.lookup(entity)
-                        .then((t) => {
-                          if (t.type === type) {
+                        .then((t: TokenInfo | null) => {
+                          if (t?.type === type) {
                             isValid.value = true
                           } else {
                             message.value = (type === 'FUNGIBLE_COMMON') ? TOKEN_NOT_FUNGIBLE_MESSAGE : TOKEN_NOT_NFT_MESSAGE

--- a/src/components/contracts/ContractResultsSection.vue
+++ b/src/components/contracts/ContractResultsSection.vue
@@ -1,0 +1,103 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <DashboardCard>
+    <template v-slot:title>
+      <p class="h-is-secondary-title">Recent Contract Calls</p>
+    </template>
+
+    <template v-slot:control>
+      <div class="is-flex is-align-items-flex-end">
+        <PlayPauseButton v-bind:controller="resultTableController"/>
+      </div>
+    </template>
+
+    <template v-slot:content>
+      <ContractResultTable
+          v-if="contractId"
+          v-bind:controller="resultTableController"
+      />
+    </template>
+  </DashboardCard>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
+import router from "@/router";
+import DashboardCard from "@/components/DashboardCard.vue";
+import {ContractResultTableController} from "@/components/contract/ContractResultTableController";
+import PlayPauseButton from "@/components/PlayPauseButton.vue";
+import ContractResultTable from "@/components/contract/ContractResultTable.vue";
+
+export default defineComponent({
+  name: 'ContractResultsSection',
+
+  components: {ContractResultTable, PlayPauseButton, DashboardCard},
+
+  props: {
+    contractId: String,
+  },
+
+  setup: function (props) {
+    const isTouchDevice = inject('isTouchDevice', false)
+    const isSmallScreen = inject('isSmallScreen', true)
+    const isMediumScreen = inject('isMediumScreen', true)
+
+    const computedContractId = computed(() => props.contractId || null)
+    const perPage = computed(() => isMediumScreen ? 10 : 5)
+
+    //
+    // resultTableController
+    //
+
+    const resultTableController = new ContractResultTableController(router, computedContractId, perPage)
+    onMounted(() => resultTableController.mount())
+    onBeforeUnmount(() => resultTableController.unmount())
+
+    return {
+      isTouchDevice,
+      isSmallScreen,
+      isMediumScreen,
+      resultTableController
+    }
+  }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+</style>

--- a/src/components/contracts/ContractResultsSection.vue
+++ b/src/components/contracts/ContractResultsSection.vue
@@ -36,10 +36,9 @@
     </template>
 
     <template v-slot:content>
-      <ContractResultTable
-          v-if="contractId"
-          v-bind:controller="resultTableController"
-      />
+      <div id="contract-result-table">
+        <ContractResultTable v-if="contractId" :controller="resultTableController"/>
+      </div>
     </template>
   </DashboardCard>
 

--- a/src/components/contracts/ContractResultsSection.vue
+++ b/src/components/contracts/ContractResultsSection.vue
@@ -24,7 +24,7 @@
 
 <template>
 
-  <DashboardCard>
+  <DashboardCard v-if="showContractResults">
     <template v-slot:title>
       <p class="h-is-secondary-title">Recent Contract Calls</p>
     </template>
@@ -75,6 +75,8 @@ export default defineComponent({
     const computedContractId = computed(() => props.contractId || null)
     const perPage = computed(() => isMediumScreen ? 10 : 5)
 
+    const showContractResults = computed(() => resultTableController.rows.value.length)
+
     //
     // resultTableController
     //
@@ -87,6 +89,7 @@ export default defineComponent({
       isTouchDevice,
       isSmallScreen,
       isMediumScreen,
+      showContractResults,
       resultTableController
     }
   }

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -89,7 +89,7 @@ export default defineComponent({
 
     const updateResponse = () => {
       if (props.tokenId) {
-        TokenInfoCache.instance.lookup(props.tokenId).then((r: TokenInfo) => {
+        TokenInfoCache.instance.lookup(props.tokenId).then((r: TokenInfo | null) => {
           response.value = r
         }, (reason: unknown) => {
           console.warn("TokenInfoCollector did fail to fetch " + props.tokenId + " with reason: " + reason)

--- a/src/components/values/TokenExtra.vue
+++ b/src/components/values/TokenExtra.vue
@@ -67,9 +67,9 @@ export default defineComponent({
 
     const updateExtra = () => {
       if (props.tokenId) {
-        TokenInfoCache.instance.lookup(props.tokenId).then((r: TokenInfo) => {
+        TokenInfoCache.instance.lookup(props.tokenId).then((r: TokenInfo | null) => {
           if (props.showName) {
-            extra.value = r.name ?? ""
+            extra.value = r?.name ?? ""
           } else {
             extra.value = makeTokenSymbol(r, 40)
           }

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -164,24 +164,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard>
-      <template v-slot:title>
-        <p class="h-is-secondary-title">Recent Contract Calls</p>
-      </template>
-
-      <template v-slot:control>
-        <div class="is-flex is-align-items-flex-end">
-          <PlayPauseButton v-bind:controller="resultTableController"/>
-        </div>
-      </template>
-
-      <template v-slot:content>
-        <ContractResultTable
-            v-if="contract"
-            v-bind:controller="resultTableController"
-        />
-      </template>
-    </DashboardCard>
+    <ContractResultsSection :contract-id="normalizedContractId"/>
 
   </section>
 
@@ -197,7 +180,6 @@
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
 import KeyValue from "@/components/values/KeyValue.vue";
-import PlayPauseButton from "@/components/PlayPauseButton.vue";
 import AccountLink from "@/components/values/AccountLink.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import DurationValue from "@/components/values/DurationValue.vue";
@@ -217,8 +199,7 @@ import {networkRegistry} from "@/schemas/NetworkRegistry";
 import router, {routeManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
-import {ContractResultTableController} from "@/components/contract/ContractResultTableController";
-import ContractResultTable from "@/components/contract/ContractResultTable.vue";
+import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -227,7 +208,7 @@ export default defineComponent({
   name: 'ContractDetails',
 
   components: {
-    ContractResultTable,
+    ContractResultsSection,
     EVMAddress,
     TransactionLink,
     ByteCodeValue,
@@ -241,7 +222,6 @@ export default defineComponent({
     AccountLink,
     TimestampValue,
     DurationValue,
-    PlayPauseButton,
     KeyValue,
     StringValue
   },
@@ -318,15 +298,6 @@ export default defineComponent({
       return result
     })
 
-    //
-    // resultTableController
-    //
-
-    const pageSize = computed(() => 10)
-    const resultTableController = new ContractResultTableController(router, normalizedContractId, pageSize)
-    onMounted(() => resultTableController.mount())
-    onBeforeUnmount(() => resultTableController.unmount())
-
     const accountRoute = computed(() => {
       return normalizedContractId.value !== null ?  routeManager.makeRouteToAccount(normalizedContractId.value) : null
     })
@@ -342,7 +313,6 @@ export default defineComponent({
       ethereumAddress: accountLocParser.ethereumAddress,
       accountChecksum,
       displayAllTokenLinks,
-      resultTableController,
       notification,
       autoRenewAccount: autoRenewAccount,
       obtainerId: obtainerId,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -264,8 +264,12 @@
       </template>
 
       <template v-slot:content>
-        <NftHolderTable v-if="isNft" :controller="nftHolderTableController"/>
-        <TokenBalanceTable v-else :controller="tokenBalanceTableController"/>
+        <div v-if="isNft" id="nft-holder-table">
+          <NftHolderTable :controller="nftHolderTableController"/>
+        </div>
+        <div v-else id="token-balance-table">
+          <TokenBalanceTable :controller="tokenBalanceTableController"/>
+        </div>
       </template>
 
     </DashboardCard>

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -270,6 +270,8 @@
 
     </DashboardCard>
 
+    <ContractResultsSection :contract-id="normalizedTokenId"/>
+
   </section>
 
   <Footer/>
@@ -308,12 +310,14 @@ import EVMAddress from "@/components/values/EVMAddress.vue";
 import {makeTokenSymbol} from "@/schemas/HederaUtils";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";
+import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
 
 export default defineComponent({
 
   name: 'TokenDetails',
 
   components: {
+    ContractResultsSection,
     EVMAddress,
     TokenCustomFees,
     PlayPauseButton,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -269,7 +269,7 @@ const MAX_INLINE_CHILDREN = 9
 
 export default defineComponent({
 
-  name: 'TransactionDetailsV2',
+  name: 'TransactionDetails',
 
   components: {
     TokenLink,

--- a/src/router.ts
+++ b/src/router.ts
@@ -21,7 +21,7 @@
 import {createRouter, createWebHistory, RouteLocationNormalized, Router, RouteRecordRaw} from 'vue-router'
 import MainDashboard from "@/pages/MainDashboard.vue";
 import Transactions from "@/pages/Transactions.vue";
-import TransactionDetailsV2 from "@/pages/TransactionDetailsV2.vue";
+import TransactionDetails from "@/pages/TransactionDetails.vue";
 import Accounts from "@/pages/Accounts.vue";
 import AccountDetails from "@/pages/AccountDetails.vue";
 import Tokens from "@/pages/Tokens.vue";
@@ -86,7 +86,7 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/:network/transaction/:transactionLoc',
     name: 'TransactionDetails',
-    component: TransactionDetailsV2,
+    component: TransactionDetails,
     props: true
   },
   {
@@ -200,7 +200,7 @@ const routes: Array<RouteRecordRaw> = [
     // EIP 3091 Support
     path: '/:network/tx/:transactionLoc',
     name: 'TransactionDetails3091',
-    component: TransactionDetailsV2,
+    component: TransactionDetails,
     props: true
   },
   {

--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -19,8 +19,11 @@
  */
 
 import { Transaction, TransactionType } from "@/schemas/HederaSchemas";
+import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
 
 export class EntityDescriptor {
+
+    static DEFAULT_ENTITY_DESCRIPTOR = new EntityDescriptor("Entity ID", null)
 
     constructor(
         readonly label: string,
@@ -28,7 +31,7 @@ export class EntityDescriptor {
     ) {
     }
 
-    static makeEntityDescriptor(row: Transaction): EntityDescriptor {
+    static async makeEntityDescriptor(row: Transaction): Promise<EntityDescriptor> {
         let result: EntityDescriptor
         switch (row.name) {
 
@@ -39,7 +42,22 @@ export class EntityDescriptor {
                 result = new EntityDescriptor("Topic ID", "TopicDetails")
                 break;
 
+            case TransactionType.ETHEREUMTRANSACTION:
+                if (row.entity_id && await ContractByIdCache.instance.lookup(row.entity_id)) {
+                    result = new EntityDescriptor("Contract ID", "ContractDetails")
+                } else {
+                    result = new EntityDescriptor("Account ID", "AccountDetails")
+                }
+                break;
+
             case TransactionType.CONTRACTCALL:
+                if (row.entity_id && await ContractByIdCache.instance.lookup(row.entity_id)) {
+                    result = new EntityDescriptor("Contract ID", "ContractDetails")
+                } else {
+                    result = new EntityDescriptor("Token ID", "TokenDetails")
+                }
+                break;
+
             case TransactionType.CONTRACTDELETEINSTANCE:
             case TransactionType.CONTRACTCREATEINSTANCE:
             case TransactionType.CONTRACTUPDATEINSTANCE:
@@ -92,12 +110,11 @@ export class EntityDescriptor {
             case TransactionType.SYSTEMDELETE:
             case TransactionType.SYSTEMUNDELETE:
             case TransactionType.UNCHECKEDSUBMIT:
-            case TransactionType.ETHEREUMTRANSACTION:
             default:
-                result = new EntityDescriptor("Entity ID", null);
+                result = EntityDescriptor.DEFAULT_ENTITY_DESCRIPTOR;
                 break;
         }
 
-        return result
+        return Promise.resolve(result)
     }
 }

--- a/src/utils/cache/TokenInfoCache.ts
+++ b/src/utils/cache/TokenInfoCache.ts
@@ -22,7 +22,7 @@ import axios from "axios";
 import {TokenInfo} from "@/schemas/HederaSchemas";
 import {SerialCache} from "@/utils/cache/SerialCache";
 
-export class TokenInfoCache extends SerialCache<string, TokenInfo> {
+export class TokenInfoCache extends SerialCache<string, TokenInfo | null> {
 
     public static readonly instance = new TokenInfoCache()
 
@@ -30,9 +30,18 @@ export class TokenInfoCache extends SerialCache<string, TokenInfo> {
     // Cache
     //
 
-    protected async load(tokenId: string): Promise<TokenInfo> {
-        const response = await axios.get<TokenInfo>("api/v1/tokens/" + tokenId)
-        return Promise.resolve(response.data)
+    protected async load(tokenId: string): Promise<TokenInfo | null> {
+        let result: Promise<TokenInfo|null>
+        try {
+            const response = await axios.get<TokenInfo>("api/v1/tokens/" + tokenId)
+            result = Promise.resolve(response.data)
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status == 404) {
+                result = Promise.resolve(null)
+            } else {
+                throw error
+            }
+        }
+        return result
     }
-
 }

--- a/tests/e2e/specs/TokenNavigation.spec.ts
+++ b/tests/e2e/specs/TokenNavigation.spec.ts
@@ -72,8 +72,9 @@ describe('Token Navigation', () => {
         cy.contains('Non Fungible Token')
         cy.contains('Token ID:' + nftId)
 
-        cy.get('table')
+        cy.get('#nft-holder-table')
             .find('tbody tr')
+            .should('be.visible')
             .should('have.length.at.least', 2)
             .eq(0)
             .find('td')
@@ -88,14 +89,15 @@ describe('Token Navigation', () => {
     })
 
     const tokenId = "0.0.1738807"
-    it('should follow links from token details', () => {
+    it('should follow links from fungible token details', () => {
         cy.visit('mainnet/token/' + tokenId)
         cy.url().should('include', '/mainnet/token/' + tokenId)
         cy.contains('Fungible Token')
         cy.contains('Token ID:' + tokenId)
 
-        cy.get('table')
+        cy.get('#token-balance-table')
             .find('tbody tr')
+            .should('be.visible')
             .should('have.length.at.least', 2)
             .eq(0)
             .find('td')

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -82,6 +82,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/balances"
         mock.onGet(matcher2).reply(200, SAMPLE_BALANCES);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -141,6 +143,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_NONFUNGIBLE_DUDE);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -196,6 +200,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_NONFUNGIBLE_DUDE);
         let matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        let matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -224,8 +230,10 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN);
         matcher2 = "/api/v1/tokens/" + testTokenId + "/balances"
         mock.onGet(matcher2).reply(200, SAMPLE_BALANCES);
-        const matcher3 = "/api/v1/tokens/" + testTokenId + "/nfts"
-        mock.onGet(matcher3).reply(200, SAMPLE_NFTS);
+        matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
+        const matcher4 = "/api/v1/tokens/" + testTokenId + "/nfts"
+        mock.onGet(matcher4).reply(200, SAMPLE_NFTS);
 
         await wrapper.setProps({
             tokenId: testTokenId
@@ -279,6 +287,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_WITH_KEYS);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -324,6 +334,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_WITHOUT_KEYS);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -371,6 +383,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_WITHOUT_KEYS);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -404,6 +418,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/balances"
         mock.onGet(matcher2).reply(200, SAMPLE_BALANCES);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
         const matcher4 = "/api/v1/network/exchangerate"
         mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
 
@@ -455,6 +471,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_NONFUNGIBLE);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
         const matcher4 = "/api/v1/network/exchangerate"
         mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
 
@@ -506,6 +524,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_WITHOUT_KEYS);
         const matcher2 = "/api/v1/tokens/" + testTokenId + "/nfts"
         mock.onGet(matcher2).reply(200, SAMPLE_NFTS);
+        const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
+        mock.onGet(matcher3).reply(200, []);
 
         const wrapper = mount(TokenDetails, {
             global: {

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -22,7 +22,7 @@
 
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
-import TransactionDetailsV2 from "@/pages/TransactionDetailsV2.vue";
+import TransactionDetails from "@/pages/TransactionDetails.vue";
 import HbarTransferGraphF from "@/components/transfer_graphs/HbarTransferGraphF.vue";
 import TokenTransferGraph from "@/components/transfer_graphs/TokenTransferGraphF.vue";
 import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue";
@@ -102,7 +102,7 @@ describe("TransactionDetails.vue", () => {
         const matcher2 = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -173,7 +173,7 @@ describe("TransactionDetails.vue", () => {
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -235,7 +235,7 @@ describe("TransactionDetails.vue", () => {
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -287,7 +287,7 @@ describe("TransactionDetails.vue", () => {
         const matcher2 = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -350,7 +350,7 @@ describe("TransactionDetails.vue", () => {
         const matcher11 = "/api/v1/transactions/" + SAMPLE_FAILED_TRANSACTION.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_FAILED_TRANSACTIONS);
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -374,7 +374,7 @@ describe("TransactionDetails.vue", () => {
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const invalidTimestamp = "1600000000.000000000"
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -406,7 +406,7 @@ describe("TransactionDetails.vue", () => {
         const matcher11 = "/api/v1/transactions/" + transaction.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS)
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -443,7 +443,7 @@ describe("TransactionDetails.vue", () => {
         const matcher5 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher5).reply(200, SAMPLE_TOKEN)
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -485,7 +485,7 @@ describe("TransactionDetails.vue", () => {
         const matcher2 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -528,7 +528,7 @@ describe("TransactionDetails.vue", () => {
             const matcher2 = "/api/v1/tokens/" + TOKEN_ID
             mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
 
-            const wrapper = mount(TransactionDetailsV2, {
+            const wrapper = mount(TransactionDetails, {
                 global: {
                     plugins: [router, Oruga]
                 },
@@ -568,7 +568,7 @@ describe("TransactionDetails.vue", () => {
         const matcher11 = "/api/v1/transactions/" + PARENT.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_PARENT_CHILD_TRANSACTIONS);
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },
@@ -620,7 +620,7 @@ describe("TransactionDetails.vue", () => {
         const matcher5 = "/api/v1/tokens/" + token2.token_id
         mock.onGet(matcher5).reply(200, token2);
 
-        const wrapper = mount(TransactionDetailsV2, {
+        const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]
             },

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -30,7 +30,7 @@ import NotificationBanner from "@/components/NotificationBanner.vue";
 import axios, {AxiosRequestConfig} from "axios";
 import {
     SAMPLE_ASSOCIATED_TOKEN, SAMPLE_ASSOCIATED_TOKEN_2,
-    SAMPLE_BLOCKSRESPONSE,
+    SAMPLE_BLOCKSRESPONSE, SAMPLE_CONTRACT,
     SAMPLE_CONTRACT_RESULT_DETAILS,
     SAMPLE_CONTRACTCALL_TRANSACTIONS,
     SAMPLE_FAILED_TRANSACTION,
@@ -168,8 +168,10 @@ describe("TransactionDetails.vue", () => {
             }
         });
 
-        const matcher2 = "/api/v1/contracts/" + contractId + "/results/" + timestamp
-        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
+        const matcher2 = "/api/v1/contracts/" + contractId
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT)
+        const matcher3 = "/api/v1/contracts/" + contractId + "/results/" + timestamp
+        mock.onGet(matcher3).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 
@@ -230,8 +232,10 @@ describe("TransactionDetails.vue", () => {
                 return [404]
             }
         });
-        const matcher2 = "/api/v1/contracts/" + contractId  + "/results/" + timestamp
-        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
+        const matcher2 = "/api/v1/contracts/" + contractId
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT)
+        const matcher3 = "/api/v1/contracts/" + contractId  + "/results/" + timestamp
+        mock.onGet(matcher3).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 


### PR DESCRIPTION
**Description**:

With these changes:
- we check whether the entity ID in a CONTRACT CALL transaction is a contract ID or a token ID and adjust the property label and router link accordingly
- we display a table of recent call results in TokenDetails (when they exist -- i.e. the token has been proxied as a contract)

Unrelated house-keeping:
- rename TransactionDetailsV2 to TransactionDetails 

**Related issue(s)**:

Fixes #494

**Notes for reviewer**:

Feature currently deployed on staging.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
