### PR TITLE
Fix compact graph alignment

### DIFF
--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -31,7 +31,7 @@
       {{ transaction?.entity_id }}
       <span v-if="tokens.length">
         <i class="fas fa-link mr-1 has-text-grey"></i>
-        <TokenExtra :token-id="tokens[0]" :show-name="true"/>
+        <TokenExtra :token-id="tokens[0]" :show-name="false"/>
         <span v-if="additionalTokensNumber" class="h-is-smaller h-is-extra-text should-wrap">
           {{ ' ( + ' + additionalTokensNumber + ' more )' }}
         </span>

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -40,9 +40,9 @@
 
   <NftTransferGraph
       data-cy="nftTransfers"
+      :class="{'mb-4': !compact}"
       v-bind:transaction="transaction"
       v-bind:compact="compact"/>
-  <br/>
 
   <TokenTransferGraphC
       data-cy="tokenTransfers"
@@ -54,9 +54,9 @@
       v-bind:transaction="transaction"/>
 
   <template v-if="netAmount === 0 && !compact">
-    <br/>
     <HbarTransferGraphF
         data-cy="feeTransfers"
+        class="mt-4"
         v-bind:transaction="transaction" title="Fee Transfers" :show-none="true"/>
   </template>
 


### PR DESCRIPTION
**Description**:

Fix for the alignment problem in compact transfer graph (inside transaction tables) for CRYPTO TRANSFER -- also make the row as compact as other tx types.

**Notes for reviewer**:

Before:
<img width="696" alt="Before" src="https://user-images.githubusercontent.com/16097111/231444697-722d6db1-7213-4ced-8f4d-0eeffab602ba.png">

After:
<img width="696" alt="After" src="https://user-images.githubusercontent.com/16097111/231444747-b9f0d0ee-c06b-4e17-88f9-394fe1308a84.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
