### PR TITLE
Refactoring

### DIFF
--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -286,7 +286,11 @@ export default defineComponent({
       if (!validEntityId.value) {
         result = "Invalid contract ID: " + props.contractId
       } else if (contractLookup.entity.value == null) {
-        result = "Contract with ID " + props.contractId + " was not found"
+          if (contractLookup.isLoaded()) {
+              result = "Contract with ID " + props.contractId + " was not found"
+          } else {
+              result = null
+          }
       } else if (contractLookup.entity.value?.deleted === true) {
         result = "Contract is deleted"
       // to be re-activated after Feb 9th

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -373,7 +373,11 @@ export default defineComponent({
       if (!validEntityId.value) {
         result = "Invalid token ID: " + props.tokenId
       } else if (tokenLookup.entity.value == null) {
-        result = "Token with ID " + props.tokenId + " was not found"
+          if (tokenLookup.isLoaded()) {
+              result = "Token with ID " + props.tokenId + " was not found"
+          } else {
+              result = null
+          }
       } else if (tokenLookup.entity.value?.deleted) {
         result = "Token is deleted"
       } else {


### PR DESCRIPTION
**Description**:

Changes below are refactoring. No semantic change.
`ContractDetails` and `TokenDetails` views now using `Lookup.isLoaded()` routine to avoid transient error banner.
