### PR TITLE
00551 Confusion on labeling for stake

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -73,7 +73,7 @@
         </o-tooltip>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="stake_not_rewarded" label="Stake Not Rewarded" position="right">
+      <o-table-column v-slot="props" field="stake_not_rewarded" label="Staked For No Reward" position="right">
         <o-tooltip :delay="tooltipDelay"
                    :label="tooltipNotRewarded"
                    class="h-tooltip"

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -119,12 +119,12 @@
         <NetworkDashboardItem id="maxStake" :value="makeFloorHbarAmount(maxStake)" name="HBAR" title="Max Stake"/>
         <br/><br/>
         <NetworkDashboardItem id="rewarded" :value="makeFloorHbarAmount(stakeRewarded)" name="HBAR"
-                              title="Stake Rewarded"/>
+                              title="Staked for Reward"/>
         <p id="rewardedPercent" class="h-is-property-text h-is-extra-text mt-1">{{ stakeRewardedPercentage }}% of
           total</p>
         <br/><br/>
         <NetworkDashboardItem id="notRewarded" :value="makeFloorHbarAmount(stakeUnrewarded)" name="HBAR"
-                              title="Stake Not Rewarded"/>
+                              title="Staked For No Reward"/>
         <p id="notRewardedPercent" class="h-is-property-text h-is-extra-text mt-1">{{ stakeUnrewardedPercentage }}% of
           total</p>
         <br/><br/>

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -624,7 +624,7 @@ export function makeNodeSelectorDescription(node: NetworkNode): string {
     if (percentMin !== 0 && percentMin < 1) {
         result += " - Not Rewarding (total stake is " + percentFormatter.format(percentMin) + " of min)"
     } else if (percentMax !== 0) {
-        result += " - Rewarding (stake rewarded is " + percentFormatter.format(percentMax) + " of max)"
+        result += " - Rewarding (staked for reward is " + percentFormatter.format(percentMax) + " of max)"
     }
     return result
 }

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -108,9 +108,9 @@ describe("NodeDetails.vue", () => {
         expect(wrapper.get("#consensusStakePercent").text()).toBe("25% of total")
         expect(wrapper.get("#minStake").text()).toBe("Min Stake1,000,000HBAR")
         expect(wrapper.get("#maxStake").text()).toBe("Max Stake30,000,000HBAR")
-        expect(wrapper.get("#rewarded").text()).toBe("Stake Rewarded5,000,000HBAR")
+        expect(wrapper.get("#rewarded").text()).toBe("Staked for Reward5,000,000HBAR")
         expect(wrapper.get("#rewardedPercent").text()).toBe("26.32% of total")
-        expect(wrapper.get("#notRewarded").text()).toBe("Stake Not Rewarded1,000,000HBAR")
+        expect(wrapper.get("#notRewarded").text()).toBe("Staked For No Reward1,000,000HBAR")
         expect(wrapper.get("#notRewardedPercent").text()).toBe("20% of total")
         expect(wrapper.get("#stakingPeriod").text()).toBe("Current Staking Period24HOURS")
 

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -91,7 +91,7 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Description Stake Stake Not Rewarded Stake Range Reward Rate")
+        expect(wrapper.get('thead').text()).toBe("Node Description Stake Staked For No Reward Stake Range Reward Rate")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
             "0" +

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -103,7 +103,7 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Description Stake Stake Not Rewarded Stake Range Reward Rate")
+        expect(table.get('thead').text()).toBe("Node Description Stake Staked For No Reward Stake Range Reward Rate")
         expect(wrapper.get('tbody').text()).toBe(
             "0" +
             "Hosted by Hedera | East Coast, USA" +

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -87,9 +87,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 16.7% of max)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 23.3% of max)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (stake rewarded is 23.3% of max)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (staked for reward is 16.7% of max)')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (staked for reward is 23.3% of max)')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (staked for reward is 23.3% of max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)
@@ -137,9 +137,9 @@ describe("Staking.vue", () => {
 
         const options = wrapper.find('select').findAll('option')
         expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 16.7% of max)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 23.3% of max)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (stake rewarded is 23.3% of max)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (staked for reward is 16.7% of max)')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (staked for reward is 23.3% of max)')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (staked for reward is 23.3% of max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(true)
@@ -186,9 +186,9 @@ describe("Staking.vue", () => {
         const options = wrapper.find('select').findAll('option')
 
         expect(options.length).toBe(SAMPLE_NETWORK_NODES.nodes.length)
-        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 16.7% of max)')
-        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (stake rewarded is 23.3% of max)')
-        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (stake rewarded is 23.3% of max)')
+        expect(options.at(0)?.element.text).toBe('0 - Hosted by Hedera | East Coast, USA - Rewarding (staked for reward is 16.7% of max)')
+        expect(options.at(1)?.element.text).toBe('1 - Hosted by Hedera | East Coast, USA - Rewarding (staked for reward is 23.3% of max)')
+        expect(options.at(2)?.element.text).toBe('2 - Hosted by Hedera | Central, USA - Rewarding (staked for reward is 23.3% of max)')
 
         expect(options.at(0)?.element.selected).toBe(false)
         expect(options.at(1)?.element.selected).toBe(false)

--- a/tests/unit/utils/AccountLocParser.spec.ts
+++ b/tests/unit/utils/AccountLocParser.spec.ts
@@ -939,7 +939,7 @@ describe("AccountLocParser.ts", () => {
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
         expect(parser.aliasByteString.value).toBeNull()
-        expect(parser.errorNotification.value).toBe("Account with Ethereum address 0x0001020304050607080900010203040506070809 was not found")
+        expect(parser.errorNotification.value).toBe("Own this account? Activate it by transferring any amount of ℏ or tokens to 0x0…070809.")
 
         // 3) Unsets
         accountLoc.value = null


### PR DESCRIPTION
**Description**:

This changes the staking terminology across UI as follows:
- stake rewarded --> staked for reward
- stake not rewarded --> staked for no reward

(bonus: unrelated unit test fix)

**Related issue(s)**:

Fixes #551

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
