### PR TITLE
00554 Token memo wrongly interpreted as base64 encoding

### DIFF
--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -85,7 +85,7 @@
         <Property id="memo">
           <template v-slot:name>Memo</template>
           <template v-slot:value>
-            <BlobValue :base64="true" :blob-value="tokenInfo?.memo" :show-none="true"/>
+            <BlobValue :blob-value="tokenInfo?.memo" :show-none="true"/>
           </template>
         </Property>
         <Property id="expiresAt">

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -102,7 +102,7 @@ export const SAMPLE_TOKEN = {
     "initial_supply": "1",
     "kyc_key": null,
     "max_supply": "0",
-    "memo": "234234",
+    "memo": "Predator",
     "modified_timestamp": "1644660150.233378000",
     "name": "23423",
     "pause_key": null,

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -104,7 +104,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#nameValue").text()).toBe("23423")
         expect(wrapper.get("#symbolValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
         expect(wrapper.find("#adminKey").text()).toBe("Admin KeyNoneToken is immutable")
-        expect(wrapper.get("#memoValue").text()).toBe("234234")
+        expect(wrapper.get("#memoValue").text()).toBe("Predator")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
         expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
         expect(wrapper.get("#autoRenewAccountValue").text()).toBe("Not yet enabled")


### PR DESCRIPTION
**Description**:

With this 1-line change, the token memo string is displayed as is and no longer base64 decoded.

**Related issue(s)**:

Fixes #554

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
