### PR TITLE
00549 replace initcode by runtime bytecode

### DIFF
--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -122,9 +122,9 @@
               </template>
             </Property>
             <Property id="code">
-              <template v-slot:name>Initcode</template>
+              <template v-slot:name>Runtime Bytecode</template>
               <template v-slot:value>
-                <ByteCodeValue :byte-code="contract?.bytecode ?? undefined"/>
+                <ByteCodeValue :byte-code="contract?.runtime_bytecode ?? undefined"/>
               </template>
             </Property>
       </template>

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -117,6 +117,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#validUntilValue").text()).toBe("None")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address:0x00000000000000000000000000000000000b70cfCopy to Clipboard")
+        expect(wrapper.get("#code").text()).toBe("Runtime BytecodeNone")
 
         expect(wrapper.findComponent(ContractResultTable).exists()).toBe(true)
     });


### PR DESCRIPTION
**Description**:

With this trivial change, the runtime byte code is displayed in lieu of the initcode in the ContractDetails view.

**Related issue(s)**:

Fixes #549

**Notes for reviewer**:

Deployed on staging.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
