### PR TITLE
Refactoring: FunctionCallAnalyzer now delegates to ContractAnalyzer and AssetCache

### DIFF
--- a/src/schemas/SystemContractRegistry.ts
+++ b/src/schemas/SystemContractRegistry.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  *
  */
-import {ethers} from "ethers";
-import axios from "axios";
 
 export class SystemContractRegistry {
 
@@ -45,58 +43,13 @@ export class SystemContractEntry {
     public readonly contractId: string
     public readonly description: string
     public readonly abiFileName: string
-
-    private interface: ethers.utils.Interface|null = null
+    public readonly abiURL: string
 
     constructor(contractId: string, description: string, abiFileName: string) {
         this.contractId = contractId
         this.description = description
         this.abiFileName = abiFileName
-    }
-
-    async parseTransaction(data: string): Promise<ethers.utils.TransactionDescription|null> {
-        if (this.interface === null) {
-            this.interface = await SystemContractEntry.loadInterface(this.abiFileName)
-        }
-        const result = this.interface?.parseTransaction({data: data}) ?? null
-        return Promise.resolve(result)
-    }
-
-    async decodeFunctionResult(functionFragment: ethers.utils.FunctionFragment, resultData: string): Promise<ethers.utils.Result|null> {
-        if (this.interface === null) {
-            this.interface = await SystemContractEntry.loadInterface(this.abiFileName)
-        }
-        const result = this.interface?.decodeFunctionResult(functionFragment, resultData) ?? null
-        return Promise.resolve(result)
-    }
-
-    async getSignature(data: string): Promise<string|null> {
-        if (this.interface === null) {
-            this.interface = await SystemContractEntry.loadInterface(this.abiFileName)
-        }
-        const result = this.interface?.parseTransaction({data: data})?.signature ?? null
-        return Promise.resolve(result)
-    }
-
-    //
-    // Private
-    //
-
-    /*
-        https://docs.ethers.io/v5/api/utils/abi/interface/
-     */
-
-    private static async loadInterface(abiFileName: string): Promise<ethers.utils.Interface|null> {
-        let result: ethers.utils.Interface|null
-        try {
-            const url = window.location.origin + "/abi/" + abiFileName
-            const response = await axios.get(url)
-            result = new ethers.utils.Interface(response.data.abi)
-        } catch(error) {
-            console.log("Failed to load ABI from " + abiFileName + " (" + error + ")")
-            result = null
-        }
-        return Promise.resolve(result)
+        this.abiURL = window.location.origin + "/abi/" + abiFileName
     }
 }
 

--- a/src/utils/ContractAnalyzer.ts
+++ b/src/utils/ContractAnalyzer.ts
@@ -1,0 +1,155 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, ComputedRef, ref, Ref, watch, WatchStopHandle} from "vue";
+import {SystemContractEntry, systemContractRegistry} from "@/schemas/SystemContractRegistry";
+import {ethers} from "ethers";
+import {AssetCache} from "@/utils/cache/AssetCache";
+
+export class ContractAnalyzer {
+
+    public readonly contractId: Ref<string|null>
+    private readonly watchHandle: Ref<WatchStopHandle|null> = ref(null)
+    private readonly systemContractEntryRef: Ref<SystemContractEntry|null> = ref(null)
+    // private readonly solcOutput: Ref<SolcOutput|null> = ref(null)
+    // private readonly contractMatchResult: Ref<ContractMatchResult|null> = ref(null)
+    private readonly interfaceRef: Ref<ethers.utils.Interface|null> = ref(null)
+
+    //
+    // Public
+    //
+
+    public constructor(contractId: Ref<string|null>) {
+        this.contractId = contractId
+    }
+
+    public mount(): void {
+        this.watchHandle.value = watch(this.contractId, this.contractIdDidChange, { immediate: true})
+    }
+
+    public unmount(): void {
+        if (this.watchHandle.value !== null) {
+            this.watchHandle.value()
+            this.watchHandle.value = null
+        }
+        this.systemContractEntryRef.value = null
+        // this.solcOutput.value = null
+        // this.contractMatchResult.value = null
+        this.interfaceRef.value = null
+    }
+    //
+    // public readonly sourceFileName: ComputedRef<string|null> = computed(
+    //     () => this.contractMatchResult.value?.sourceFileName ?? null)
+    //
+    // public readonly contractName: ComputedRef<string|null> = computed(
+    //     () => this.contractMatchResult.value?.contractName ?? null)
+    //
+    // public readonly bytecodeComparison: ComputedRef<BytecodeComparison|null> = computed(
+    //     () => this.contractMatchResult.value?.comparison ?? null)
+
+    public readonly interface: ComputedRef<ethers.utils.Interface|null> = computed(
+        () => this.interfaceRef.value)
+
+
+    // public readonly contractURL: ComputedRef<string|null> = computed(() => {
+    //     let result: string|null
+    //     if (this.contractId.value !== null) {
+    //         result = SolcOutputCache.makeContractURL(this.contractId.value)
+    //     } else {
+    //         result = null
+    //     }
+    //     return result
+    // })
+    //
+    // public readonly sourceFileURL: ComputedRef<string|null> = computed(() => {
+    //     let result: string|null
+    //     if (this.contractURL.value !== null) {
+    //         if (this.contractMatchResult.value !== null) {
+    //             result = this.contractURL.value + "/" + this.contractMatchResult.value.sourceFileName
+    //         } else {
+    //             result = this.contractURL.value
+    //         }
+    //     } else {
+    //         result = null
+    //     }
+    //     return result
+    // })
+
+    //
+    // Private
+    //
+
+    private readonly contractIdDidChange = async() => {
+        if (this.contractId.value !== null) {
+            const sce = systemContractRegistry.lookup(this.contractId.value)
+            if (sce !== null) {
+                // This is a system contract
+                this.systemContractEntryRef.value = sce
+                // this.solcOutput.value = null
+                // this.contractMatchResult.value = null
+                try {
+                    const asset = await AssetCache.instance.lookup(sce.abiURL) as { abi: ethers.utils.Fragment[]}
+                    const i = new ethers.utils.Interface(asset.abi)
+                    this.interfaceRef.value = Object.preventExtensions(i) // Because ethers does not like Ref introspection
+                } catch {
+                    this.interfaceRef.value = null
+                }
+            } else {
+                // Check if contract metadata are available and fetch abi
+                this.systemContractEntryRef.value = null
+                // try {
+                //     const o = await SolcOutputCache.instance.lookup(this.contractId.value)
+                //     if (o !== null) {
+                //         this.solcOutput.value = o
+                //         const contractInfo = await ContractByIdCache.instance.lookup(this.contractId.value)
+                //         const deployedByteCode = contractInfo?.runtime_bytecode ?? null
+                //         if (deployedByteCode !== null) {
+                //             const r = SolcUtils.findMatchingContract(deployedByteCode, this.solcOutput.value)
+                //             if (r !== null) {
+                //                 const d = SolcUtils.fetchDescription(r.sourceFileName, r.contractName, o)
+                //                 const i = d?.abi ? new ethers.utils.Interface(d?.abi) : null
+                //                 this.contractMatchResult.value = r
+                //                 this.interfaceRef.value = Object.preventExtensions(i) // Because ethers does not like Ref introspection
+                //             } else {
+                //                 this.contractMatchResult.value = null
+                //                 this.interfaceRef.value = null
+                //             }
+                //         } else {
+                //             this.contractMatchResult.value = null
+                //             this.interfaceRef.value = null
+                //         }
+                //     } else {
+                //         this.solcOutput.value = null
+                //         this.contractMatchResult.value = null
+                //         this.interfaceRef.value = null
+                //     }
+                // } catch {
+                //     this.solcOutput.value = null
+                //     this.contractMatchResult.value = null
+                //     this.interfaceRef.value = null
+                // }
+            }
+        } else {
+            this.systemContractEntryRef.value = null
+            // this.solcOutput.value = null
+            // this.contractMatchResult.value = null
+        }
+    }
+}

--- a/src/utils/cache/AssetCache.ts
+++ b/src/utils/cache/AssetCache.ts
@@ -1,0 +1,37 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import axios from "axios";
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+
+export class AssetCache extends EntityCache<string, unknown> {
+
+    public static readonly instance = new AssetCache()
+
+    //
+    // Cache
+    //
+
+    protected async load(url: string): Promise<unknown> {
+        const response = await axios.get<unknown>(url)
+        return Promise.resolve(response.data)
+    }
+
+}

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -36,6 +36,7 @@ import {AccountByAliasCache} from "@/utils/cache/AccountByAliasCache";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {TransactionGroupByBlockCache} from "@/utils/cache/TransactionGroupByBlockCache";
 import {TokenRelationshipCache} from "@/utils/cache/TokenRelationshipCache";
+import {AssetCache} from "@/utils/cache/AssetCache";
 
 export class CacheUtils {
 
@@ -43,6 +44,7 @@ export class CacheUtils {
         AccountByAddressCache.instance.clear()
         AccountByAliasCache.instance.clear()
         AccountByIdCache.instance.clear()
+        AssetCache.instance.clear()
         BlockByNbCache.instance.clear()
         BlockByHashCache.instance.clear()
         BlockByTsCache.instance.clear()

--- a/tests/unit/utils/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/FunctionCallAnalyzer.spec.ts
@@ -40,42 +40,42 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string|null> = ref(null)
         const output: Ref<string|null> = ref(null)
         const contractId: Ref<string|null> = ref(null)
-        const analyzer = new FunctionCallAnalyzer(input, output, contractId)
-        expect(analyzer.functionHash.value).toBeNull()
-        expect(analyzer.signature.value).toBeNull()
-        expect(analyzer.inputs.value).toStrictEqual([])
-        expect(analyzer.outputs.value).toStrictEqual([])
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, contractId)
+        expect(functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(functionCallAnalyzer.signature.value).toBeNull()
+        expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
 
         // 2) mount
-        analyzer.mount()
+        functionCallAnalyzer.mount()
         await flushPromises()
-        expect(analyzer.functionHash.value).toBeNull()
-        expect(analyzer.signature.value).toBeNull()
-        expect(analyzer.inputs.value).toStrictEqual([])
-        expect(analyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(functionCallAnalyzer.signature.value).toBeNull()
+        expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
 
         // 3) input setup
         input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
         output.value = "0x0000000000000000000000000000000000000000000000000000000005a995c0"
         contractId.value = "0.0.359"
         await flushPromises()
-        expect(analyzer.functionHash.value).toBe("0x49146bde")
-        expect(analyzer.signature.value).toBe("associateToken(address,address)")
-        expect(analyzer.inputs.value).toStrictEqual([
+        expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
+        expect(functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
+        expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("account", "address", "0x845b706151aEd537b1FD81c1Ea4EA03920097ABD"),
             new NameTypeValue("token", "address", "0x0000000000000000000000000000000002E6Ae09"),
         ])
-        expect(analyzer.outputs.value).toStrictEqual([
+        expect(functionCallAnalyzer.outputs.value).toStrictEqual([
             new NameTypeValue("responseCode", "int64", BigNumber.from("0x05a995c0")),
         ])
 
         // 4) unmount
-        analyzer.unmount()
+        functionCallAnalyzer.unmount()
         await flushPromises()
-        expect(analyzer.functionHash.value).toBeNull()
-        expect(analyzer.signature.value).toBeNull()
-        expect(analyzer.inputs.value).toStrictEqual([])
-        expect(analyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(functionCallAnalyzer.signature.value).toBeNull()
+        expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
 
     })
 


### PR DESCRIPTION
**Description**:

Changes below are refactoring. No semantic changes.
`FunctionCallAnalyzer` now delegates to `ContractAnalyzer` and `AssetCache`.


**Notes for reviewer**:

Use testnet transaction `1676977337.514767623` to check `FunctionCallAnalyzer` behavior.

