### PR TITLE
00562 Incorrect fee for CryptoUpdate transaction

### DIFF
--- a/src/components/values/HbarExtra.vue
+++ b/src/components/values/HbarExtra.vue
@@ -89,7 +89,7 @@ export default defineComponent({
   }
 });
 
-const fractionDigits = 4
+const fractionDigits = 5
 
 const dollarFormatting = new Intl.NumberFormat('en-US', {
   style: 'currency',

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -129,7 +129,7 @@ describe("AccountDetails.vue", () => {
         // console.log(wrapper.html())
 
         expect(wrapper.text()).toMatch("Account Account ID:" + SAMPLE_ACCOUNT.account)
-        expect(wrapper.get("#balanceValue").text()).toBe("23.42647909$5.7637998234231ĦFRENSKINGDOM")
+        expect(wrapper.get("#balanceValue").text()).toBe("23.42647909$5.76369998234231ĦFRENSKINGDOM")
         expect(wrapper.get("#keyValue").text()).toBe(
             "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
             "Copy to Clipboard" +
@@ -377,7 +377,7 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.get("#stakedToName").text()).toBe("Staked to")
         expect(wrapper.get("#stakedToValue").text()).toBe("Node 1 - Hosted by Hedera | East Coast, USA")
-        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.12345678$0.0304Period Started Nov 11, 2022, 00:00 UTC")
+        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.12345678$0.03037Period Started Nov 11, 2022, 00:00 UTC")
         expect(wrapper.get("#declineRewardValue").text()).toBe("Accepted")
     });
 
@@ -427,7 +427,7 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.get("#stakedToName").text()).toBe("Staked to")
         expect(wrapper.get("#stakedToValue").text()).toBe("Account 0.0.5Hosted by Hedera | Central, USA")
-        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.00000000$0.0000")
+        expect(wrapper.get("#pendingRewardValue").text()).toBe("0.00000000$0.00000")
         expect(wrapper.find("#declineRewardValue").exists()).toBe(false)
     });
 });

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -103,7 +103,7 @@ describe("ContractDetails.vue", () => {
         // console.log(wrapper.html())
 
         expect(wrapper.text()).toMatch(RegExp("^Contract Contract ID:" + SAMPLE_CONTRACT.contract_id))
-        expect(wrapper.get("#balanceValue").text()).toBe("2.00000000$0.4921")
+        expect(wrapper.get("#balanceValue").text()).toBe("2.00000000$0.49207")
         expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38Copy to ClipboardED25519")
         expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
         expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -167,7 +167,7 @@ describe("Staking.vue", () => {
         expect(stakingModals.length).toBeGreaterThanOrEqual(2)
         const stakingModal = stakingModals[1]
         expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
-        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.07792")
         expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Account 0.0.5")
         const buttons = stakingModal.findAll("button")
         expect(buttons.length).toBe(2) // Cancel and Change
@@ -241,7 +241,7 @@ describe("Staking.vue", () => {
 
         // 3.2) Checks StakingDialog content
         expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
-        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.07792")
         expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Account 0.0.7")
         expect(changeButton.text()).toBe("CHANGE")
         // expect(changeButton.attributes("disabled")).toBeDefined()
@@ -293,7 +293,7 @@ describe("Staking.vue", () => {
 
         // 4.2) Checks StakingDialog content
         expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
-        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.07792")
         expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Node 2 - Hosted by Hedera")
         expect(changeButton.text()).toBe("CHANGE")
         // expect(changeButton.attributes("disabled")).toBeDefined()

--- a/tests/unit/staking/StakingDialog.spec.ts
+++ b/tests/unit/staking/StakingDialog.spec.ts
@@ -125,7 +125,7 @@ describe("StakingDialog.vue", () => {
         // console.log(stakingModal.text())
 
         expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
-        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.07792")
         expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Account 0.0.5")
         const buttons = stakingModal.findAll("button")
         expect(buttons.length).toBe(2) // Cancel and Change
@@ -227,7 +227,7 @@ describe("StakingDialog.vue", () => {
         // console.log(stakingModal.text())
 
         expect(stakingModal.element.classList.contains("is-active")).toBeTruthy()
-        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.0779")
+        expect(stakingModal.get("#amountStakedValue").text()).toBe("0.31669471$0.07792")
         expect(stakingModal.get("#currentlyStakedToValue").text()).toBe("Account 0.0.5")
         const buttons = stakingModal.findAll("button")
         expect(buttons.length).toBe(2) // Cancel and Change

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -446,7 +446,7 @@ describe("TokenDetails.vue", () => {
             "5" + "0.0.2966295623423" + "0.0.617888" +
             "1" + "0.0.2966295623423" + "0.0.617889" +
             "2" + "0.0.2966295623423" + "0.0.617890" +
-            "1.00000000" + "$0.2460" + "HBAR" + "0.0.617888")
+            "1.00000000" + "$0.24603" + "HBAR" + "0.0.617888")
 
         const fractionalFee = customFees.findComponent(FractionalFeeTable)
         expect(fractionalFee.exists()).toBe(true)
@@ -499,7 +499,7 @@ describe("TokenDetails.vue", () => {
             "5" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617888" +
             "1" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617889" +
             "2" + "0.0.748383" + "Ħ Frens Kingdom" + "0.0.617890" +
-            "1.00000000" + "$0.2460" + "HBAR" + "0.0.617888")
+            "1.00000000" + "$0.24603" + "HBAR" + "0.0.617888")
 
         expect(customFees.findComponent(FractionalFeeTable).exists()).toBe(false)
 

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -133,8 +133,8 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#consensusAtValue").text()).toBe("5:12:31.6676 AMFeb 28, 2022, UTC") // UTC because of HMSF.forceUTC
         expect(wrapper.get("#transactionHashValue").text()).toBe("a012 9612 32ed 7d28 4283 6e95 f7e9 c435 6fdf e2de 0819 9091 701a 969c 1d1f d936 71d3 078e e83b 28fb 460a 88b4 cbd8 ecd2Copy to Clipboard")
         // expect(wrapper.get("#netAmountValue").text()).toBe("0.00000000$0.0000")
-        expect(wrapper.get("#chargedFeeValue").text()).toBe("0.00470065$0.0012")
-        expect(wrapper.get("#maxFeeValue").text()).toBe("1.00000000$0.2460")
+        expect(wrapper.get("#chargedFeeValue").text()).toBe("0.00470065$0.00116")
+        expect(wrapper.get("#maxFeeValue").text()).toBe("1.00000000$0.24603")
 
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#operatorAccountValue").text()).toBe("0.0.29624024")
@@ -148,9 +148,9 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.findComponent(NftTransferGraph).exists()).toBe(true)
 
         expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe(
-            "Fee TransfersAccountHbar AmountAccountHbar Amount0.0.29624024-0.00470065-$0.0012\n\n" +
-            "0.0.40.00022028$0.0001Hosted by Hedera | East Coast, USA\n\n" +
-            "0.0.980.00448037$0.0011Hedera fee collection account")
+            "Fee TransfersAccountHbar AmountAccountHbar Amount0.0.29624024-0.00470065-$0.00116\n\n" +
+            "0.0.40.00022028$0.00005Hosted by Hedera | East Coast, USA\n\n" +
+            "0.0.980.00448037$0.00110Hedera fee collection account")
 
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe(
             "Token TransfersAccountToken AmountAccountToken Amount0.0.29624024-123423\n\n" +
@@ -669,9 +669,9 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
         expect(wrapper.findComponent(NftTransferGraph).exists()).toBe(true)
 
-        expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe("Fee TransfersAccountHbar AmountAccountHbar Amount0.0.642949-1.15905210-$0.2852\n\n" +
-            "0.0.30.05805847$0.0143Hosted by Hedera | East Coast, USA\n\n" +
-            "0.0.981.10099363$0.2709Hedera fee collection account")
+        expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe("Fee TransfersAccountHbar AmountAccountHbar Amount0.0.642949-1.15905210-$0.28517\n\n" +
+            "0.0.30.05805847$0.01428Hosted by Hedera | East Coast, USA\n\n" +
+            "0.0.981.10099363$0.27088Hedera fee collection account")
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("Token TransfersNone")
         expect(wrapper.findComponent(NftTransferGraph).text()).toBe("NFT TransfersNone")
 

--- a/tests/unit/values/HbarAmount.spec.ts
+++ b/tests/unit/values/HbarAmount.spec.ts
@@ -56,7 +56,7 @@ describe("HbarAmount.vue ", () => {
 
         const testTinybarAmount = 42
         const expectedHbarAmount = "0.00000042"
-        const expectedDollarAmount = "$0.0001"
+        const expectedDollarAmount = "$0.00001"
 
         const wrapper = mount(HbarAmount, {
             props: {
@@ -77,7 +77,7 @@ describe("HbarAmount.vue ", () => {
 
         const testTinybarAmount = 42
         const expectedHbarAmount = "0.00000042"
-        const expectedDollarAmount = "$0.0001"
+        const expectedDollarAmount = "$0.00001"
 
         const wrapper = mount(HbarAmount, {
             props: {


### PR DESCRIPTION
**Description**:

With changes below, `HbarExtra` now rounds dollar value to 5 digits (in place of 4).


**Related issue(s)**:

Fixes #562

**Notes for reviewer**:
See sample data provided in #562.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
