### PR TITLE
Fixes wrong supply in the token page;

### DIFF
--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -46,7 +46,7 @@ export default defineComponent({
 
   components: {TokenExtra},
   props: {
-    amount: Number,
+    amount: BigInt,
     tokenId: String,
     showExtra: {
       type: Boolean,
@@ -69,7 +69,7 @@ export default defineComponent({
         } else if (initialLoading.value) {
           result = ""
         } else {
-          result = formatTokenAmount(0, response.value.decimals)
+          result = "0"
         }
       } else {
         result = ""
@@ -111,14 +111,13 @@ export default defineComponent({
   }
 });
 
-function formatTokenAmount(rawAmount: number, decimals: string|undefined): string {
+function formatTokenAmount(rawAmount: bigint, decimals: string|undefined): string {
   const decimalCount = computeDecimalCount(decimals) ?? 0
-  const amount = rawAmount / Math.pow(10, decimalCount)
   const amountFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: decimalCount,
     maximumFractionDigits: decimalCount
   })
-  return amountFormatter.format(amount)
+  return amountFormatter.format(rawAmount)
 }
 
 function computeDecimalCount(decimals: string|undefined): number|null {

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -147,14 +147,14 @@
         <Property id="totalSupply">
           <template v-slot:name>Total Supply</template>
           <template v-if="validEntityId" v-slot:value>
-            <TokenAmount :amount="parseIntString(tokenInfo?.total_supply)" :show-extra="false"
+            <TokenAmount :amount="tokenInfo?.total_supply" :show-extra="false"
                          :token-id="normalizedTokenId"/>
           </template>
         </Property>
         <Property id="initialSupply">
           <template v-slot:name>Initial Supply</template>
           <template v-if="validEntityId" v-slot:value>
-            <TokenAmount :amount="parseIntString(tokenInfo?.initial_supply)" :show-extra="false"
+            <TokenAmount :amount="tokenInfo?.initial_supply" :show-extra="false"
                          :token-id="normalizedTokenId"/>
           </template>
         </Property>
@@ -162,7 +162,7 @@
           <template v-slot:name>Max Supply</template>
           <template v-if="validEntityId" v-slot:value>
             <div v-if="tokenInfo?.supply_type === 'INFINITE'" class="has-text-grey">Infinite</div>
-            <TokenAmount v-else :amount="parseIntString(tokenInfo?.max_supply)" :show-extra="false"
+            <TokenAmount v-else :amount="tokenInfo?.max_supply" :show-extra="false"
                          :token-id="normalizedTokenId"/>
           </template>
         </Property>
@@ -421,7 +421,6 @@ export default defineComponent({
       normalizedTokenId,
       notification,
       showTokenDetails,
-      parseIntString,
       ethereumAddress: tokenAnalyzer.ethereumAddress,
       tokenSymbol: tokenAnalyzer.tokenSymbol,
       tokenBalanceTableController,
@@ -429,11 +428,6 @@ export default defineComponent({
     }
   },
 });
-
-function parseIntString(s: string | undefined): number | undefined {
-  const result = Number(s)
-  return isNaN(result) ? undefined : result
-}
 
 
 </script>


### PR DESCRIPTION
**Description**:
Token page currently shows `9,223,372,036,854,776,000` instead of `
9,223,372,036,854,775,807`. (I.e., https://hashscan.io/mainnet/token/0.0.284338)

This PR fixes that.

Please note the same issue can still be found in the balance page (i.e. https://hashscan.io/mainnet/accountbalances/0.0.278981)

**Related issue(s)**:

N/A

**Notes for reviewer**:
`Number` handles up to 2^53-1 values, we should probably always use `BigInt` (like in this PR) or `Strings`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
