### PR TITLE
New label for "IMPORT TO METAMASK" button.

### DIFF
--- a/src/components/token/MetaMaskImport.vue
+++ b/src/components/token/MetaMaskImport.vue
@@ -24,7 +24,7 @@
 
 <template v-if="showImport" class="">
   <button id="showStakingDialog" class="button is-white h-is-smaller"
-          @click="handleAction">ADD TO METAMASK…</button>
+          @click="handleAction">IMPORT TO METAMASK</button>
   <span style="display: inline-block">
     <ModalDialog v-model:show-dialog="showErrorDialog">
       <template v-slot:dialogMessage>Please install MetaMask!</template>


### PR DESCRIPTION
**Description**:

Trivial 1-line change to adjust the label of the button to `IMPORT TO METAMASK`

**Related issue(s)**:

Fixes #558 

**Notes for reviewer**:

<img width="741" alt="Screenshot 2023-05-03 at 15 01 35" src="https://user-images.githubusercontent.com/16097111/235923629-cee68131-341d-4e4c-945e-b4ffa1b1ce5a.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
