### PR TITLE
Put 'Hosted by/for' in low contrast in node descriptions

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -56,7 +56,8 @@
 
       <o-table-column v-slot="props" field="description" label="Description">
         <div class="should-wrap regular-node-column is-inline-block">
-          <StringValue :string-value="makeNodeDescription(props.row)"/>
+          <StringValue :string-value="makeNodeDescriptionPrefix(props.row)" class="has-text-grey"/>
+          <StringValue :string-value="makeNodeOwnerDescription(props.row)"/>
         </div>
       </o-table-column>
 
@@ -121,7 +122,7 @@
     </o-table>
   </div>
 
-  <EmptyTable v-if="nodes && nodes.length == 0"/>
+  <EmptyTable v-if="nodes && nodes.length === 0"/>
 
 </template>
 
@@ -139,7 +140,14 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import StakeRange from "@/components/node/StakeRange.vue";
 import {routeManager} from "@/router";
 import StringValue from "@/components/values/StringValue.vue";
-import {isCouncilNode, makeNodeDescription, makeAnnualizedRate, makeStakePercentage, makeUnclampedStake} from "@/schemas/HederaUtils";
+import {
+  isCouncilNode,
+  makeAnnualizedRate,
+  makeStakePercentage,
+  makeUnclampedStake,
+  makeNodeDescriptionPrefix,
+  makeNodeOwnerDescription
+} from "@/schemas/HederaUtils";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 
 
@@ -191,7 +199,8 @@ export default defineComponent({
       isMediumScreen,
       networkAnalyzer,
       isCouncilNode,
-      makeNodeDescription,
+      makeNodeDescriptionPrefix,
+      makeNodeOwnerDescription,
       makeUnclampedStake,
       makeWeightPercentage,
       makeAnnualizedRate,

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -71,6 +71,32 @@ export function makeNodeDescription(node: NetworkNode): string {
     return result
 }
 
+export function makeNodeDescriptionPrefix(node: NetworkNode): string {
+    const description = makeNodeDescription(node)
+    let result: string
+    if (description.slice(0, 9).toLowerCase() === "hosted by") {
+        result = description.slice(0,9) + " "
+    } else if (description.slice(0, 10).toLowerCase() === "hosted for") {
+        result = description.slice(0,10) + " "
+    } else {
+        result = ""
+    }
+    return result
+}
+
+export function makeNodeOwnerDescription(node: NetworkNode): string {
+    const description = makeNodeDescription(node)
+    let result: string
+    if (description?.slice(0, 9).toLowerCase() === "hosted by") {
+        result = description.slice(10)
+    } else if (description.slice(0, 10).toLowerCase() === "hosted for") {
+        result = description.slice(11)
+    } else {
+        result = description
+    }
+    return result
+}
+
 export function makeDefaultNodeDescription(nodeId: number | null): string {
     return "Node " + nodeId ?? "?"
 }


### PR DESCRIPTION
**Description**:

Simple formatting change. All is in the title...

**Related issue(s)**:

None.

**Notes for reviewer**:

<img width="1091" alt="Screenshot 2023-05-04 at 10 11 01" src="https://user-images.githubusercontent.com/16097111/236222339-dac16084-7665-42a6-8e3c-2f7074c7d3c2.png">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
