### PR TITLE
Refactoring: AddressDetails now uses AccountByAddressCache and ContractByAddressCache

### DIFF
--- a/src/pages/AddressDetails.vue
+++ b/src/pages/AddressDetails.vue
@@ -33,11 +33,11 @@
 <script lang="ts">
 
 import {defineComponent, onMounted} from 'vue';
-import axios from "axios";
 import router, {routeManager} from "@/router";
 import {PathParam} from "@/utils/PathParam";
-import {AccountBalanceTransactions, ContractResponse} from "@/schemas/HederaSchemas";
 import {RouteLocationRaw} from "vue-router";
+import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
+import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 
 export default defineComponent({
 
@@ -52,27 +52,14 @@ export default defineComponent({
 
   setup(props) {
 
-
     const getContractId = async (evmAddress: string): Promise<string|null> => {
-      let result: string|null
-      try {
-        const response = await axios.get<ContractResponse>("api/v1/contracts/" + evmAddress)
-        result = response.data.contract_id ?? null
-      } catch {
-        result = null
-      }
-      return Promise.resolve(result)
+      const contract = await ContractByAddressCache.instance.lookup(evmAddress)
+      return Promise.resolve(contract?.contract_id ?? null)
     }
 
     const getAccountId = async (evmAddress: string): Promise<string|null> => {
-      let result: string|null
-      try {
-        const response = await axios.get<AccountBalanceTransactions>("api/v1/accounts/" + evmAddress)
-        result = response.data.account ?? null
-      } catch {
-        result = null
-      }
-      return Promise.resolve(result)
+      const account = await AccountByAddressCache.instance.lookup(evmAddress)
+      return Promise.resolve(account?.account ?? null)
     }
 
     const selectRoute = async () => {

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -39,6 +39,7 @@ import {TokenRelationshipCache} from "@/utils/cache/TokenRelationshipCache";
 import {AssetCache} from "@/utils/cache/AssetCache";
 import {BalanceCache} from "@/utils/cache/BalanceCache";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
+import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
 
 export class CacheUtils {
 
@@ -52,6 +53,7 @@ export class CacheUtils {
         BlockByHashCache.instance.clear()
         BlockByTsCache.instance.clear()
         ContractByIdCache.instance.clear()
+        ContractByAddressCache.instance.clear()
         ContractResultByHashCache.instance.clear()
         NetworkCache.instance.clear()
         StakeCache.instance.clear()

--- a/src/utils/cache/ContractByAddressCache.ts
+++ b/src/utils/cache/ContractByAddressCache.ts
@@ -18,23 +18,23 @@
  *
  */
 
-import {ContractResponse} from "@/schemas/HederaSchemas";
+import {AccountBalanceTransactions, ContractResponse} from "@/schemas/HederaSchemas";
 import {EntityCache} from "@/utils/cache/base/EntityCache";
 import axios from "axios";
-import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
+import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
 
-export class ContractByIdCache extends EntityCache<string, ContractResponse|null> {
+export class ContractByAddressCache extends EntityCache<string, ContractResponse|null> {
 
-    public static readonly instance = new ContractByIdCache()
+    public static readonly instance = new ContractByAddressCache()
 
     //
     // Public
     //
 
     public updateWithContractResponse(contractResponse: ContractResponse): void {
-        if (contractResponse.contract_id) {
-            this.forget(contractResponse.contract_id)
-            this.mutate(contractResponse.contract_id, Promise.resolve(contractResponse))
+        if (contractResponse.evm_address) {
+            this.forget(contractResponse.evm_address)
+            this.mutate(contractResponse.evm_address, Promise.resolve(contractResponse))
         }
     }
 
@@ -42,12 +42,12 @@ export class ContractByIdCache extends EntityCache<string, ContractResponse|null
     // Cache
     //
 
-    protected async load(key: string): Promise<ContractResponse | null> {
+    protected async load(address: string): Promise<ContractResponse | null> {
         let result: Promise<ContractResponse|null>
         try {
-            const response = await axios.get<ContractResponse>("api/v1/contracts/" + key)
+            const response = await axios.get<ContractResponse>("api/v1/contracts/" + address)
             result = Promise.resolve(response.data)
-            ContractByAddressCache.instance.updateWithContractResponse(response.data)
+            ContractByIdCache.instance.updateWithContractResponse(response.data)
         } catch(error) {
             if (axios.isAxiosError(error) && error.response?.status == 404) {
                 result = Promise.resolve(null)

--- a/src/utils/cache/NetworkCache.ts
+++ b/src/utils/cache/NetworkCache.ts
@@ -33,8 +33,12 @@ export class NetworkCache extends SingletonCache<NetworkNode[]> {
     protected async load(): Promise<NetworkNode[]> {
         let result: NetworkNode[] = []
         let nextURL: string|null = "api/v1/network/nodes"
+        const params = {
+            limit: 25
+        }
         while (nextURL !== null) {
-            const response: AxiosResponse<NetworkNodesResponse> = await axios.get<NetworkNodesResponse>(nextURL)
+            const response: AxiosResponse<NetworkNodesResponse>
+                = await axios.get<NetworkNodesResponse>(nextURL, { params: params})
             result = result.concat(response.data.nodes ?? [])
             nextURL = response.data.links?.next ?? null
         }

--- a/tests/unit/utils/cache/ContractByAddressCache.spec.ts
+++ b/tests/unit/utils/cache/ContractByAddressCache.spec.ts
@@ -1,0 +1,63 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+import {TransactionGroupByBlockCache} from "@/utils/cache/TransactionGroupByBlockCache";
+import {SAMPLE_ACCOUNT, SAMPLE_BLOCK, SAMPLE_CONTRACT, SAMPLE_PARENT_CHILD_TRANSACTIONS} from "../../Mocks";
+import {flushPromises} from "@vue/test-utils";
+import MockAdapter from "axios-mock-adapter";
+import axios, {AxiosRequestConfig} from "axios";
+import {TransactionByHashCache} from "@/utils/cache/TransactionByHashCache";
+import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache";
+import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
+import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
+
+describe("ContractByAddressCache", () => {
+
+    test("ContractByAddressCache", async () => {
+
+        expect(ContractByAddressCache.instance.isEmpty()).toBeTruthy()
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        // 1) First lookup() triggers http requests
+        const contractAddress = SAMPLE_CONTRACT.evm_address
+        const contract = await ContractByAddressCache.instance.lookup(contractAddress)
+        expect(contract).toStrictEqual(SAMPLE_CONTRACT)
+        expect(mock.history.get.length).toBe(1)
+
+        // 2) Second lookup() triggers no http requests
+        mock.resetHistory()
+        const contract2 = await ContractByAddressCache.instance.lookup(contractAddress)
+        await flushPromises()
+        expect(contract2).toStrictEqual(SAMPLE_CONTRACT)
+        expect(mock.history.get.length).toBe(0)
+
+        // Checks that ContractByAddressCache has been populated
+        if (contract?.contract_id) {
+            expect(ContractByIdCache.instance.contains(contract.contract_id))
+        }
+    })
+})

--- a/tests/unit/utils/cache/ContractByIdCache.spec.ts
+++ b/tests/unit/utils/cache/ContractByIdCache.spec.ts
@@ -1,0 +1,63 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+import {TransactionGroupByBlockCache} from "@/utils/cache/TransactionGroupByBlockCache";
+import {SAMPLE_ACCOUNT, SAMPLE_BLOCK, SAMPLE_CONTRACT, SAMPLE_PARENT_CHILD_TRANSACTIONS} from "../../Mocks";
+import {flushPromises} from "@vue/test-utils";
+import MockAdapter from "axios-mock-adapter";
+import axios, {AxiosRequestConfig} from "axios";
+import {TransactionByHashCache} from "@/utils/cache/TransactionByHashCache";
+import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache";
+import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
+import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
+
+describe("ContractByIdCache", () => {
+
+    test("ContractByIdCache", async () => {
+
+        expect(ContractByIdCache.instance.isEmpty()).toBeTruthy()
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        // 1) First lookup() triggers http requests
+        const contractId = SAMPLE_CONTRACT.contract_id
+        const contract = await ContractByIdCache.instance.lookup(contractId)
+        expect(contract).toStrictEqual(SAMPLE_CONTRACT)
+        expect(mock.history.get.length).toBe(1)
+
+        // 2) Second lookup() triggers no http requests
+        mock.resetHistory()
+        const contract2 = await ContractByIdCache.instance.lookup(contractId)
+        await flushPromises()
+        expect(contract2).toStrictEqual(SAMPLE_CONTRACT)
+        expect(mock.history.get.length).toBe(0)
+
+        // Checks that ContractByAddressCache has been populated
+        if (contract?.evm_address) {
+            expect(ContractByAddressCache.instance.contains(contract.evm_address))
+        }
+    })
+})


### PR DESCRIPTION
**Description**:

Changes below are refactoring. No semantic change.

`AddressDetails` vue now re-uses `AccountByAddressCache` and `ContractByAddressCache` in place of inlined rest calls.
