### PR TITLE
00587  show fungible token decimals on detailed token page

### DIFF
--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -166,6 +166,12 @@
                          :token-id="normalizedTokenId"/>
           </template>
         </Property>
+        <Property id="decimals">
+          <template v-slot:name>Decimals</template>
+          <template v-if="validEntityId" v-slot:value>
+            <StringValue :string-value="tokenInfo?.decimals"/>
+          </template>
+        </Property>
       </template>
 
     </DashboardCard>

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -98,6 +98,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#totalSupplyValue").text()).toBe("1")
         expect(wrapper.get("#initialSupplyValue").text()).toBe("1")
         expect(wrapper.get("#maxSupplyValue").text()).toBe("Infinite")
+        expect(wrapper.get("#decimalsValue").text()).toBe("0")
         expect(wrapper.get("#evmAddress").text()).toMatch(
             RegExp("^EVM Address:0x0000000000000000000000000000000001c49eecCopy to Clipboard"))
 
@@ -157,6 +158,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#totalSupplyValue").text()).toBe("2")
         expect(wrapper.get("#initialSupplyValue").text()).toBe("0")
         expect(wrapper.get("#maxSupplyValue").text()).toBe("150")
+        expect(wrapper.get("#decimalsValue").text()).toBe("0")
 
         expect(wrapper.text()).toMatch("NFT Holders")
         expect(wrapper.findComponent(NftHolderTable).exists()).toBe(true)


### PR DESCRIPTION
**Description**:

Changes below show the `Decimals` field in `Token Details` page and update unit tests.

**Related issue(s)**:

Fixes #587 

**Notes for reviewer**:

On mainnet:
- Token `0.0.2302966` has 10 decimals.
- Token `0.0.2303594` has 8 decimals.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
