### PR TITLE
Added missing wrapper.unmount() in unit tests

### DIFF
--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -86,6 +86,9 @@ describe("ContractResult.vue", () => {
         expect(wrapper.get("#gasPriceValue").text()).toBe("None")
 
         expect(wrapper.findAll("#logIndexValue").length).toBe(3)
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
     it("Should display the reverted contract result and decode the error message", async () => {
@@ -118,6 +121,9 @@ describe("ContractResult.vue", () => {
         expect(wrapper.get("#errorMessageValue").text()).toBe("Insufficient token balance for wiped")
 
         expect(wrapper.findAll("#logIndexValue").length).toBe(0)
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
     it("Should display the reverted contract result with call trace and state trace", async () => {
@@ -223,6 +229,9 @@ describe("ContractResult.vue", () => {
         )
 
         expect(wrapper.findAll("#logIndexValue").length).toBe(0)
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
 });

--- a/tests/unit/dashboard/HbarMarketDashboard.spec.ts
+++ b/tests/unit/dashboard/HbarMarketDashboard.spec.ts
@@ -93,6 +93,9 @@ describe("HbarMarketDashboard.vue ", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe("TESTNET")
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
     it("should display the previewnet banner", async () => {
@@ -104,5 +107,8 @@ describe("HbarMarketDashboard.vue ", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe("PREVIEWNET")
+
+        wrapper.unmount()
+        await flushPromises()
     });
 });

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -133,5 +133,8 @@ describe("MainDashboard.vue", () => {
             "0.0.120438" + "None" + "1:59:03.9969 PMMar 8, 2022, UTC" +
             "0.0.120438" + "None" + "1:59:03.9622 PMMar 8, 2022, UTC"
         )
+
+        wrapper.unmount()
+        await flushPromises()
     });
 });

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -83,6 +83,9 @@ describe("Staking.vue", () => {
         expect(wrapper.find('#monthlyReward').text()).toBe("Approx Monthly Reward0HBAR")
         expect(wrapper.find('#yearlyReward').text()).toBe("Approx Yearly Reward0HBAR")
         expect(wrapper.find('#yearlyRate').text()).toBe("Approx Yearly Reward Rate0%")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     it("should display a Rewards Estimator preset with 10000Hbar and Node1", async () => {
@@ -133,6 +136,9 @@ describe("Staking.vue", () => {
         expect(wrapper.find('#monthlyReward').text()).toBe("Approx Monthly Reward16.44HBAR")
         expect(wrapper.find('#yearlyReward').text()).toBe("Approx Yearly Reward200HBAR")
         expect(wrapper.find('#yearlyRate').text()).toBe("Approx Yearly Reward Rate2%")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     it("should input different values for Hbar amount and selected Node", async () => {
@@ -193,5 +199,8 @@ describe("Staking.vue", () => {
         expect(wrapper.find('#monthlyReward').text()).toBe("Approx Monthly Reward16.44HBAR")
         expect(wrapper.find('#yearlyReward').text()).toBe("Approx Yearly Reward200HBAR")
         expect(wrapper.find('#yearlyRate').text()).toBe("Approx Yearly Reward Rate2%")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 });

--- a/tests/unit/staking/StakingDialog.spec.ts
+++ b/tests/unit/staking/StakingDialog.spec.ts
@@ -25,7 +25,8 @@ import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {
     SAMPLE_ACCOUNT,
-    SAMPLE_ACCOUNT_STAKING_ACCOUNT, SAMPLE_ACCOUNTS,
+    SAMPLE_ACCOUNT_STAKING_ACCOUNT,
+    SAMPLE_ACCOUNTS,
     SAMPLE_NETWORK_EXCHANGERATE,
     SAMPLE_NETWORK_NODES,
 } from "../Mocks";
@@ -168,6 +169,9 @@ describe("StakingDialog.vue", () => {
         await changeButton.trigger("click")
         await nextTick()
         await confirmChangeStaking("Change Staking  for account 0.0.730632Do you want to stake to account 0.0.7-bmurp ?FillerCANCELCONFIRM")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     it("provides invalid values for account to stake to", async () => {
@@ -273,5 +277,8 @@ describe("StakingDialog.vue", () => {
         await waitFor(500)
         await flushPromises()
         expect(feedbackMessage.text()).toBe("This account does not exist")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 });

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -73,6 +73,9 @@ describe("TransactionByIdTable.vue", () => {
             "1:29:17.0144 PMSep 6, 2022, UTCTOKEN MINTMINT\n\n0.0.48193741Reptilian Egg NFT\n\n0.0.48113503Child1" +
             "1:29:17.0144 PMSep 6, 2022, UTCCRYPTO TRANSFER0.0.48113503\n\n0.0.48193741Reptilian Egg NFT\n\n0.0.48193739Child2"
         )
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
     it("Should list transactions as scheduling and scheduled", async () => {
@@ -113,6 +116,9 @@ describe("TransactionByIdTable.vue", () => {
         expect(cells[1].text()).toBe("TOKEN MINT")
         expect(cells[3].text()).toBe("Scheduled")
         expect(cells[4].text()).toBe("0")
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
     it("Should list transactions as unrelated", async () => {
@@ -153,5 +159,8 @@ describe("TransactionByIdTable.vue", () => {
         expect(cells[1].text()).toBe("CONTRACT DELETE")
         expect(cells[3].text()).toBe("")
         expect(cells[4].text()).toBe("2")
+
+        wrapper.unmount()
+        await flushPromises()
     });
 });

--- a/tests/unit/transaction/Transactions.spec.ts
+++ b/tests/unit/transaction/Transactions.spec.ts
@@ -91,6 +91,9 @@ describe("Transactions.vue", () => {
             "123423\n\n" +
             "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC"
         )
+
+        wrapper.unmount()
+        await flushPromises()
     });
 
 });

--- a/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
@@ -52,6 +52,9 @@ describe("NftTransferGraph.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe("NFT TransfersNone")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Two tokens, Transfer", async () => {
@@ -182,6 +185,9 @@ describe("NftTransferGraph.vue", () => {
             "0.0.748383Ħ Frens Kingdom #604\n\n" +
             "0.0.100")
         expect(wrapper.text()).toMatch(SAMPLE_NONFUNGIBLE.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Mint, one token, two destinations", async() => {
@@ -224,6 +230,9 @@ describe("NftTransferGraph.vue", () => {
             "0.0.748383Ħ Frens Kingdom #601\n\n" +
             "0.0.101")
         expect(wrapper.text()).toMatch(SAMPLE_NONFUNGIBLE.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Burn, one token, one source", async() => {
@@ -261,6 +270,9 @@ describe("NftTransferGraph.vue", () => {
             "0.0.748383Ħ Frens Kingdom #604\n\n" +
             "BURN")
         expect(wrapper.text()).toMatch(SAMPLE_NONFUNGIBLE.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Burn, one token, two sources", async() => {
@@ -303,6 +315,9 @@ describe("NftTransferGraph.vue", () => {
             "0.0.748383Ħ Frens Kingdom #601\n\n" +
             "BURN")
         expect(wrapper.text()).toMatch(SAMPLE_NONFUNGIBLE.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 })
 

--- a/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
@@ -55,6 +55,9 @@ describe("TokenTransferGraphC.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe("")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     //
@@ -88,6 +91,9 @@ describe("TokenTransferGraphC.vue", () => {
         expect(wrapper.text()).toBe("MINT\n\n" +
             "1023423\n\n" +
             "0.0.200")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, single source, single dest", async () => {
@@ -119,6 +125,9 @@ describe("TokenTransferGraphC.vue", () => {
             "0.0.100\n\n" +
             "1023423\n\n" +
             "0.0.200")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, single source, two dest", async () => {
@@ -152,6 +161,9 @@ describe("TokenTransferGraphC.vue", () => {
             "1023423\n\n" +
             "0.0.200\n\n\n\n" +
             "0.0.201")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, two sources, zero dest", async () => {
@@ -182,6 +194,9 @@ describe("TokenTransferGraphC.vue", () => {
         expect(wrapper.text()).toBe("0.0.100\n\n" +
             "1023423\n\n" +
             "BURN0.0.101")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, two sources, single dest", async () => {
@@ -214,6 +229,9 @@ describe("TokenTransferGraphC.vue", () => {
             "0.0.100\n\n" +
             "1023423\n\n" +
             "0.0.2000.0.101")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, two sources, two dest", async () => {
@@ -248,6 +266,9 @@ describe("TokenTransferGraphC.vue", () => {
             "1023423\n\n" +
             "0.0.2000.0.101\n\n\n\n" +
             "0.0.201")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
 
@@ -291,6 +312,9 @@ describe("TokenTransferGraphC.vue", () => {
             "0.0.2010.0.100\n\n" +
             "0.0623423 DUDE\n\n" +
             "0.0.200")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
 })

--- a/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
@@ -53,6 +53,9 @@ describe("TokenTransferGraphF.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe("Token TransfersNone")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     //
@@ -87,6 +90,9 @@ describe("TokenTransferGraphF.vue", () => {
             "Token TransfersAccountToken AmountAccountToken AmountMINT-1023423\n\n" +
             "0.0.2001023423")
         expect(wrapper.text()).toMatch(SAMPLE_TOKEN.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, single source, single dest", async () => {
@@ -139,6 +145,9 @@ describe("TokenTransferGraphF.vue", () => {
             "Token TransfersAccountToken AmountAccountToken Amount0.0.100-10\n\n" +
             "0.0.20010")
         expect(wrapper2.text()).not.toMatch(SAMPLE_TOKEN.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, single source, two dest", async () => {
@@ -172,6 +181,9 @@ describe("TokenTransferGraphF.vue", () => {
             "0.0.200223423Transfer\n\n" +
             "0.0.201823423Transfer")
         expect(wrapper.text()).toMatch(SAMPLE_TOKEN.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, two sources, zero dest", async () => {
@@ -203,6 +215,9 @@ describe("TokenTransferGraphF.vue", () => {
             "Token TransfersAccountToken AmountAccountToken Amount0.0.100-723423\n\n" +
             "BURN10234230.0.101-323423")
         expect(wrapper.text()).toMatch(SAMPLE_TOKEN.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, two sources, single dest", async () => {
@@ -235,6 +250,9 @@ describe("TokenTransferGraphF.vue", () => {
             "Token TransfersAccountToken AmountAccountToken Amount0.0.100-723423\n\n" +
             "0.0.2001023423Transfer0.0.101-323423")
         expect(wrapper.text()).toMatch(SAMPLE_TOKEN.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
     test("Single token, two sources, two dest", async () => {
@@ -269,6 +287,9 @@ describe("TokenTransferGraphF.vue", () => {
             "0.0.200223423Transfer0.0.101-323423\n\n" +
             "0.0.201823423Transfer")
         expect(wrapper.text()).toMatch(SAMPLE_TOKEN.name)
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
 
@@ -310,6 +331,9 @@ describe("TokenTransferGraphF.vue", () => {
             "0.0.200223423Transfer0.0.101-323423\n\n" +
             "0.0.201823423Transfer0.0.100-0.0623423 DUDE\n\n" +
             "0.0.2000.0623423 DUDETransfer")
+
+        wrapper.unmount()
+        await flushPromises()
     })
 
 })


### PR DESCRIPTION
**Description**:
Change below add some `Wrapper.unmount()` calls in unit tests.
This should (hopefully) fix remaining memory overflows happening randomly during unit tests with coverage.

**Related issue(s)**:
None
