### PR TITLE
Force BlobValue to wrap.

### DIFF
--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -31,7 +31,7 @@
          :style="{'max-width': windowWidth-limitingFactor + 'px'}">{{ decodedValue }}</div>
     <div v-else-if="limitingFactor" class="h-is-one-line is-inline-block"
          :style="{'max-width': windowWidth-limitingFactor+200 + 'px'}">{{ decodedValue }}</div>
-    <div v-else>{{ decodedValue }}</div>
+    <div v-else style="word-break: break-word">{{ decodedValue }}</div>
   </template>
   <span v-else-if="showNone && !initialLoading" class="has-text-grey">None</span>
   <span v-else/>


### PR DESCRIPTION
**Description**:

1-line change to force BlobValue to wrap even in the absence of natural word break.

**Related issue(s)**:

Fixes #566

**Notes for reviewer**:

<img width="587" alt="Screenshot 2023-05-11 at 13 23 34" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/988cc716-33d4-4cc3-9b34-b49e77a2f642">
