### PR TITLE
Re-enabled CopyToHexaClipboard e2e test

### DIFF
--- a/tests/e2e/specs/CopyHexaToClipboard.cy.ts
+++ b/tests/e2e/specs/CopyHexaToClipboard.cy.ts
@@ -34,7 +34,7 @@ describe('Copy HexaValue to Clipboard', () => {
         }))
     })
 
-    it.skip('should copy the last transaction hash', () => {
+    it('should copy the last transaction hash', () => {
         cy.visit('testnet/transactions')
         cy.contains('Transactions')
 
@@ -55,7 +55,7 @@ describe('Copy HexaValue to Clipboard', () => {
             .click()
 
         cy.window().its('navigator.clipboard')
-            .invoke('readText').should('not.be.empty')
+            .then ((clipboard) => clipboard.readText())
             .then(($txt) => {
                 // cy.log($txt)
                 cy.get('#transactionHashValue').should(($hash) => {


### PR DESCRIPTION
**Description**:

Changes below adapt and re-enable `CopyToHexaClipboard` e2e test.
This one was temporarily disabled when migrating to Cypress 12.


**Related issue(s)**:

None

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
