### PR TITLE
00535 Enhance EthereumTransaction list to show inner sender

### DIFF
--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -51,14 +51,14 @@
       <TransactionLabel v-bind:transaction-id="props.row.transaction_id" v-bind:result="props.row.result"/>
     </o-table-column>
 
-    <o-table-column v-if="showingEthereumTransactions" v-slot="props" field="sender" label="Sender">
-      <InnerSenderEVMAddress :transaction-id="props.row.transaction_id"/>
-    </o-table-column>
-
     <o-table-column v-slot="props" field="name" label="Type">
       <div class="h-has-pill" style="display: inline-block">
         <div class="h-is-text-size-2">{{ makeTypeLabel(props.row.name) }}</div>
       </div>
+    </o-table-column>
+
+    <o-table-column v-if="showingEthereumTransactions" v-slot="props" field="sender" label="Sender">
+      <InnerSenderEVMAddress :transaction-id="props.row.transaction_id"/>
     </o-table-column>
 
     <o-table-column v-slot="props" label="Content">

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -51,6 +51,10 @@
       <TransactionLabel v-bind:transaction-id="props.row.transaction_id" v-bind:result="props.row.result"/>
     </o-table-column>
 
+    <o-table-column v-if="showingEthereumTransactions" v-slot="props" field="sender" label="Sender">
+      <InnerSenderEVMAddress :transaction-id="props.row.transaction_id"/>
+    </o-table-column>
+
     <o-table-column v-slot="props" field="name" label="Type">
       <div class="h-has-pill" style="display: inline-block">
         <div class="h-is-text-size-2">{{ makeTypeLabel(props.row.name) }}</div>
@@ -76,8 +80,8 @@
 
 <script lang="ts">
 
-import {ComputedRef, defineComponent, inject, PropType, Ref} from "vue";
-import {Transaction} from "@/schemas/HederaSchemas";
+import {computed, ComputedRef, defineComponent, inject, PropType, Ref} from "vue";
+import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
@@ -86,11 +90,12 @@ import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
 import {TransactionTableControllerXL} from "@/components/transaction/TransactionTableControllerXL";
 import EmptyTable from "@/components/EmptyTable.vue";
+import InnerSenderEVMAddress from "@/components/values/InnerSenderEVMAddress.vue";
 
 export default defineComponent({
   name: "TransactionTable",
 
-  components: {TransactionSummary, TimestampValue, TransactionLabel, EmptyTable },
+  components: {InnerSenderEVMAddress, TransactionSummary, TimestampValue, TransactionLabel, EmptyTable},
 
   props: {
     narrowed: Boolean,
@@ -103,6 +108,10 @@ export default defineComponent({
   setup(props) {
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
+
+    const showingEthereumTransactions = computed(() => {
+      return props.controller.transactionType.value === TransactionType.ETHEREUMTRANSACTION
+    })
 
     const handleClick = (t: Transaction) => {
       routeManager.routeToTransaction(t)
@@ -117,6 +126,7 @@ export default defineComponent({
       currentPage: props.controller.currentPage as Ref<number>,
       onPageChange: props.controller.onPageChange,
       perPage: props.controller.pageSize as Ref<number>,
+      showingEthereumTransactions,
       handleClick,
       makeTypeLabel,
       ORUGA_MOBILE_BREAKPOINT,

--- a/src/components/values/AliasValue.vue
+++ b/src/components/values/AliasValue.vue
@@ -23,11 +23,23 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div class="should-wrap">
-
-    <EVMAddress :address="hexValue" :show-id="false"/>
-
+  <div v-if="hexValue" class="should-wrap">
+    <div :class="{'is-flex': isSmallScreen}" class="is-inline-block h-is-text-size-3 is-family-monospace"
+         style="line-height: 20px">
+      <div class="shy-scope mr-1" style="display: inline-block; position: relative;">
+        <span class="has-text-grey">0x</span>
+        <span>{{ hexValue }}</span>
+        <div id="shyCopyButton" class="shy" style="position: absolute; left: 0; top: 0; width: 100%; height: 100%">
+          <div style="position: absolute; left: 0; top: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.50)"></div>
+          <div style="position: absolute; display: inline-block; left: 50%; top: 50%; transform: translate(-50%, -50%);">
+            <button class="button is-dark h-is-text-size-3" @click.stop="copyToClipboard">Copy to Clipboard</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
+  <div v-else-if="initialLoading"/>
+  <div v-else class="has-text-grey">None</div>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -36,29 +48,41 @@
 
 <script lang="ts">
 
-import {computed, defineComponent} from "vue";
+import {computed, defineComponent, inject, ref} from "vue";
 import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
-import EVMAddress from "@/components/values/EVMAddress.vue";
+import {initialLoadingKey} from "@/AppKeys";
 
-export default defineComponent( {
+export default defineComponent({
   name: "AliasValue",
-  components: {EVMAddress},
   props: {
     aliasValue: String,
   },
   setup(props) {
+    const initialLoading = inject(initialLoadingKey, ref(false))
+    const isSmallScreen = inject('isSmallScreen', ref(false))
+
     const hexValue = computed(() => {
       let result
       if (props.aliasValue) {
         const alias = base32ToAlias(props.aliasValue)
-        result = alias ? "0x" + byteToHex(alias) : null
+        result = alias ? byteToHex(alias) : null
       } else {
         result = null
       }
       return result
     })
+
+    const copyToClipboard = (): void => {
+      if (hexValue.value) {
+        navigator.clipboard.writeText(hexValue.value)
+      }
+    }
+
     return {
-      hexValue
+      initialLoading,
+      isSmallScreen,
+      hexValue,
+      copyToClipboard
     }
   }
 })
@@ -71,5 +95,12 @@ export default defineComponent( {
 
 <style scoped>
 
+.shy {
+  display: none
+}
+
+.shy-scope:hover > .shy {
+  display: block;
+}
 
 </style>

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -50,7 +50,8 @@
     <div v-if="showType" class="h-is-extra-text h-is-text-size-2">{{ entityType }}</div>
   </div>
   <div v-else-if="initialLoading"/>
-  <div v-else class="has-text-grey">None</div>
+  <div v-else-if="showNone" class="has-text-grey">None</div>
+  <div v-else></div>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -93,7 +94,11 @@ export default defineComponent({
     enableCopy: {
       type: Boolean,
       default: true
-    }
+    },
+    showNone: {
+      type: Boolean,
+      default: true
+    },
   },
 
   setup(props) {

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -26,7 +26,7 @@
   <div v-if="address">
     <div :class="{'is-flex': isSmallScreen, 'h-is-text-size-3': !hasCustomFont, 'is-family-monospace': !hasCustomFont}"
          class="is-inline-block" style="line-height: 20px">
-      <div class="shy-scope" style="display: inline-block; position: relative;">
+      <div class="shy-scope mr-1" style="display: inline-block; position: relative;">
         <span class="has-text-grey">{{ nonSignificantPart }}</span>
         <span>{{ significantPart }}</span>
         <div v-if="address" id="shyCopyButton" class="shy"
@@ -40,7 +40,7 @@
         </div>
       </div>
       <span v-if="entityId && showId">
-        <span class="ml-1">(</span>
+        <span>(</span>
         <router-link v-if="isContract" :to="{name: 'ContractDetails', params: {contractId: entityId}}">{{ entityId }}</router-link>
         <router-link v-else-if="isAccount" :to="{name: 'AccountDetails', params: {accountId: entityId}}">{{ entityId }}</router-link>
         <span v-else>{{ entityId }}</span>

--- a/src/components/values/InnerSenderEVMAddress.vue
+++ b/src/components/values/InnerSenderEVMAddress.vue
@@ -1,0 +1,70 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <EVMAddress :address="senderAddress" :compact="false" :show-id="true" :show-none="false"/>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref} from "vue";
+import EVMAddress from "@/components/values/EVMAddress.vue";
+import {ContractResultByTransactionIdCache} from "@/utils/cache/ContractResultByTransactionIdCache";
+
+export default defineComponent({
+  name: "InnerSenderEVMAddress",
+  components: {EVMAddress},
+  props: {
+    transactionId: String,
+  },
+
+  setup(props) {
+    const isSmallScreen = inject('isSmallScreen', ref(false))
+
+    const contractResultLookup = ContractResultByTransactionIdCache.instance.makeLookup(computed(() => props.transactionId ?? null))
+    onMounted(() => contractResultLookup.mount())
+    onBeforeUnmount(() => contractResultLookup.unmount())
+
+    const senderAddress = computed(() => {
+      return contractResultLookup.entity.value?.from ?? null
+    })
+
+    return {
+      isSmallScreen,
+      senderAddress
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -19,6 +19,7 @@
  */
 
 import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
+import {TransactionID} from "@/utils/TransactionID";
 
 export function makeSummaryLabel(row: Transaction): string {
     let result: string
@@ -305,18 +306,11 @@ export function makeTypeLabel(type: TransactionType | undefined): string {
     return result.toUpperCase()
 }
 
-export function makeOperatorAccountLabel(row: Transaction): string {
-
-    //
-    // Derived from transaction id
-    //      account-timestamp-fraction
-    //      0.0.3107590-1639489392-138251957
-
-    let result: string
-    const transactionId = row.transaction_id;
+export function makeOperatorAccountLabel(transaction: Transaction): string {
+    let result: string | null
+    const transactionId = transaction.transaction_id;
     if (transactionId != null) {
-        const index = transactionId.indexOf("-")
-        result = index != -1 ? transactionId.substring(0, index) : "?";
+        result = TransactionID.makePayerID(transactionId) ?? "?"
     } else {
         result = "?"
     }

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -41,6 +41,7 @@ import {BalanceCache} from "@/utils/cache/BalanceCache";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
 import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
 import {HbarPriceCache} from "@/utils/cache/HbarPriceCache";
+import {ContractResultByTransactionIdCache} from "@/utils/cache/ContractResultByTransactionIdCache";
 
 export class CacheUtils {
 
@@ -56,6 +57,7 @@ export class CacheUtils {
         ContractByIdCache.instance.clear()
         ContractByAddressCache.instance.clear()
         ContractResultByHashCache.instance.clear()
+        ContractResultByTransactionIdCache.instance.clear()
         HbarPriceCache.instance.clear()
         NetworkCache.instance.clear()
         StakeCache.instance.clear()

--- a/src/utils/cache/ContractResultByTransactionIdCache.ts
+++ b/src/utils/cache/ContractResultByTransactionIdCache.ts
@@ -1,0 +1,49 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityCache} from "@/utils/cache/base/EntityCache"
+import {ContractResultDetails} from "@/schemas/HederaSchemas";
+import axios from "axios";
+
+export class ContractResultByTransactionIdCache extends EntityCache<string, ContractResultDetails | null> {
+
+    public static readonly instance = new ContractResultByTransactionIdCache()
+
+    //
+    // Cache
+    //
+
+    protected async load(transactionId: string): Promise<ContractResultDetails | null> {
+        let result: Promise<ContractResultDetails | null>
+        try {
+            const response = await axios.get<ContractResultDetails>("api/v1/contracts/results/" + transactionId)
+            result = Promise.resolve(response.data)
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status == 404) {
+                result = Promise.resolve(null)
+            } else {
+                throw error
+            }
+        }
+        return result
+    }
+
+}
+

--- a/tests/unit/utils/cache/ContractResultByTransactionIdCache.spec.ts
+++ b/tests/unit/utils/cache/ContractResultByTransactionIdCache.spec.ts
@@ -1,0 +1,56 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {SAMPLE_CONTRACT_RESULT_DETAILS,} from "../../Mocks";
+import {flushPromises} from "@vue/test-utils";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {ContractResultByTransactionIdCache} from "@/utils/cache/ContractResultByTransactionIdCache";
+
+describe("ContractResultByTransactionIdCache", () => {
+
+    test("ContractResultByTransactionIdCache", async () => {
+
+        expect(ContractResultByTransactionIdCache.instance.isEmpty()).toBeTruthy()
+
+        const mock = new MockAdapter(axios);
+
+        const transactionId = "0.0.2307776@1683720888.979207121"
+        const matcher1 = "/api/v1/contracts/results/" + transactionId
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS);
+
+        // 1) First lookup() triggers http requests
+        const contractResult = await ContractResultByTransactionIdCache.instance.lookup(transactionId)
+        expect(contractResult).toStrictEqual(SAMPLE_CONTRACT_RESULT_DETAILS)
+        expect(mock.history.get.length).toBe(1)
+
+        // 2) Second lookup() triggers no http requests
+        mock.resetHistory()
+        const contractResult2 = await ContractResultByTransactionIdCache.instance.lookup(transactionId)
+        await flushPromises()
+        expect(contractResult2).toStrictEqual(SAMPLE_CONTRACT_RESULT_DETAILS)
+        expect(mock.history.get.length).toBe(0)
+
+        // Checks that ContractResultByTransactionIdCache has been populated
+        expect(ContractResultByTransactionIdCache.instance.contains(transactionId))
+    })
+})


### PR DESCRIPTION
**Description**:

With the following changes:
- a new _**Sender**_ column is added to the TransactionTable when filtering _ETHEREUM TRANSACTION_ type, to display the inner sender of the original transaction, as reported by the from field of the corresponding contract result.

**Related issue(s)**:

Fixes #535

**Notes for reviewer**:

- This is deployed on the staging server.
- EVMAddress is now able to get the corresponding sender Account to retrieve its entity ID if it is not provided and if the address is not a long zero form from which we can derive the ID.
- EVMAdress (and InnerSenderEVMAddress) deserve their own unit tests and do not have one yet. This will be addressed in another PR.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
