### PR TITLE
00497 revisit compact transfer diagram

### DIFF
--- a/src/components/transfer_graphs/HbarTransferGraphC.vue
+++ b/src/components/transfer_graphs/HbarTransferGraphC.vue
@@ -48,7 +48,7 @@
       <!-- #2 : hbar amount -->
       <div class="justify-end">
         <HbarAmount v-if="i === 1"
-                    v-bind:amount="hbarTransferLayout.netAmount"/>
+                    v-bind:amount="hbarTransferLayout.destinationAmount"/>
       </div>
 
       <!-- #3 : arrow -->

--- a/src/components/transfer_graphs/layout/HbarTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/HbarTransferLayout.ts
@@ -19,7 +19,7 @@
  */
 
 import {compareTransferByAccount, NetworkNode, Transaction, Transfer} from "@/schemas/HederaSchemas";
-import {makeOperatorDescription} from "@/schemas/HederaUtils";
+import {isFeeTransfer, makeOperatorDescription} from "@/schemas/HederaUtils";
 import {computeNetAmount} from "@/utils/TransactionTools";
 
 export class HbarTransferLayout {
@@ -54,13 +54,13 @@ export class HbarTransferLayout {
             positiveTransfers.sort(compareTransferByAccount)
 
             for (const t of negativeTransfers) {
-                const payload = t.account === null || t.amount < 0 || makeOperatorDescription(t.account, this.nodes) === null
-                this.sources.push(new HbarTransferRow(t, null, payload))
+                const isFee = isFeeTransfer(t, this.nodes)
+                this.sources.push(new HbarTransferRow(t, null, !isFee))
             }
             for (const t of positiveTransfers) {
-                const operator = t.account !== null ? makeOperatorDescription(t.account, this.nodes) : null
-                const payload = t.account === null || t.amount < 0 || operator === null
-                this.destinations.push(new HbarTransferRow(t, operator ?? "Transfer", payload))
+                const isFee = isFeeTransfer(t, this.nodes)
+                const operator = t.account ? makeOperatorDescription(t.account, this.nodes) : null
+                this.destinations.push(new HbarTransferRow(t, operator ?? "Transfer", !isFee))
             }
         }
 

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {AccountInfo, KeyType, NetworkNode, TokenInfo} from "@/schemas/HederaSchemas";
+import {AccountInfo, KeyType, NetworkNode, TokenInfo, Transfer} from "@/schemas/HederaSchemas";
 import {EntityID} from "@/utils/EntityID";
 import {ethers} from "ethers";
 
@@ -110,6 +110,12 @@ export function makeOperatorDescription(accountId: string, nodes: NetworkNode[])
         result = node !== null ? makeNodeDescription(node) : null
     }
     return result
+}
+
+export function isFeeTransfer(t: Transfer, nodes: NetworkNode[]): boolean {
+    return t.account !== null
+        && t.amount > 0
+        && makeOperatorDescription(t.account, nodes) !== null
 }
 
 const errorStringSelector = '0x08c379a0'

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -55,7 +55,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(0)
+        expect(fullLayout.destinationAmount).toBe(10)
         expect(fullLayout.rowCount).toBe(2)
         expect(fullLayout.sources.length).toBe(1)
         expect(fullLayout.destinations.length).toBe(2)
@@ -85,7 +85,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(0)
+        expect(compactLayout.destinationAmount).toBe(0)
         expect(compactLayout.rowCount).toBe(0)
         expect(compactLayout.sources.length).toBe(0)
         expect(compactLayout.destinations.length).toBe(0)
@@ -111,7 +111,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(90)
+        expect(fullLayout.destinationAmount).toBe(100)
         expect(fullLayout.rowCount).toBe(3)
         expect(fullLayout.sources.length).toBe(1)
         expect(fullLayout.destinations.length).toBe(3)
@@ -147,7 +147,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(90)
+        expect(compactLayout.destinationAmount).toBe(90)
         expect(compactLayout.rowCount).toBe(1)
         expect(compactLayout.sources.length).toBe(1)
         expect(compactLayout.destinations.length).toBe(1)
@@ -185,7 +185,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(90)
+        expect(fullLayout.destinationAmount).toBe(100)
         expect(fullLayout.rowCount).toBe(4)
         expect(fullLayout.sources.length).toBe(1)
         expect(fullLayout.destinations.length).toBe(4)
@@ -227,7 +227,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(90)
+        expect(compactLayout.destinationAmount).toBe(90)
         expect(compactLayout.rowCount).toBe(2)
         expect(compactLayout.sources.length).toBe(1)
         expect(compactLayout.destinations.length).toBe(2)
@@ -275,7 +275,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(0)
+        expect(fullLayout.destinationAmount).toBe(10)
         expect(fullLayout.rowCount).toBe(2)
         expect(fullLayout.sources.length).toBe(2)
         expect(fullLayout.destinations.length).toBe(2)
@@ -312,7 +312,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(0)
+        expect(compactLayout.destinationAmount).toBe(0)
         expect(compactLayout.rowCount).toBe(0)
         expect(compactLayout.sources.length).toBe(0)
         expect(compactLayout.destinations.length).toBe(0)
@@ -339,7 +339,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(90)
+        expect(fullLayout.destinationAmount).toBe(100)
         expect(fullLayout.rowCount).toBe(3)
         expect(fullLayout.sources.length).toBe(2)
         expect(fullLayout.destinations.length).toBe(3)
@@ -381,7 +381,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(90)
+        expect(compactLayout.destinationAmount).toBe(90)
         expect(compactLayout.rowCount).toBe(2)
         expect(compactLayout.sources.length).toBe(2)
         expect(compactLayout.destinations.length).toBe(1)
@@ -426,7 +426,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(90)
+        expect(fullLayout.destinationAmount).toBe(100)
         expect(fullLayout.rowCount).toBe(4)
         expect(fullLayout.sources.length).toBe(2)
         expect(fullLayout.destinations.length).toBe(4)
@@ -475,7 +475,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(90)
+        expect(compactLayout.destinationAmount).toBe(90)
         expect(compactLayout.rowCount).toBe(2)
         expect(compactLayout.sources.length).toBe(2)
         expect(compactLayout.destinations.length).toBe(2)
@@ -527,7 +527,7 @@ describe("HbarTransferLayout.vue", () => {
         const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
 
         expect(fullLayout.transaction).toBe(transaction)
-        expect(fullLayout.netAmount).toBe(2)
+        expect(fullLayout.destinationAmount).toBe(10)
         expect(fullLayout.rowCount).toBe(3)
         expect(fullLayout.sources.length).toBe(1)
         expect(fullLayout.destinations.length).toBe(3)
@@ -563,7 +563,7 @@ describe("HbarTransferLayout.vue", () => {
         const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
 
         expect(compactLayout.transaction).toBe(transaction)
-        expect(compactLayout.netAmount).toBe(2)
+        expect(compactLayout.destinationAmount).toBe(2)
         expect(compactLayout.rowCount).toBe(1)
         expect(compactLayout.sources.length).toBe(1)
         expect(compactLayout.destinations.length).toBe(1)


### PR DESCRIPTION
**Description**:

Changes below implement suggestion proposed in #497.

To make compact version of hbar transfer diagram, explorer now applies the following logic.
It excludes Transfer objects satisfying the following conditions:
- `Transfer.amount` > 0
- `Transfer.account` is an operator account (ie `0.0.98` or a comity member account)

**Related issue(s)**:

Fixes #497

**Notes for reviewer**:

Look at the following page:
https://hashscan.io/mainnet/account/0.0.55954?p1=1&k1=1679579112.950568003&p2=1

Without the fix, this [page](https://hashscan.io/mainnet/account/0.0.55954?p1=1&k1=1679579112.950568003&p2=1) looks like this (rows 3 and 6 do not show transfer diagram in `Content` column):
![](https://user-images.githubusercontent.com/91124272/227252679-256df4d5-c88a-43c2-916b-937a50ba3982.png)

With the fix, rows 3 and 6 now have show a transfer diagram:
<img width="1194" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/12e9a9ec-62b1-4d28-bfd3-c4c288d21ee1">

Note: rows 1 and 4 do not show transfer diagram because these contain only fee transfers (so compact diagram is reduced to void).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
