### PR TITLE
Fixes 'JavaScript heap out of memory' issues with Github CI/CD

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serve:https": "export NODE_OPTIONS=--openssl-legacy-provider && npm run install:branding && vue-cli-service serve --https",
     "serve:prod": "export NODE_OPTIONS=--openssl-legacy-provider && npm run install:branding && vue-cli-service serve --mode production --port 38920",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider && npm run install:branding && vue-cli-service build",
-    "test:unit": "export NODE_OPTIONS=--openssl-legacy-provider && npm run install:branding && vue-cli-service test:unit --runInBand",
+    "test:unit": "export NODE_OPTIONS='--openssl-legacy-provider --max_old_space_size=4096' && npm run install:branding && vue-cli-service test:unit --runInBand",
     "cover:unit": "export NODE_OPTIONS=--openssl-legacy-provider && npm run install:branding && vue-cli-service test:unit --runInBand --collectCoverage",
     "test:e2e": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service test:e2e --url http://localhost:38920",
     "test:e2e:headless": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service test:e2e --headless --browser chrome --url http://localhost:38920",


### PR DESCRIPTION
**Description**:

In some cases, CI/CD fails to complete properly because of memory issues with NodeJS. For example [here](https://github.com/hashgraph/hedera-mirror-node-explorer/actions/runs/5022631216/jobs/9006323434):

```
<--- Last few GCs --->

[3543:0x56a2ae0]   120384 ms: Mark-Compact 4042.3 (4137.9) -> 4030.0 (4141.9) MB, 1999.0 / 0.0 ms  (average mu = 0.520, current mu = 0.039) allocation failure; scavenge might not succeed
[3543:0x56a2ae0]   123710 ms: Mark-Compact 4046.6 (4142.1) -> 4034.3 (4146.1) MB, 3250.0 / 0.0 ms  (average mu = 0.282, current mu = 0.023) allocation failure; scavenge might not succeed

<--- JS stacktrace --->
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

This PR sets a maximum heap size before freeing the memory, so that error can be avoided leveraging the garbage collector.

**Related issue(s)**:

See this [thread](https://github.com/hashgraph/hedera-mirror-node-explorer/pull/604#issuecomment-1554339488).

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
