### PR TITLE
00609 Output Result field missing in Call Trace section

### DIFF
--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -29,13 +29,13 @@
         <Property id="actionDetailFrom" :custom-nb-col-class="propertySizeClass">
           <template v-slot:name>From</template>
           <template v-slot:value>
-            <EVMAddress :id="action.caller" :address="action.from" :entity-type="action.caller_type" :show-type="true"/>
+            <EVMAddress :id="action?.caller" :address="action?.from" :entity-type="action?.caller_type" :show-type="true"/>
           </template>
         </Property>
         <Property id="actionDetailTo" :custom-nb-col-class="propertySizeClass">
           <template v-slot:name>To</template>
           <template v-slot:value>
-            <EVMAddress :id="action.recipient" :address="action.to" :entity-type="action.recipient_type"
+            <EVMAddress :id="action?.recipient" :address="action?.to" :entity-type="action?.recipient_type"
                         :show-type="true"/>
           </template>
         </Property>
@@ -50,13 +50,13 @@
         <Property id="actionDetailGasLimit" :custom-nb-col-class="propertySizeClass">
           <template v-slot:name>Gas Limit</template>
           <template v-slot:value>
-            <PlainAmount :amount="action.gas"/>
+            <PlainAmount :amount="action?.gas"/>
           </template>
         </Property>
         <Property id="actionDetailGasUsed" :custom-nb-col-class="propertySizeClass">
           <template v-slot:name>Gas Used</template>
           <template v-slot:value>
-            <PlainAmount :amount="action.gas_used"/>
+            <PlainAmount :amount="action?.gas_used"/>
           </template>
         </Property>
         <Property id="actionDetailError" :custom-nb-col-class="propertySizeClass">
@@ -85,13 +85,13 @@
       <Property id="actionDetailFrom" :custom-nb-col-class="propertySizeClass">
         <template v-slot:name>From</template>
         <template v-slot:value>
-          <EVMAddress :id="action.caller" :address="action.from" :entity-type="action.caller_type" :show-type="true"/>
+          <EVMAddress :id="action?.caller" :address="action?.from" :entity-type="action?.caller_type" :show-type="true"/>
         </template>
       </Property>
       <Property id="actionDetailTo" :custom-nb-col-class="propertySizeClass">
         <template v-slot:name>To</template>
         <template v-slot:value>
-          <EVMAddress :id="action.recipient" :address="action.to" :entity-type="action.recipient_type"
+          <EVMAddress :id="action?.recipient" :address="action?.to" :entity-type="action?.recipient_type"
                       :show-type="true"/>
         </template>
       </Property>
@@ -104,13 +104,13 @@
       <Property id="actionDetailGasUsed" :custom-nb-col-class="propertySizeClass">
         <template v-slot:name>Gas Used</template>
         <template v-slot:value>
-          <PlainAmount :amount="action.gas_used"/>
+          <PlainAmount :amount="action?.gas_used"/>
         </template>
       </Property>
       <Property id="actionDetailError" :custom-nb-col-class="propertySizeClass">
         <template v-slot:name>Error Message</template>
         <template v-slot:value>
-          <StringValue :string-value="errorMessage"/>
+          <StringValue :string-value="errorMessage ?? undefined"/>
         </template>
       </Property>
       <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass"/>

--- a/src/utils/analyzer/ContractActionAnalyzer.ts
+++ b/src/utils/analyzer/ContractActionAnalyzer.ts
@@ -1,0 +1,75 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, Ref} from "vue";
+import {ContractAction, ResultDataType} from "@/schemas/HederaSchemas";
+import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
+import {decodeSolidityErrorMessage} from "@/schemas/HederaUtils";
+
+export class ContractActionAnalyzer {
+
+    public readonly action: Ref<ContractAction|undefined>
+    public readonly functionCallAnalyzer: FunctionCallAnalyzer
+
+    //
+    // Public
+    //
+
+    public constructor(action: Ref<ContractAction|undefined>) {
+        this.action = action
+        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.contractId)
+    }
+
+    public mount(): void {
+        this.functionCallAnalyzer.mount()
+    }
+
+    public unmount(): void {
+        this.functionCallAnalyzer.unmount()
+    }
+
+    public readonly errorMessage = computed(() => {
+        let result: string|null
+        if (this.action?.value?.result_data_type != ResultDataType.OUTPUT) {
+            result = decodeSolidityErrorMessage(this.action?.value?.result_data ?? null)
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    //
+    // Private
+    //
+
+    private readonly input = computed(() => this.action.value?.input ?? null)
+
+    private readonly output = computed(() => {
+        let result: string|null
+        if (this.action?.value?.result_data_type == ResultDataType.OUTPUT) {
+            result = this.action?.value?.result_data ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    private readonly contractId = computed(() => this.action.value?.recipient ?? null)
+}


### PR DESCRIPTION
**Description**:

Changes below fix #609.
They also include some refactoring : `ContractActionDetails` vue now delegates some logic to `ContractActionAnalyzer` class.
 
**Related issue(s)**:

Fixes #609

**Notes for reviewer**:

Use transaction [0.0.1093@1684933051.154776111](https://hashscan.io/previewnet/transaction/1684933063.077913506) (on `previewnet`) for testing.
