### PR TITLE
00613 Add logic to decode Contract and Action errors

### DIFF
--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -39,12 +39,6 @@
                         :show-type="true"/>
           </template>
         </Property>
-        <Property v-if="signature" id="function" :custom-nb-col-class="propertySizeClass">
-          <template v-slot:name>Function</template>
-          <template v-slot:value>
-            <SignatureValue :analyzer="functionCallAnalyzer"/>
-          </template>
-        </Property>
       </div>
       <div class="column h-has-column-dashed-separator">
         <Property id="actionDetailGasLimit" :custom-nb-col-class="propertySizeClass">
@@ -59,12 +53,7 @@
             <PlainAmount :amount="action?.gas_used"/>
           </template>
         </Property>
-        <Property id="actionDetailError" :custom-nb-col-class="propertySizeClass">
-          <template v-slot:name>Error Message</template>
-          <template v-slot:value>
-            <StringValue :string-value="errorMessage"/>
-          </template>
-        </Property>
+      <FunctionError :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
       </div>
     </div>
 
@@ -72,10 +61,10 @@
 
     <div class="columns pt-0 mt-0 pb-2">
       <div class="column">
-        <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass"/>
+        <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
       </div>
       <div class="column h-has-column-dashed-separator">
-        <FunctionResult :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass"/>
+        <FunctionResult :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
       </div>
     </div>
   </template>
@@ -95,26 +84,15 @@
                       :show-type="true"/>
         </template>
       </Property>
-      <Property v-if="signature" id="function" :custom-nb-col-class="propertySizeClass">
-        <template v-slot:name>Function</template>
-        <template v-slot:value>
-          <SignatureValue :analyzer="functionCallAnalyzer"/>
-        </template>
-      </Property>
       <Property id="actionDetailGasUsed" :custom-nb-col-class="propertySizeClass">
         <template v-slot:name>Gas Used</template>
         <template v-slot:value>
           <PlainAmount :amount="action?.gas_used"/>
         </template>
       </Property>
-      <Property id="actionDetailError" :custom-nb-col-class="propertySizeClass">
-        <template v-slot:name>Error Message</template>
-        <template v-slot:value>
-          <StringValue :string-value="errorMessage ?? undefined"/>
-        </template>
-      </Property>
-      <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass"/>
-      <FunctionResult :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass"/>
+      <FunctionError :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
+      <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
+      <FunctionResult :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
     </div>
   </template>
 </template>
@@ -133,20 +111,20 @@ import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType,
 import {ContractAction} from "@/schemas/HederaSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
 import Property from "@/components/Property.vue";
-import StringValue from "@/components/values/StringValue.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
-import SignatureValue from "@/components/values/SignatureValue.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import FunctionInput from "@/components/values/FunctionInput.vue";
 import FunctionResult from "@/components/values/FunctionResult.vue";
 import {ContractActionAnalyzer} from "@/utils/analyzer/ContractActionAnalyzer";
+import FunctionError from "@/components/values/FunctionError.vue";
 
 export default defineComponent({
   name: 'ContractActionDetails',
 
   components: {
+    FunctionError,
     FunctionResult,
-    FunctionInput, EVMAddress, SignatureValue, PlainAmount, StringValue, Property
+    FunctionInput, EVMAddress, PlainAmount, Property
   },
 
   props: {

--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -41,12 +41,6 @@
             <StringValue :string-value="contractResult?.result"/>
           </template>
         </Property>
-        <Property id="errorMessage">
-          <template v-slot:name>Error Message</template>
-          <template v-slot:value>
-            <StringValue :string-value ="errorMessage"/>
-          </template>
-        </Property>
         <Property id="from">
           <template v-slot:name>From</template>
           <template v-slot:value>
@@ -60,14 +54,9 @@
           </template>
         </Property>
 
-        <Property v-if="signature" id="function">
-          <template v-slot:name>Function</template>
-          <template v-slot:value>
-            <SignatureValue :analyzer="analyzer" />
-          </template>
-        </Property>
         <FunctionInput :analyzer="analyzer"/>
         <FunctionResult :analyzer="analyzer"/>
+        <FunctionError :analyzer="analyzer"/>
       </template>
 
       <template v-slot:rightContent>
@@ -140,14 +129,14 @@ import ContractResultLogs from "@/components/contract/ContractResultLogs.vue";
 import {ContractResultAnalyzer} from "@/utils/analyzer/ContractResultAnalyzer";
 import FunctionInput from "@/components/values/FunctionInput.vue";
 import FunctionResult from "@/components/values/FunctionResult.vue";
-import SignatureValue from "@/components/values/SignatureValue.vue";
+import FunctionError from "@/components/values/FunctionError.vue";
 
 export default defineComponent({
 
   name: 'ContractResult',
 
   components: {
-    SignatureValue,
+    FunctionError,
     FunctionResult,
     FunctionInput,
     ContractResultLogs,

--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -33,7 +33,7 @@
             <Property :custom-nb-col-class="customNbColClass" id="errorFunction">
                 <template v-slot:name>Signature</template>
                 <template v-slot:value>
-                    <HexaValue :byte-string="errorHash" show-none/>
+                    <HexaValue :byte-string="errorHash" :show-none="true"/>
                     <div class="h-is-extra-text h-is-text-size-3 should-wrap">{{ errorSignature }}</div>
                 </template>
             </Property>

--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -1,0 +1,118 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+    <template v-if="errorSignature">
+
+        <div v-if="error">
+
+            <div class="h-is-tertiary-text my-2">Error</div>
+
+            <Property :custom-nb-col-class="customNbColClass" id="errorFunction">
+                <template v-slot:name>Signature</template>
+                <template v-slot:value>
+                    <HexaValue :byte-string="errorHash" show-none/>
+                    <div class="h-is-extra-text h-is-text-size-3 should-wrap">{{ errorSignature }}</div>
+                </template>
+            </Property>
+
+        </div><template v-else>
+
+            <Property :custom-nb-col-class="customNbColClass" id="functionInput">
+                <template v-slot:name>Error Message</template>
+                <template v-slot:value>
+                    <HexaValue :show-none="true"/>
+                </template>
+            </Property>
+
+        </template>
+
+    </template><template v-else>
+
+        <Property :custom-nb-col-class="customNbColClass" id="errorMessage">
+            <template v-slot:name>Error Message</template>
+            <template v-slot:value>
+                <StringValue v-if="decodedError" :string-value="decodedError"/>
+                <HexaValue v-else :byte-string="error" :show-none="true"/>
+            </template>
+        </Property>
+
+    </template>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, inject, PropType, ref} from 'vue';
+import {initialLoadingKey} from "@/AppKeys";
+import HexaValue from "@/components/values/HexaValue.vue";
+import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
+import Property from "@/components/Property.vue";
+import {decodeSolidityErrorMessage} from "@/schemas/HederaUtils";
+import StringValue from "@/components/values/StringValue.vue";
+
+export default defineComponent({
+    name: 'FunctionError',
+    components: {StringValue, Property, HexaValue},
+    props: {
+        analyzer: {
+            type: Object as PropType<FunctionCallAnalyzer>,
+            required: true
+        },
+        customNbColClass: String,
+        showNone: {
+            type: Boolean,
+            default: false
+        }
+    },
+
+    setup(props) {
+
+        const initialLoading = inject(initialLoadingKey, ref(false))
+        const decodedError = computed( () =>
+            props.analyzer.normalizedError.value != null ? decodeSolidityErrorMessage(props.analyzer.normalizedError.value) : null)
+
+        return {
+            error: props.analyzer.normalizedError,
+            errorSignature: props.analyzer.errorSignature,
+            errorHash: props.analyzer.errorHash,
+            errorInputs: props.analyzer.errorInputs,
+            decodedError,
+            initialLoading
+        }
+    }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -25,7 +25,15 @@
 <template>
 
   <div v-if="signature">
-    <div class="h-is-tertiary-text my-2">Arguments</div>
+
+    <div class="h-is-tertiary-text my-2">Input</div>
+
+    <Property :custom-nb-col-class="customNbColClass" id="function">
+      <template v-slot:name>Signature</template>
+        <template v-slot:value>
+          <SignatureValue :analyzer="analyzer"/>
+        </template>
+    </Property>
 
     <template v-for="arg in inputs" :key="arg.name">
       <Property :custom-nb-col-class="customNbColClass">
@@ -37,14 +45,14 @@
     </template>
 
   </div>
-  <div v-else>
+  <template v-else>
     <Property :custom-nb-col-class="customNbColClass" id="functionInput">
       <template v-slot:name>Input - Function & Args</template>
       <template v-slot:value>
         <HexaValue :byte-string="input" :show-none="true"/>
       </template>
     </Property>
-  </div>
+  </template>
 
 </template>
 
@@ -60,10 +68,11 @@ import HexaValue from "@/components/values/HexaValue.vue";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";
+import SignatureValue from "@/components/values/SignatureValue.vue";
 
 export default defineComponent({
   name: 'FunctionInput',
-  components: {FunctionValue, Property, HexaValue},
+  components: {SignatureValue, FunctionValue, Property, HexaValue},
   props: {
     analyzer: {
       type: Object as PropType<FunctionCallAnalyzer>,
@@ -76,7 +85,7 @@ export default defineComponent({
 
     const initialLoading = inject(initialLoadingKey, ref(false))
     return {
-      input: props.analyzer.input,
+      input: props.analyzer.normalizedInput,
       signature: props.analyzer.signature,
       functionHash: props.analyzer.functionHash,
       inputs: props.analyzer.inputs,

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -24,27 +24,42 @@
 
 <template>
 
-  <div v-if="signature">
-    <div class="h-is-tertiary-text my-2">Output Result</div>
+  <template v-if="signature">
 
-    <template v-for="result in outputs" :key="result.name">
-      <Property :custom-nb-col-class="customNbColClass">
-        <template v-slot:name>{{ result.name }}</template>
-        <template v-slot:value>
-          <FunctionValue :ntv="result"/>
-        </template>
-      </Property>
+    <template v-if="output">
+
+      <div v-if="outputs.length >= 1" class="h-is-tertiary-text my-2">Output</div>
+
+      <template v-for="result in outputs" :key="result.name">
+        <Property :custom-nb-col-class="customNbColClass">
+          <template v-slot:name>{{ result.name }}</template>
+          <template v-slot:value>
+            <FunctionValue :ntv="result"/>
+          </template>
+        </Property>
+      </template>
+
+    </template><template v-else-if="showNone">
+
+        <Property :custom-nb-col-class="customNbColClass" id="functionInput">
+            <template v-slot:name>Output Result</template>
+            <template v-slot:value>
+                <HexaValue :show-none="true"/>
+            </template>
+        </Property>
+
     </template>
 
-  </div>
-  <div v-else>
-    <Property :custom-nb-col-class="customNbColClass" id="FunctionResult">
-      <template v-slot:name>Output Result</template>
-      <template v-slot:value>
-        <HexaValue :byte-string="output" :show-none="true"/>
-      </template>
+  </template><template v-else>
+
+    <Property :custom-nb-col-class="customNbColClass" id="functionInput">
+        <template v-slot:name>Output Result</template>
+        <template v-slot:value>
+          <HexaValue :byte-string="output" :show-none="true"/>
+        </template>
     </Property>
-  </div>
+
+  </template>
 
 </template>
 
@@ -69,14 +84,18 @@ export default defineComponent({
       type: Object as PropType<FunctionCallAnalyzer>,
       required: true
     },
-    customNbColClass: String
+    customNbColClass: String,
+    showNone: {
+      type: Boolean,
+      default: false
+    }
   },
 
   setup(props) {
 
     const initialLoading = inject(initialLoadingKey, ref(false))
     return {
-      output: props.analyzer.output,
+      output: props.analyzer.normalizedOutput,
       signature: props.analyzer.signature,
       outputs: props.analyzer.outputs,
       initialLoading

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -131,20 +131,22 @@ export function isSolidityPanic(message: string | null): boolean {
 
 export function decodeSolidityErrorMessage(message: string | null): string | null {
 
-    let result = message
+    let result: string|null
 
-    if (isSolidityError(result)) {
+    if (isSolidityError(message)) {
         const reason = ethers.utils.defaultAbiCoder.decode(
             ['string'],
-            ethers.utils.hexDataSlice(result ?? "", 4)
+            ethers.utils.hexDataSlice(message ?? "", 4)
         )
-        result = reason.toString() ?? result
-    } else if (isSolidityPanic(result)) {
+        result = reason.toString() ?? message
+    } else if (isSolidityPanic(message)) {
         const code = ethers.utils.defaultAbiCoder.decode(
             ['uint256'],
-            ethers.utils.hexDataSlice(result ?? "", 4)
+            ethers.utils.hexDataSlice(message ?? "", 4)
         )
-        result = 'Panic(0x' + parseInt(code.toString()).toString(16) + ')'  ?? result
+        result = 'Panic(0x' + parseInt(code.toString()).toString(16) + ')'  ?? message
+    } else {
+        result = null
     }
 
     return result

--- a/src/utils/analyzer/ContractActionAnalyzer.ts
+++ b/src/utils/analyzer/ContractActionAnalyzer.ts
@@ -34,7 +34,7 @@ export class ContractActionAnalyzer {
 
     public constructor(action: Ref<ContractAction|undefined>) {
         this.action = action
-        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.contractId)
+        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.error, this.contractId)
     }
 
     public mount(): void {
@@ -59,6 +59,8 @@ export class ContractActionAnalyzer {
     // Private
     //
 
+    private readonly contractId = computed(() => this.action.value?.recipient ?? null)
+
     private readonly input = computed(() => this.action.value?.input ?? null)
 
     private readonly output = computed(() => {
@@ -71,5 +73,13 @@ export class ContractActionAnalyzer {
         return result
     })
 
-    private readonly contractId = computed(() => this.action.value?.recipient ?? null)
+    public readonly error = computed(() => {
+        let result: string|null
+        if (this.action?.value?.result_data_type == ResultDataType.ERROR) {
+            result = this.action?.value?.result_data ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
 }

--- a/src/utils/analyzer/ContractActionAnalyzer.ts
+++ b/src/utils/analyzer/ContractActionAnalyzer.ts
@@ -75,7 +75,7 @@ export class ContractActionAnalyzer {
 
     public readonly error = computed(() => {
         let result: string|null
-        if (this.action?.value?.result_data_type == ResultDataType.ERROR) {
+        if (this.action?.value?.result_data_type != ResultDataType.OUTPUT) {
             result = this.action?.value?.result_data ?? null
         } else {
             result = null

--- a/src/utils/analyzer/ContractAnalyzer.ts
+++ b/src/utils/analyzer/ContractAnalyzer.ts
@@ -28,8 +28,6 @@ export class ContractAnalyzer {
     public readonly contractId: Ref<string|null>
     private readonly watchHandle: Ref<WatchStopHandle|null> = ref(null)
     private readonly systemContractEntryRef: Ref<SystemContractEntry|null> = ref(null)
-    // private readonly solcOutput: Ref<SolcOutput|null> = ref(null)
-    // private readonly contractMatchResult: Ref<ContractMatchResult|null> = ref(null)
     private readonly interfaceRef: Ref<ethers.utils.Interface|null> = ref(null)
 
     //
@@ -50,47 +48,13 @@ export class ContractAnalyzer {
             this.watchHandle.value = null
         }
         this.systemContractEntryRef.value = null
-        // this.solcOutput.value = null
-        // this.contractMatchResult.value = null
         this.interfaceRef.value = null
     }
-    //
-    // public readonly sourceFileName: ComputedRef<string|null> = computed(
-    //     () => this.contractMatchResult.value?.sourceFileName ?? null)
-    //
-    // public readonly contractName: ComputedRef<string|null> = computed(
-    //     () => this.contractMatchResult.value?.contractName ?? null)
-    //
-    // public readonly bytecodeComparison: ComputedRef<BytecodeComparison|null> = computed(
-    //     () => this.contractMatchResult.value?.comparison ?? null)
 
     public readonly interface: ComputedRef<ethers.utils.Interface|null> = computed(
         () => this.interfaceRef.value)
 
 
-    // public readonly contractURL: ComputedRef<string|null> = computed(() => {
-    //     let result: string|null
-    //     if (this.contractId.value !== null) {
-    //         result = SolcOutputCache.makeContractURL(this.contractId.value)
-    //     } else {
-    //         result = null
-    //     }
-    //     return result
-    // })
-    //
-    // public readonly sourceFileURL: ComputedRef<string|null> = computed(() => {
-    //     let result: string|null
-    //     if (this.contractURL.value !== null) {
-    //         if (this.contractMatchResult.value !== null) {
-    //             result = this.contractURL.value + "/" + this.contractMatchResult.value.sourceFileName
-    //         } else {
-    //             result = this.contractURL.value
-    //         }
-    //     } else {
-    //         result = null
-    //     }
-    //     return result
-    // })
 
     //
     // Private
@@ -102,8 +66,6 @@ export class ContractAnalyzer {
             if (sce !== null) {
                 // This is a system contract
                 this.systemContractEntryRef.value = sce
-                // this.solcOutput.value = null
-                // this.contractMatchResult.value = null
                 try {
                     const asset = await AssetCache.instance.lookup(sce.abiURL) as { abi: ethers.utils.Fragment[]}
                     const i = new ethers.utils.Interface(asset.abi)
@@ -114,42 +76,9 @@ export class ContractAnalyzer {
             } else {
                 // Check if contract metadata are available and fetch abi
                 this.systemContractEntryRef.value = null
-                // try {
-                //     const o = await SolcOutputCache.instance.lookup(this.contractId.value)
-                //     if (o !== null) {
-                //         this.solcOutput.value = o
-                //         const contractInfo = await ContractByIdCache.instance.lookup(this.contractId.value)
-                //         const deployedByteCode = contractInfo?.runtime_bytecode ?? null
-                //         if (deployedByteCode !== null) {
-                //             const r = SolcUtils.findMatchingContract(deployedByteCode, this.solcOutput.value)
-                //             if (r !== null) {
-                //                 const d = SolcUtils.fetchDescription(r.sourceFileName, r.contractName, o)
-                //                 const i = d?.abi ? new ethers.utils.Interface(d?.abi) : null
-                //                 this.contractMatchResult.value = r
-                //                 this.interfaceRef.value = Object.preventExtensions(i) // Because ethers does not like Ref introspection
-                //             } else {
-                //                 this.contractMatchResult.value = null
-                //                 this.interfaceRef.value = null
-                //             }
-                //         } else {
-                //             this.contractMatchResult.value = null
-                //             this.interfaceRef.value = null
-                //         }
-                //     } else {
-                //         this.solcOutput.value = null
-                //         this.contractMatchResult.value = null
-                //         this.interfaceRef.value = null
-                //     }
-                // } catch {
-                //     this.solcOutput.value = null
-                //     this.contractMatchResult.value = null
-                //     this.interfaceRef.value = null
-                // }
             }
         } else {
             this.systemContractEntryRef.value = null
-            // this.solcOutput.value = null
-            // this.contractMatchResult.value = null
         }
     }
 }

--- a/src/utils/analyzer/ContractResultAnalyzer.ts
+++ b/src/utils/analyzer/ContractResultAnalyzer.ts
@@ -38,7 +38,7 @@ export class ContractResultAnalyzer {
 
     public constructor(timestamp: Ref<string | null>) {
         this.timestamp = timestamp
-        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.toId)
+        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.error, this.toId)
     }
 
     public mount(): void {
@@ -117,6 +117,9 @@ export class ContractResultAnalyzer {
 
     private readonly output = computed(
         () => this.contractResult.value?.call_result ?? null)
+
+    private readonly error = computed(
+        () => this.contractResult.value?.error_message ?? null)
 
     private readonly updateContractResult = async () => {
         if (this.timestamp.value !== null) {

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -116,8 +116,12 @@ export class FunctionCallAnalyzer {
         const i = this.contractAnalyzer.interface.value
         const input = this.input.value
         if (i !== null && input !== null) {
-            const td = i.parseTransaction({data: input})
-            this.transactionDescription.value = Object.preventExtensions(td) // Because ethers does not like Ref introspection
+            try {
+                const td = i.parseTransaction({data: input})
+                this.transactionDescription.value = Object.preventExtensions(td) // Because ethers does not like Ref introspection
+            } catch {
+                this.transactionDescription.value = null
+            }
         } else {
             this.transactionDescription.value = null
         }

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -60,6 +60,18 @@ export class FunctionCallAnalyzer {
         this.transactionDescription.value = null
     }
 
+    public readonly normalizedInput: ComputedRef<string|null> = computed(() => {
+        return this.input.value == "0x" ? null : this.input.value
+    })
+
+    public readonly normalizedOutput: ComputedRef<string|null> = computed(() => {
+        return this.output.value == "0x" ? null : this.output.value
+    })
+
+    public readonly normalizedError: ComputedRef<string|null> = computed(() => {
+        return this.error.value == "0x" ? null : this.error.value
+    })
+
     public readonly functionHash: ComputedRef<string|null> = computed(() => {
         return this.transactionDescription.value?.sighash ?? null
     })

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -26,34 +26,37 @@ export class FunctionCallAnalyzer {
 
     public readonly input: Ref<string|null>
     public readonly output: Ref<string|null>
+    public readonly error: Ref<string|null>
     private readonly contractAnalyzer: ContractAnalyzer
     private readonly transactionDescription = ref<ethers.utils.TransactionDescription|null>(null)
-    private readonly watchHandle: Ref<WatchStopHandle|null> = ref(null)
+    private readonly errorDescription = ref<ErrorDescription|null>(null) // Where is ethers.utils.ErrorDescription ?
+    private readonly watchHandle: Ref<WatchStopHandle[]> = ref([])
 
     //
     // Public
     //
 
-    public constructor(input: Ref<string|null>, output: Ref<string|null>, contractId: Ref<string|null>) {
+    public constructor(input: Ref<string|null>, output: Ref<string|null>, error: Ref<string|null>, contractId: Ref<string|null>) {
         this.input = input
         this.output = output
+        this.error = error
         this.contractAnalyzer = new ContractAnalyzer(contractId)
     }
 
     public mount(): void {
-        this.watchHandle.value = watch(
-            [this.input, this.contractAnalyzer.interface],
-            this.updateTransactionDescription,
-            { immediate: true})
+        this.watchHandle.value = [
+            watch([this.input, this.contractAnalyzer.interface], this.updateTransactionDescription, { immediate: true}),
+            watch([this.error, this.contractAnalyzer.interface], this.updateErrorDescription, { immediate: true})
+        ]
         this.contractAnalyzer.mount()
     }
 
     public unmount(): void {
         this.contractAnalyzer.unmount()
-        if (this.watchHandle.value !== null) {
-            this.watchHandle.value()
-            this.watchHandle.value = null
+        for (const wh of this.watchHandle.value) {
+            wh()
         }
+        this.watchHandle.value = []
         this.transactionDescription.value = null
     }
 
@@ -63,6 +66,14 @@ export class FunctionCallAnalyzer {
 
     public readonly signature: ComputedRef<string|null> = computed(() => {
         return this.transactionDescription.value?.signature ?? null
+    })
+
+    public readonly errorSignature: ComputedRef<string|null> = computed(() => {
+        return this.errorDescription.value?.signature ?? null
+    })
+
+    public readonly errorHash: ComputedRef<string|null> = computed(() => {
+        return this.errorDescription.value?.sighash ?? null
     })
 
     public readonly inputs: ComputedRef<NameTypeValue[]> = computed(() => {
@@ -95,22 +106,56 @@ export class FunctionCallAnalyzer {
         return result
     })
 
+    public readonly errorInputs: ComputedRef<NameTypeValue[]> = computed(() => {
+        const result: NameTypeValue[] = []
+        if (this.decodedFunctionError.value !== null) {
+            const results = this.decodedFunctionError.value
+            const fragmentInputs = this.errorDescription.value?.errorFragment.inputs ?? []
+            for (let i = 0, count = results.length; i < count; i += 1) {
+                const value = results[i]
+                const name = i < fragmentInputs.length ? fragmentInputs[i].name : "?"
+                const type = i < fragmentInputs.length ? fragmentInputs[i].type : "?"
+                result.push(new NameTypeValue(name, type, value))
+            }
+        }
+        return result
+    })
+
     public readonly decodedFunctionResult: ComputedRef<ethers.utils.Result|null> = computed(() => {
         let result: ethers.utils.Result|null
         const td = this.transactionDescription.value
         const i = this.contractAnalyzer.interface.value
         const output = this.output.value
         if (td !== null && i !== null && output !== null) {
-            result = i.decodeFunctionResult(td.functionFragment, output)
+            try {
+                result = i.decodeFunctionResult(td.functionFragment, output)
+            } catch {
+                result = null
+            }
         } else {
             result = null
         }
         return result
     })
 
-    //
-    // Private
-    //
+    public readonly decodedFunctionError: ComputedRef<ethers.utils.Result|null> = computed(() => {
+        let result: ethers.utils.Result|null
+        const d = this.errorDescription.value
+        const i = this.contractAnalyzer.interface.value
+        const error = this.error.value
+        if (d !== null && i !== null && error !== null) {
+            try {
+                // result = i.decodeErrorResult(d.errorFragment, error)
+                const bytes = ethers.utils.arrayify(error)
+                result = ethers.utils.defaultAbiCoder.decode(d.errorFragment.inputs, bytes.slice(4))
+            } catch {
+                result = null
+            }
+        } else {
+            result = null
+        }
+        return result
+    })
 
     private readonly updateTransactionDescription = async () => {
         const i = this.contractAnalyzer.interface.value
@@ -127,6 +172,21 @@ export class FunctionCallAnalyzer {
         }
     }
 
+    private readonly updateErrorDescription = async() => {
+        const i = this.contractAnalyzer.interface.value
+        const error = this.error.value
+        if (i !== null && error !== null) {
+            try {
+                const ed = i.parseError(error)
+                this.errorDescription.value = Object.preventExtensions(ed)
+            } catch(reason) {
+                this.errorDescription.value = null
+            }
+        } else {
+            this.errorDescription.value = null
+        }
+    }
+
 }
 
 export class NameTypeValue {
@@ -138,4 +198,12 @@ export class NameTypeValue {
         this.type = type
         this.value = value
     }
+}
+
+export interface ErrorDescription {
+    readonly errorFragment: ethers.utils.ErrorFragment
+    readonly name: string
+    readonly args: ethers.utils.Result
+    readonly signature: string
+    readonly sighash: string
 }

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -280,7 +280,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#toValue").text()).toBe("0x0000000000000000000000000000000000103783Copy to Clipboard(0.0.1062787)")
         expect(wrapper.get("#typeValue").text()).toBe("None")
         // expect(wrapper.get("#functionParametersValue").text()).toBe("18cb afe5 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0017 4876 e800 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 001b 2702 b2a0 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 00a0 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 000c e9b4 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0183 1e10 602d 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0003 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 000c ba44 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 000d 1ea6 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0010 3708Copy to Clipboard")
-        expect(wrapper.get("#errorMessageValue").text()).toBe("None")
+        // expect(wrapper.get("#errorMessageValue").text()).toBe("None")
         expect(wrapper.get("#gasLimitValue").text()).toBe("480,000")
         expect(wrapper.get("#gasUsedValue").text()).toBe("384,000")
         expect(wrapper.get("#maxFeePerGasValue").text()).toBe("None")

--- a/tests/unit/utils/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/FunctionCallAnalyzer.spec.ts
@@ -39,12 +39,15 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         // 1) new
         const input: Ref<string|null> = ref(null)
         const output: Ref<string|null> = ref(null)
+        const error: Ref<string|null> = ref(null)
         const contractId: Ref<string|null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
         expect(functionCallAnalyzer.signature.value).toBeNull()
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorHash.value).toBeNull()
+        expect(functionCallAnalyzer.errorSignature.value).toBeNull()
 
         // 2) mount
         functionCallAnalyzer.mount()
@@ -53,6 +56,8 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.signature.value).toBeNull()
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorHash.value).toBeNull()
+        expect(functionCallAnalyzer.errorSignature.value).toBeNull()
 
         // 3) input setup
         input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
@@ -68,6 +73,8 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([
             new NameTypeValue("responseCode", "int64", BigNumber.from("0x05a995c0")),
         ])
+        expect(functionCallAnalyzer.errorHash.value).toBeNull()
+        expect(functionCallAnalyzer.errorSignature.value).toBeNull()
 
         // 4) unmount
         functionCallAnalyzer.unmount()
@@ -76,6 +83,8 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.signature.value).toBeNull()
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorHash.value).toBeNull()
+        expect(functionCallAnalyzer.errorSignature.value).toBeNull()
 
     })
 


### PR DESCRIPTION
**Description**:

Changes logic add required logic to Contract and Action errors ie bytes from Mirror Node fields:
- `ContractResult.error_message`
- `ContractAction.result_data` (when  result_data_type == ERROR)

They also modifies field ordering in Contract Result section: Input and Output are now presented first and Error is the last.

**Related issue(s)**:

 Fixes #613

**Notes for reviewer**:

Field re-ordering can be visualized on transaction `1685115468.045782003`.

Error decoding will be visible once custom contract verification is enabled.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
