### PR TITLE
00612 Expiration date is confusing until account expiry is turned in

### DIFF
--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -1,0 +1,61 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <o-tooltip :label="label"
+             :delay="delay"
+             multiline="multiline"
+             :position="position ?? 'auto'"
+             class="h-tooltip ml-1">
+    <span class="icon is-small h-is-extra-text"><i class="fas fa-info-circle"></i></span>
+  </o-tooltip>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent} from "vue";
+
+export default defineComponent({
+  name: "InfoTooltip",
+  props: {
+    label: String,
+    delay: {
+      type: Number,
+      default: 200
+    },
+    position: String
+  },
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -172,16 +172,21 @@
         </Property>
 
         <Property id="expiresAt">
-          <template v-slot:name>Expires at</template>
+          <template v-slot:name>
+            <span>Expires at</span>
+            <InfoTooltip label="Account expiry is not turned on yet. Value in this field is not relevant."/>
+          </template>
           <template v-slot:value>
             <TimestampValue v-bind:show-none="true" v-bind:timestamp="account?.expiry_timestamp ?? undefined"/>
           </template>
         </Property>
         <Property id="autoRenewPeriod">
-          <template v-slot:name>Auto Renew Period</template>
+          <template v-slot:name>
+            <span>Auto Renew Period</span>
+            <InfoTooltip label="Account auto-renew is not turned on yet. Value in this field is not relevant."/>
+          </template>
           <template v-slot:value>
-            <DurationValue v-if="false" v-bind:number-value="account?.auto_renew_period ?? undefined"/>
-            <span v-else class="has-text-grey">Not yet enabled</span>
+            <DurationValue v-bind:number-value="account?.auto_renew_period ?? undefined"/>
           </template>
         </Property>
         <Property id="maxAutoAssociation">
@@ -298,6 +303,7 @@ import AliasValue from "@/components/values/AliasValue.vue";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import ApproveAllowanceSection from "@/components/allowances/ApproveAllowanceSection.vue";
+import InfoTooltip from "@/components/InfoTooltip.vue";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -306,6 +312,7 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
+    InfoTooltip,
     ApproveAllowanceSection,
     EVMAddress,
     AliasValue,

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -98,19 +98,28 @@
               </template>
             </Property>
             <Property id="expiresAt">
-              <template v-slot:name>Expires at</template>
+              <template v-slot:name>
+                <span>Expires at</span>
+                <InfoTooltip label="Contract expiry is not turned on yet. Value in this field is not relevant."/>
+              </template>
               <template v-slot:value>
                 <TimestampValue v-bind:timestamp="contract?.expiration_timestamp ?? undefined" v-bind:show-none="true"/>
               </template>
             </Property>
             <Property id="autoRenewPeriod">
-              <template v-slot:name>Auto Renew Period</template>
+              <template v-slot:name>
+                <span>Auto Renew Period</span>
+                <InfoTooltip label="Contract auto-renew is not turned on yet. Value in this field is not relevant."/>
+              </template>
               <template v-slot:value>
                 <DurationValue v-bind:number-value="contract?.auto_renew_period ?? undefined"/>
               </template>
             </Property>
             <Property id="autoRenewAccount">
-              <template v-slot:name>Auto Renew Account</template>
+              <template v-slot:name>
+                <span>Auto Renew Account</span>
+                <InfoTooltip label="Contract auto-renew is not turned on yet. Value in this field is not relevant."/>
+              </template>
               <template v-slot:value>
                 <AccountLink :account-id="autoRenewAccount" :show-none="true" null-label="None"/>
               </template>
@@ -200,6 +209,7 @@ import router, {routeManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
+import InfoTooltip from "@/components/InfoTooltip.vue";
 
 const MAX_TOKEN_BALANCES = 3
 
@@ -208,6 +218,7 @@ export default defineComponent({
   name: 'ContractDetails',
 
   components: {
+    InfoTooltip,
     ContractResultsSection,
     EVMAddress,
     TransactionLink,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -89,23 +89,30 @@
           </template>
         </Property>
         <Property id="expiresAt">
-          <template v-slot:name>Expires at</template>
+          <template v-slot:name>
+            <span>Expires at</span>
+            <InfoTooltip label="Token expiry is not turned on yet. Value in this field is not relevant."/>
+          </template>
           <template v-slot:value>
             <TimestampValue :nano="true" :show-none="true" :timestamp="tokenInfo?.expiry_timestamp?.toString()"/>
           </template>
         </Property>
         <Property id="autoRenewPeriod">
-          <template v-slot:name>Auto Renew Period</template>
+          <template v-slot:name>
+            <span>Auto Renew Period</span>
+            <InfoTooltip label="Token auto-renew is not turned on yet. Value in this field is not relevant."/>
+          </template>
           <template v-slot:value>
-            <DurationValue v-if="false" v-bind:string-value="tokenInfo?.auto_renew_period?.toString()"/>
-            <span v-else class="has-text-grey">Not yet enabled</span>
+            <DurationValue v-bind:string-value="tokenInfo?.auto_renew_period?.toString()"/>
           </template>
         </Property>
         <Property id="autoRenewAccount">
-          <template v-slot:name>Auto Renew Account</template>
+          <template v-slot:name>
+            <span>Auto Renew Account</span>
+            <InfoTooltip label="Token auto-renew is not turned on yet. Value in this field is not relevant."/>
+          </template>
           <template v-slot:value>
-            <AccountLink v-if="false" :account-id="tokenInfo?.auto_renew_account" :show-none="true"/>
-            <span v-else class="has-text-grey">Not yet enabled</span>
+            <AccountLink :account-id="tokenInfo?.auto_renew_account" :show-none="true"/>
           </template>
         </Property>
         <Property id="freezeDefault">
@@ -319,12 +326,14 @@ import {makeTokenSymbol} from "@/schemas/HederaUtils";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";
 import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
+import InfoTooltip from "@/components/InfoTooltip.vue";
 
 export default defineComponent({
 
   name: 'TokenDetails',
 
   components: {
+    InfoTooltip,
     ContractResultsSection,
     EVMAddress,
     TokenCustomFees,

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -121,7 +121,7 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
 
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("false")
 
@@ -234,7 +234,7 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
         expect(wrapper.find("#aliasValue").exists()).toBe(false)
         expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
 

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -182,7 +182,7 @@ describe("NodeDetails.vue", () => {
         expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
         expect(wrapper.find("#aliasValue").exists()).toBe(false)
         expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("10")
         expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -87,8 +87,8 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.find("#adminKey").text()).toBe("Admin KeyNoneToken is immutable")
         expect(wrapper.get("#memoValue").text()).toBe("Predator")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
-        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("Not yet enabled")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.29612329")
         expect(wrapper.get("#freezeDefaultValue").text()).toBe("false")
         expect(wrapper.get("#pauseStatusValue").text()).toBe("Not applicable")
 
@@ -151,7 +151,7 @@ describe("TokenDetails.vue", () => {
         )
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("Not yet enabled")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
 
         expect(wrapper.get("#createdAtValue").text()).toBe("3:29:27.7128 PMMar 6, 2022, UTC")
         expect(wrapper.get("#modifiedAtValue").text()).toBe("8:56:33.5203 PMMar 6, 2022, UTC")


### PR DESCRIPTION
**Description**:

This PR add a small InfoTooltip component (explanatory tooltip attached to a circle-info icon) and makes use of it in Account/Contract/Token details pages to clarify the following properties:
- `Expires at`
- `Auto Renew Period`
- `Auto Renew Account`

**Related issue(s)**:

Fixes #612

**Notes for reviewer**:

<img width="743" alt="Screenshot 2023-05-31 at 11 37 34" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/93260ae9-d395-42fe-b465-0744937a66f7">


Also deployed on staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
