### PR TITLE
00617 Add tooltip to explain why transaction fee may exceed 'max fee'

### DIFF
--- a/src/components/transaction/TransactionAnalyzer.ts
+++ b/src/components/transaction/TransactionAnalyzer.ts
@@ -76,6 +76,9 @@ export class TransactionAnalyzer {
         return isNaN(result) ? -9999 : result
     })
 
+    public readonly chargedFee: ComputedRef<number> = computed(
+        () => this.transaction.value?.charged_tx_fee ?? 0)
+
     public readonly formattedTransactionId: ComputedRef<string|null> = computed(() => {
         const transaction_id = this.transaction.value?.transaction_id
         return transaction_id ? normalizeTransactionId(transaction_id, true) : null

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -139,7 +139,11 @@
           </template>
         </Property>
         <Property id="maxFee">
-          <template v-slot:name>Max fee</template>
+          <template v-slot:name>
+            <span>Max fee</span>
+            <InfoTooltip v-if="showMaxFeeTooltip"
+                         label="Max fee limit does not include the hbar cost of gas consumed by transactions executed on the EVM."/>
+          </template>
           <template v-slot:value>
             <HbarAmount v-if="transaction" :amount="maxFee" :show-extra="true"
                         :timestamp="transaction.consensus_timestamp"/>
@@ -262,6 +266,7 @@ import {TransactionLocParser} from "@/utils/parser/TransactionLocParser";
 import {TransactionGroupAnalyzer} from "@/components/transaction/TransactionGroupAnalyzer";
 import {TransactionAnalyzer} from "@/components/transaction/TransactionAnalyzer";
 import {TransactionGroupCache} from "@/utils/cache/TransactionGroupCache";
+import InfoTooltip from "@/components/InfoTooltip.vue";
 
 const MAX_INLINE_CHILDREN = 9
 
@@ -270,6 +275,7 @@ export default defineComponent({
   name: 'TransactionDetails',
 
   components: {
+    InfoTooltip,
     TokenLink,
     TopicMessage,
     ContractResult,
@@ -331,6 +337,9 @@ export default defineComponent({
     const topicMessageLookup = TopicMessageCache.instance.makeLookup(messageTimestamp)
     onMounted(() => topicMessageLookup.mount())
     onBeforeUnmount(() => topicMessageLookup.unmount())
+
+    const showMaxFeeTooltip = computed(
+        () => transactionAnalyzer.chargedFee.value > transactionAnalyzer.maxFee.value)
 
     const transactionDetail = computed(() => {
       let result: TransactionDetail|null
@@ -401,6 +410,7 @@ export default defineComponent({
       isSmallScreen,
       isLargeScreen,
       isTouchDevice,
+      showMaxFeeTooltip,
       transactionId: transactionLocParser.transactionId,
       transaction: transactionDetail,
       formattedTransactionId: transactionAnalyzer.formattedTransactionId,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -140,9 +140,9 @@
         </Property>
         <Property id="maxFee">
           <template v-slot:name>
-            <span>Max fee</span>
+            <span>Max Fee</span>
             <InfoTooltip v-if="showMaxFeeTooltip"
-                         label="Max fee limit does not include the hbar cost of gas consumed by transactions executed on the EVM."/>
+                         label="Max Fee limit does not include the hbar cost of gas consumed by transactions executed on the EVM."/>
           </template>
           <template v-slot:value>
             <HbarAmount v-if="transaction" :amount="maxFee" :show-extra="true"

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -577,7 +577,7 @@ export const SAMPLE_CONTRACTCALL_TRANSACTIONS = {
             "charged_tx_fee": 95515604,
             "consensus_timestamp": "1646665766.574738471",
             "entity_id": "0.0.749774",
-            "max_fee": "10000000000",
+            "max_fee": "20000000",
             "memo_base64": "TWlycm9yIE5vZGUgYWNjZXB0YW5jZSB0ZXN0OiAyMDIyLTAzLTA3VDE1OjA5OjI2LjA2NjY4MDk3N1ogRXhlY3V0ZSBjb250cmFjdA==",
             "name": "CONTRACTCALL",
             "node": "0.0.3",

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -115,6 +115,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#transactionHashValue").text()).toBe("a012 9612 32ed 7d28 4283 6e95 f7e9 c435 6fdf e2de 0819 9091 701a 969c 1d1f d936 71d3 078e e83b 28fb 460a 88b4 cbd8 ecd2Copy to Clipboard")
         // expect(wrapper.get("#netAmountValue").text()).toBe("0.00000000$0.0000")
         expect(wrapper.get("#chargedFeeValue").text()).toBe("0.00470065$0.00116")
+        expect(wrapper.get("#maxFeeName").text()).toBe("Max Fee")
         expect(wrapper.get("#maxFeeValue").text()).toBe("1.00000000$0.24603")
 
         expect(wrapper.get("#memoValue").text()).toBe("None")
@@ -196,6 +197,11 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get("#transactionTypeValue").text()).toBe("CONTRACT CALL")
         expect(wrapper.get("#entityId").text()).toBe("Contract ID" + contractId)
         expect(wrapper.get("#durationValue").text()).toBe("None")
+
+        expect(wrapper.get("#chargedFeeName").text()).toBe("Charged Fee")
+        expect(wrapper.get("#chargedFeeValue").text()).toBe("0.95515604$0.23500")
+        expect(wrapper.get("#maxFeeName").text()).toBe("Max FeeMax Fee limit does not include the hbar cost of gas consumed by transactions executed on the EVM.")
+        expect(wrapper.get("#maxFeeValue").text()).toBe("0.20000000$0.04921")
 
         expect(wrapper.findComponent(ContractResult).exists()).toBe(true)
         expect(wrapper.findComponent(ContractResult).text()).toMatch(RegExp("^Contract Result"))


### PR DESCRIPTION
**Description**:

This displays an InfoTooltip on the `Max Fee` property when `Charged Fee > Max Fee`

**Related issue(s)**:

Fixes #617 

**Notes for reviewer**:

(examples of such transactions in issue #617)

<img width="568" alt="Screenshot 2023-05-31 at 16 45 07" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/50d034b3-48a5-4613-9ad2-2e2af120bbd5">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
