### PR TITLE
00622 Ethereum transaction details may fail to display contract result

### DIFF
--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -349,6 +349,7 @@ export default defineComponent({
         for (const t of transactionGroupAnalyzer.transactions.value ?? []) {
           if (consensusTimestamp == t.consensus_timestamp) {
             result = t
+            break
           }
         }
       } else {

--- a/src/utils/cache/ContractByAddressCache.ts
+++ b/src/utils/cache/ContractByAddressCache.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {AccountBalanceTransactions, ContractResponse} from "@/schemas/HederaSchemas";
+import {ContractResponse} from "@/schemas/HederaSchemas";
 import {EntityCache} from "@/utils/cache/base/EntityCache";
 import axios from "axios";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";

--- a/src/utils/cache/ContractResultByTsCache.ts
+++ b/src/utils/cache/ContractResultByTsCache.ts
@@ -49,11 +49,16 @@ export class ContractResultByTsCache extends EntityCache<string, ContractResultD
         const contractId = contractResult?.contract_id ?? null
         if (contractId !== null) {
             result = await this.loadContractResultDetail(contractId, timestamp)
+            if (result !== null) {
+                ContractResultByHashCache.instance.updateWithContractResult(result);
+            }
         } else {
-            result = null
-        }
-        if (result !== null) {
-            ContractResultByHashCache.instance.updateWithContractResult(result);
+            const ethereumHash = contractResult?.hash ?? null
+            if (ethereumHash !== null) {
+                result = await ContractResultByHashCache.instance.lookup(ethereumHash)
+            } else {
+                result = null
+            }
         }
         return  Promise.resolve(result)
     }

--- a/tests/e2e/specs/AccountNavigation.cy.ts
+++ b/tests/e2e/specs/AccountNavigation.cy.ts
@@ -157,7 +157,7 @@ describe('Account Navigation', () => {
 
         cy.url().should('include', '/mainnet/transaction/')
         cy.contains('Transaction')
-        cy.get('[data-cy=hbarTransfers]')
+        cy.get('[data-cy=feeTransfers]')
             .contains('0.0.800')
     })
 

--- a/tests/e2e/specs/TokenNavigation.cy.ts
+++ b/tests/e2e/specs/TokenNavigation.cy.ts
@@ -161,8 +161,8 @@ describe('Token Navigation', () => {
             .eq(0)
             .click()
 
-        cy.url().should('include', '/mainnet/transaction/1677545104.611658003')
-        cy.contains('Transaction 0.0.939841@1677545092.878406670')
+        cy.url().should('include', '/mainnet/transaction/1685904941.951445727')
+        cy.contains('0.0.2159637@1685904926.973808295')
         cy.contains('CONTRACT CALL')
         cy.contains('Token ID' + proxiedTokenId)
     })

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1141,6 +1141,31 @@ export const SAMPLE_REVERT_CONTRACT_RESULT_ACTIONS = {
         }], "links": {"next": null}
 }
 
+
+export const SAMPLE_ERROR_RESULTS = {
+    "results": [
+        {
+            "address": null,
+            "amount": 0,
+            "bloom": "0x",
+            "call_result": "0x",
+            "contract_id": null,
+            "created_contract_ids": [],
+            "error_message": "INSUFFICIENT_GAS",
+            "from": "0x0000000000000000000000000000000000000386",
+            "function_parameters": "0xd09de08a",
+            "gas_limit": 21500,
+            "gas_used": 21500,
+            "timestamp": "1685737274.278536163",
+            "to": null,
+            "hash": "0x9059179bccd15bfabb246dd24572f4556cbf3a5dbb1d335759e593a7a6a8abed"
+        }
+    ],
+    "links": {
+        "next": null
+    }
+}
+
 // https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=2&transactiontype=CRYPTOTRANSFER
 
 export const SAMPLE_CRYPTO_TRANSACTIONS = {

--- a/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
+++ b/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
@@ -21,7 +21,7 @@
  */
 
 
-import {SAMPLE_CONTRACT_RESULT_DETAILS} from "../../Mocks";
+import {SAMPLE_CONTRACT_RESULT_DETAILS, SAMPLE_ERROR_RESULTS} from "../../Mocks";
 import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
@@ -30,7 +30,7 @@ import {ContractResultByHashCache} from "@/utils/cache/ContractResultByHashCache
 
 describe("ContractResultByTsCache", () => {
 
-    test("ContractResultByTsCache", async () => {
+    test("contract results with contract_id", async () => {
 
         expect(ContractResultByTsCache.instance.isEmpty()).toBeTruthy()
 
@@ -59,6 +59,41 @@ describe("ContractResultByTsCache", () => {
         const contractResult2 = await ContractResultByTsCache.instance.lookup(timestamp)
         await flushPromises()
         expect(contractResult2).toStrictEqual(SAMPLE_CONTRACT_RESULT_DETAILS)
+        expect(mock.history.get.length).toBe(0)
+
+        // Checks that ContractResultByHashCache has been populated
+        if (contractResult?.hash) {
+            expect(ContractResultByHashCache.instance.contains(contractResult.hash))
+        }
+    })
+
+    test("contract result without contract_id", async () => {
+
+        expect(ContractResultByTsCache.instance.isEmpty()).toBeTruthy()
+
+        const mock = new MockAdapter(axios);
+
+        const timestamp = SAMPLE_ERROR_RESULTS.results[0].timestamp
+        const matcher1 = "/api/v1/contracts/results"
+        const param1 = {
+            timestamp: timestamp,
+            internal: true
+        }
+        mock.onGet(matcher1, param1).reply(200, SAMPLE_ERROR_RESULTS );
+        const ethereumHash = SAMPLE_ERROR_RESULTS.results[0].hash
+        const matcher2 = "/api/v1/contracts/results/" + ethereumHash
+        mock.onGet(matcher2).reply(200, SAMPLE_ERROR_RESULTS.results[0]);
+
+        // 1) First lookup() triggers http requests
+        const contractResult = await ContractResultByTsCache.instance.lookup(timestamp)
+        expect(contractResult).toStrictEqual(SAMPLE_ERROR_RESULTS.results[0])
+        expect(mock.history.get.length).toBe(2)
+
+        // 2) Second lookup() triggers no http requests
+        mock.resetHistory()
+        const contractResult2 = await ContractResultByTsCache.instance.lookup(timestamp)
+        await flushPromises()
+        expect(contractResult2).toStrictEqual(SAMPLE_ERROR_RESULTS.results[0])
         expect(mock.history.get.length).toBe(0)
 
         // Checks that ContractResultByHashCache has been populated


### PR DESCRIPTION
**Description**:

Root cause of this issue is located in `ContractResultByTsCache`.

This class fetches contract result details for a given transaction timestamp. It does this in two steps:
1) first it uses `api/v1/contracts/results/?timestamp=TTT` to retrieve contract id
2) next it uses `api/v1/contracts/{contractId}/results/TTT` to retrieve full details of contract result

In the case of transaction [1685737274.278536163](https://hashscan.io/previewnet/transaction/1685737274.278536163), first call returns `contract_id == null` and causes fetching to stop.

Changes below enhance logic above: when first call returns `contract_id == null`, `ContractResultByTsCache` checks if `hash` value is available and uses it to retrieve contract result details.

Changes below also include:
- extra unit test for `ContractResultByTsCache`
- some imports cleaning,
- some fixes to e2e tests to adapt to `mainnet` latest data

**Related issue(s)**:

Fixes #622

**Notes for reviewer**:

See PR for transaction test URL.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
