### PR TITLE
00602 Transaction wrongly shows a parent transaction property

### DIFF
--- a/src/components/transaction/TransactionGroupAnalyzer.ts
+++ b/src/components/transaction/TransactionGroupAnalyzer.ts
@@ -41,7 +41,7 @@ export class TransactionGroupAnalyzer {
                 break
             }
         }
-        return result
+        return this.childTransactions.value.length ? result : null
     })
 
     public readonly childTransactions = computed(() => {

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -37,17 +37,18 @@
             </div>
             <div v-else class="h-has-pill has-background-danger mr-3 h-is-text-size-2 mt-3">FAILURE</div>
           </div>
-          <span v-if="routeToAllTransactions && isLargeScreen" id="allTransactionsLink" class="is-inline-block mt-2">
-          <router-link :to="routeToAllTransactions">
-            <span class="h-is-property-text has-text-grey">Show all transactions with the same ID</span>
-          </router-link>
-        </span>
         </div>
         <span v-if="routeToAllTransactions && !isLargeScreen">
           <router-link :to="routeToAllTransactions">
             <span class="h-is-property-text has-text-grey">Show all transactions with the same ID</span>
           </router-link>
         </span>
+      </template>
+
+      <template v-slot:control>
+        <router-link v-if="routeToAllTransactions && isLargeScreen" id="allTransactionsLink" :to="routeToAllTransactions">
+          <span class="h-is-property-text has-text-grey">Show all transactions with the same ID</span>
+        </router-link>
       </template>
 
       <template v-slot:content>


### PR DESCRIPTION
**Description**:

Simple change to make sure that a random transaction with nonce=0 is not considered a 'parent' transaction. To be a parent, it also needs to have at least one child (i.e. transaction with same ID and parent_consensus_timestamp property set).

**Related issue(s)**:

Fixes #602

**Notes for reviewer**:

Without this fix, the following transaction wrongly displays a parent transaction:
https://hashscan.io/mainnet/transaction/1684345315.068887004

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
