### PR TITLE
00629 Show native EVM address when possible.

### DIFF
--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -118,7 +118,7 @@ export default defineComponent({
     const updateIdAndAddress = async () => {
       hederaId.value = props.id ?? null
       evmAddress.value = props.address ?? null
-      let account
+      let account: AccountBalanceTransactions|null
 
       if (hederaId.value === null || evmAddress.value === null || ethereumAddress.value?.isLongZeroForm()) {
         if (hederaId.value !== null) {

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -132,6 +132,9 @@ export default defineComponent({
           entityId.value = account?.account
           evmAddress.value = makeEthAddressForAccount(account) ?? evmAddress.value
         }
+        // else leave entityId.value and evmAddress.value untouched since we may well already be able to
+        // display both in case of a long-zero address.
+
       }
       if (entityId.value === null) {
         entityId.value = ethereumAddress.value?.toEntityID()?.toString() ?? null

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -32,11 +32,11 @@
           <span>{{ significantPart }}</span>
         </template>
       </Copyable>
-      <span v-if="hederaId && showId">
+      <span v-if="entityId && showId">
         <span class="ml-1">(</span>
-        <router-link v-if="isContract" :to="{name: 'ContractDetails', params: {contractId: hederaId}}">{{ hederaId }}</router-link>
-        <router-link v-else-if="isAccount" :to="{name: 'AccountDetails', params: {accountId: hederaId}}">{{ hederaId }}</router-link>
-        <span v-else>{{ hederaId }}</span>
+        <router-link v-if="isContract" :to="{name: 'ContractDetails', params: {contractId: entityId}}">{{ entityId }}</router-link>
+        <router-link v-else-if="isAccount" :to="{name: 'AccountDetails', params: {accountId: entityId}}">{{ entityId }}</router-link>
+        <span v-else>{{ entityId }}</span>
         <span>)</span>
       </span>
     </div>
@@ -108,7 +108,7 @@ export default defineComponent({
     const isContract = computed(() => props.entityType === 'CONTRACT')
     const isAccount = computed(() => props.entityType === 'ACCOUNT')
 
-    const hederaId = ref<string|null>(null)
+    const entityId = ref<string|null>(null)
     const evmAddress = ref<string|null>(null)
     const ethereumAddress = computed( () => EthereumAddress.parse(evmAddress.value ?? ''))
 
@@ -116,31 +116,31 @@ export default defineComponent({
     watch([() => props.address, () => props.id], () => updateIdAndAddress())
 
     const updateIdAndAddress = async () => {
-      hederaId.value = props.id ?? null
+      entityId.value = props.id ?? null
       evmAddress.value = props.address ?? null
       let account: AccountBalanceTransactions|null
 
-      if (hederaId.value === null || evmAddress.value === null || ethereumAddress.value?.isLongZeroForm()) {
-        if (hederaId.value !== null) {
-          account = await AccountByIdCache.instance.lookup(hederaId.value)
+      if (entityId.value === null || evmAddress.value === null || ethereumAddress.value?.isLongZeroForm()) {
+        if (entityId.value !== null) {
+          account = await AccountByIdCache.instance.lookup(entityId.value)
         } else if (evmAddress.value !== null) {
           account = await AccountByAddressCache.instance.lookup(evmAddress.value.toString())
         } else {
           account = null
         }
         if (account) {
-          hederaId.value = account?.account
+          entityId.value = account?.account
           evmAddress.value = makeEthAddressForAccount(account) ?? evmAddress.value
         }
       }
-      if (hederaId.value === null) {
-        hederaId.value = ethereumAddress.value?.toEntityID()?.toString() ?? null
+      if (entityId.value === null) {
+        entityId.value = ethereumAddress.value?.toEntityID()?.toString() ?? null
       }
       if (evmAddress.value === null) {
-        evmAddress.value = EntityID.parse(hederaId.value ?? '')?.toAddress() ?? null
+        evmAddress.value = EntityID.parse(entityId.value ?? '')?.toAddress() ?? null
       }
-      if (hederaId.value) {
-        hederaId.value = systemContractRegistry.lookup(hederaId.value)?.description ?? hederaId.value
+      if (entityId.value) {
+        entityId.value = systemContractRegistry.lookup(entityId.value)?.description ?? entityId.value
       }
     }
 
@@ -179,7 +179,7 @@ export default defineComponent({
       initialLoading,
       nonSignificantPart,
       significantPart,
-      hederaId,
+      entityId,
       evmAddress,
       copyToClipboard
     }

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -146,8 +146,6 @@ export default defineComponent({
           // hederaId.value and evmAddress.value are both null - do nothing
         }
       }
-      if (evmAddress.value === null) {
-      }
       if (hederaId.value) {
         hederaId.value = systemContractRegistry.lookup(hederaId.value)?.description ?? hederaId.value
       }

--- a/src/components/values/InnerSenderEVMAddress.vue
+++ b/src/components/values/InnerSenderEVMAddress.vue
@@ -23,7 +23,7 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <EVMAddress :address="senderAddress" :compact="false" :show-id="true" :show-none="false"/>
+  <EVMAddress :address="senderAddress ?? undefined" :compact="false" :show-id="true" :show-none="false"/>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->

--- a/src/utils/EthereumAddress.ts
+++ b/src/utils/EthereumAddress.ts
@@ -40,7 +40,7 @@ export class EthereumAddress {
 
     public toCompactString(digitKept=6): string {
        return "0x"
-           + byteToHex(this.bytes.slice(0, 1))[0]
+           + byteToHex(this.bytes.slice(0, 1))
            + "…" + byteToHex(this.bytes.slice(-digitKept/2))
     }
 

--- a/src/utils/EthereumAddress.ts
+++ b/src/utils/EthereumAddress.ts
@@ -45,10 +45,20 @@ export class EthereumAddress {
     }
 
     public toEntityID(): EntityID|null {
-        const view = new DataView(this.bytes.buffer)
-        const bigNum = view.getBigInt64(12)
-        const num = 0 <= bigNum && bigNum < EntityID.MAX_INT ? Number(bigNum) : null
-        return num != null ? new EntityID(0, 0, num) : null
+        let result: EntityID | null
+        if (this.isLongZeroForm()) {
+            const view = new DataView(this.bytes.buffer)
+            const bigNum = view.getBigInt64(12)
+            const num = 0 <= bigNum && bigNum < EntityID.MAX_INT ? Number(bigNum) : null
+            result = num != null ? new EntityID(0, 0, num) : null
+        } else {
+            result = null
+        }
+        return result
+    }
+
+    public isLongZeroForm(): boolean {
+        return this.bytes.slice(0,12).every((value) => value === 0)
     }
 
     //

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2194,6 +2194,33 @@ export const SAMPLE_ACCOUNT_PROTOBUF_KEY = {
 }
 
 //
+// Account inspired from: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts/0xe6d5514b8de7ef9e5f5c4cc2e8ca0207129deb65
+//
+
+export const SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS = {
+    "account": "0.0.2957798",
+    "alias": "43KVCS4N47XZ4X24JTBORSQCA4JJ323F",
+    "auto_renew_period": 7776000,
+    "balance": {"balance": 3457440000, "timestamp": "1686309927.971781003", "tokens": []},
+    "created_timestamp": "1685800751.186366002",
+    "decline_reward": false,
+    "deleted": false,
+    "ethereum_nonce": 3,
+    "evm_address": "0xe6d5514b8de7ef9e5f5c4cc2e8ca0207129deb65",
+    "expiry_timestamp": "1693576751.186366002",
+    "key": {"_type": "ECDSA_SECP256K1", "key": "0332efb3b38121d96bb000050f50e402730939dbaf206a8a77b4cfe7d510b6cfb7"},
+    "max_automatic_token_associations": 0,
+    "memo": "lazy-created account",
+    "pending_reward": 0,
+    "receiver_sig_required": false,
+    "staked_account_id": null,
+    "staked_node_id": null,
+    "stake_period_start": null,
+    "transactions": [],
+    "links": {"next": null}
+}
+
+//
 // Contract inspired from: https://mainnet-public.mirrornode.hedera.com/api/v1/contracts/0.0.749775
 //
 

--- a/tests/unit/utils/AccountLocParser.spec.ts
+++ b/tests/unit/utils/AccountLocParser.spec.ts
@@ -936,7 +936,7 @@ describe("AccountLocParser.ts", () => {
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
         expect(parser.aliasByteString.value).toBeNull()
-        expect(parser.errorNotification.value).toBe("Own this account? Activate it by transferring any amount of ℏ or tokens to 0x0…070809.")
+        expect(parser.errorNotification.value).toBe("Own this account? Activate it by transferring any amount of ℏ or tokens to 0x00…070809.")
 
         // 3) Unsets
         accountLoc.value = null

--- a/tests/unit/utils/EVMAddress.spec.ts
+++ b/tests/unit/utils/EVMAddress.spec.ts
@@ -1,0 +1,174 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {flushPromises, mount} from "@vue/test-utils";
+import EVMAddress from "@/components/values/EVMAddress.vue";
+import router from "@/router";
+import Oruga from "@oruga-ui/oruga-next";
+import {SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+describe("EVMAddress", () => {
+
+    const evmAddress = "0xe6d5514b8de7ef9e5f5c4cc2e8ca0207129deb65"
+    const compactAddress = "0xe6…9deb65"
+    const longZeroAddress = "0x00000000000000000000000000000000002d21e6"
+    const entityId = "0.0.2957798"
+    const systemContractId = "0.0.359"
+    const systemContractAddress = "0x0000000000000000000000000000000000000167"
+    const systemContractLabel = "Hedera Token Service System Contract"
+
+    const mock = new MockAdapter(axios);
+    const matcher1 = "/api/v1/accounts/" + evmAddress
+    mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS);
+    const matcher2 = "/api/v1/accounts/" + longZeroAddress
+    mock.onGet(matcher2).reply(200, SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS);
+    const matcher3 = "/api/v1/accounts/" + entityId
+    mock.onGet(matcher3).reply(200, SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS);
+
+    test("Constructing with no Hedera ID and no EVM address", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe("None")
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing with Hedera ID and no EVM address", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                id: entityId,
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${evmAddress}Copy(${entityId})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing a compact form with Hedera ID and no EVM address", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                id: entityId,
+                compact: true
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${compactAddress}Copy(${entityId})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing with EVM address and no Hedera ID", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                address: evmAddress
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${evmAddress}Copy(${entityId})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing with long-zero address and no Hedera ID", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                address: longZeroAddress
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${evmAddress}Copy(${entityId})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing with Hedera ID and EVM address", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                address: evmAddress,
+                id: entityId,
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${evmAddress}Copy(${entityId})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing with System Contract ID and no EVM address", async () => {
+
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                id: systemContractId,
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${systemContractAddress}Copy(${systemContractLabel})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+})

--- a/tests/unit/utils/EthereumAddress.spec.ts
+++ b/tests/unit/utils/EthereumAddress.spec.ts
@@ -25,7 +25,7 @@ describe("EthereumAddress", () => {
     test("Parsing from a long-zero address", () => {
 
         const longZeroAddress = "0x000000000000000000000000000000000010400e"
-        const compactAddress = "0x0…10400e"
+        const compactAddress = "0x00…10400e"
         const entityId = "0.0.1064974"
 
         const address = EthereumAddress.parse(longZeroAddress)
@@ -39,7 +39,7 @@ describe("EthereumAddress", () => {
     test("Parsing from a native evm address", () => {
 
         const nativeEvmAddress = "0xe6d5514b8de7ef9e5f5c4cc2e8ca0207129deb65"
-        const compactAddress = "0xe…9deb65"
+        const compactAddress = "0xe6…9deb65"
 
         const address = EthereumAddress.parse(nativeEvmAddress)
 

--- a/tests/unit/utils/EthereumAddress.spec.ts
+++ b/tests/unit/utils/EthereumAddress.spec.ts
@@ -1,0 +1,61 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EthereumAddress} from "@/utils/EthereumAddress";
+
+describe("EthereumAddress", () => {
+
+    test("Parsing from a long-zero address", () => {
+
+        const longZeroAddress = "0x000000000000000000000000000000000010400e"
+        const compactAddress = "0x0…10400e"
+        const entityId = "0.0.1064974"
+
+        const address = EthereumAddress.parse(longZeroAddress)
+
+        expect(address?.isLongZeroForm()).toBe(true)
+        expect(address?.toString()).toBe(longZeroAddress)
+        expect(address?.toCompactString()).toBe(compactAddress)
+        expect(address?.toEntityID()?.toString()).toBe(entityId)
+    })
+
+    test("Parsing from a native evm address", () => {
+
+        const nativeEvmAddress = "0xe6d5514b8de7ef9e5f5c4cc2e8ca0207129deb65"
+        const compactAddress = "0xe…9deb65"
+
+        const address = EthereumAddress.parse(nativeEvmAddress)
+
+        expect(address?.isLongZeroForm()).toBe(false)
+        expect(address?.toString()).toBe(nativeEvmAddress)
+        expect(address?.toCompactString()).toBe(compactAddress)
+        expect(address?.toEntityID()).toBe(null)
+    })
+
+    test("Parsing from an invalid address", () => {
+
+        const invalidEvmAddress = "0xe6d5514b8de7ef9e5f5c4cc2e8ca0207129deb6500"
+
+        const address = EthereumAddress.parse(invalidEvmAddress)
+
+        expect(address).toBe(null)
+    })
+
+})


### PR DESCRIPTION
**Description**:

This PR refactors the logic of EVMAddress and enhances it such that when the evmAddress argument is a long-zero address, we systematically fetch the corresponding Account information to retrieve its native EVM address in case it holds one.
The compact display now shows 1 byte (instead of 1 digit) before the ellipsis.

**Related issue(s)**:

Related to #629. 
It is not confirmed at this point that we want to duplicate the _from_ property found in the _Contract Result_ to show a _Sender_ property in the top section. But in any case we want to make sure the _from_ (and other EVM addresses) show the native EVM address when there is one.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
