### PR TITLE
00639 HBAR transfer diagram for 1686467061.803821702 is missing

### DIFF
--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -53,7 +53,7 @@
       v-else
       v-bind:transaction="transaction"/>
 
-  <template v-if="netAmount === 0 && !compact">
+  <template v-if="netAmount <= 0 && !compact">
     <HbarTransferGraphF
         data-cy="feeTransfers"
         class="mt-4"


### PR DESCRIPTION

**Description**:

In transaction [1686467061.803821702](https://hashscan.io/mainnet/transaction/1686467061.803821702), net amount (ie sum of all positive hbar transfers - charged fee) is negative.

So far, `TransferGraphSection` vue assumed that net amount was always positive and simply skip`Hbar / Fee Transfer `diagram in the case above.

With the changes below, `TransferGraphSection` vue now displays transfers as a fee diagram when net amount is negative.


**Related issue(s)**:

Fixes #639 

**Notes for reviewer**:

Uses transaction  [1686467061.803821702](https://hashscan.io/mainnet/transaction/1686467061.803821702) to experiment. Without the fix, `Transfer Section` does not contain `Hbar/Fee Transfer` subsection. With the fix, `Fee Transfer` subsection is displayed.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
