### PR TITLE
00600 Explorer fails to decode call to system contract

### DIFF
--- a/public/abi/IHederaTokenService.json
+++ b/public/abi/IHederaTokenService.json
@@ -151,9 +151,9 @@
           "type": "address"
         },
         {
-          "internalType": "uint64",
+          "internalType": "int64",
           "name": "amount",
-          "type": "uint64"
+          "type": "int64"
         },
         {
           "internalType": "int64[]",
@@ -169,9 +169,9 @@
           "type": "int64"
         },
         {
-          "internalType": "uint64",
+          "internalType": "int64",
           "name": "newTotalSupply",
-          "type": "uint64"
+          "type": "int64"
         }
       ],
       "stateMutability": "nonpayable",
@@ -263,9 +263,9 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "second",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -273,9 +273,9 @@
                   "type": "address"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "autoRenewPeriod",
-                  "type": "uint32"
+                  "type": "int64"
                 }
               ],
               "internalType": "struct IHederaTokenService.Expiry",
@@ -288,14 +288,14 @@
           "type": "tuple"
         },
         {
-          "internalType": "uint64",
+          "internalType": "int64",
           "name": "initialTotalSupply",
-          "type": "uint64"
+          "type": "int64"
         },
         {
-          "internalType": "uint32",
+          "internalType": "int32",
           "name": "decimals",
-          "type": "uint32"
+          "type": "int32"
         }
       ],
       "name": "createFungibleToken",
@@ -400,9 +400,9 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "second",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -410,9 +410,9 @@
                   "type": "address"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "autoRenewPeriod",
-                  "type": "uint32"
+                  "type": "int64"
                 }
               ],
               "internalType": "struct IHederaTokenService.Expiry",
@@ -425,21 +425,21 @@
           "type": "tuple"
         },
         {
-          "internalType": "uint64",
+          "internalType": "int64",
           "name": "initialTotalSupply",
-          "type": "uint64"
+          "type": "int64"
         },
         {
-          "internalType": "uint32",
+          "internalType": "int32",
           "name": "decimals",
-          "type": "uint32"
+          "type": "int32"
         },
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "amount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -469,24 +469,24 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "numerator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "denominator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "minimumAmount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "maximumAmount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "bool",
@@ -606,9 +606,9 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "second",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -616,9 +616,9 @@
                   "type": "address"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "autoRenewPeriod",
-                  "type": "uint32"
+                  "type": "int64"
                 }
               ],
               "internalType": "struct IHederaTokenService.Expiry",
@@ -733,9 +733,9 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "second",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -743,9 +743,9 @@
                   "type": "address"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "autoRenewPeriod",
-                  "type": "uint32"
+                  "type": "int64"
                 }
               ],
               "internalType": "struct IHederaTokenService.Expiry",
@@ -760,9 +760,9 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "amount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -792,19 +792,19 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "numerator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "denominator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "amount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -1170,9 +1170,9 @@
                     {
                       "components": [
                         {
-                          "internalType": "uint32",
+                          "internalType": "int64",
                           "name": "second",
-                          "type": "uint32"
+                          "type": "int64"
                         },
                         {
                           "internalType": "address",
@@ -1180,9 +1180,9 @@
                           "type": "address"
                         },
                         {
-                          "internalType": "uint32",
+                          "internalType": "int64",
                           "name": "autoRenewPeriod",
-                          "type": "uint32"
+                          "type": "int64"
                         }
                       ],
                       "internalType": "struct IHederaTokenService.Expiry",
@@ -1195,9 +1195,9 @@
                   "type": "tuple"
                 },
                 {
-                  "internalType": "uint64",
+                  "internalType": "int64",
                   "name": "totalSupply",
-                  "type": "uint64"
+                  "type": "int64"
                 },
                 {
                   "internalType": "bool",
@@ -1217,9 +1217,9 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "amount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "address",
@@ -1249,24 +1249,24 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "numerator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "denominator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "minimumAmount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "maximumAmount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "bool",
@@ -1286,19 +1286,19 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "numerator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "denominator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "amount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "address",
@@ -1331,9 +1331,9 @@
               "type": "tuple"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int32",
               "name": "decimals",
-              "type": "uint32"
+              "type": "int32"
             }
           ],
           "internalType": "struct IHederaTokenService.FungibleTokenInfo",
@@ -1452,9 +1452,9 @@
                     {
                       "components": [
                         {
-                          "internalType": "uint32",
+                          "internalType": "int64",
                           "name": "second",
-                          "type": "uint32"
+                          "type": "int64"
                         },
                         {
                           "internalType": "address",
@@ -1462,9 +1462,9 @@
                           "type": "address"
                         },
                         {
-                          "internalType": "uint32",
+                          "internalType": "int64",
                           "name": "autoRenewPeriod",
-                          "type": "uint32"
+                          "type": "int64"
                         }
                       ],
                       "internalType": "struct IHederaTokenService.Expiry",
@@ -1477,9 +1477,9 @@
                   "type": "tuple"
                 },
                 {
-                  "internalType": "uint64",
+                  "internalType": "int64",
                   "name": "totalSupply",
-                  "type": "uint64"
+                  "type": "int64"
                 },
                 {
                   "internalType": "bool",
@@ -1499,9 +1499,9 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "amount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "address",
@@ -1531,24 +1531,24 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "numerator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "denominator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "minimumAmount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "maximumAmount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "bool",
@@ -1568,19 +1568,19 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "numerator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "denominator",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "amount",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "address",
@@ -1664,9 +1664,9 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "amount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -1696,24 +1696,24 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "numerator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "denominator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "minimumAmount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "maximumAmount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "bool",
@@ -1733,19 +1733,19 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "numerator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "denominator",
-              "type": "uint32"
+              "type": "int64"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "amount",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -1837,9 +1837,9 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "second",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -1847,9 +1847,9 @@
               "type": "address"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "autoRenewPeriod",
-              "type": "uint32"
+              "type": "int64"
             }
           ],
           "internalType": "struct IHederaTokenService.Expiry",
@@ -1961,9 +1961,9 @@
                 {
                   "components": [
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "second",
-                      "type": "uint32"
+                      "type": "int64"
                     },
                     {
                       "internalType": "address",
@@ -1971,9 +1971,9 @@
                       "type": "address"
                     },
                     {
-                      "internalType": "uint32",
+                      "internalType": "int64",
                       "name": "autoRenewPeriod",
-                      "type": "uint32"
+                      "type": "int64"
                     }
                   ],
                   "internalType": "struct IHederaTokenService.Expiry",
@@ -1986,9 +1986,9 @@
               "type": "tuple"
             },
             {
-              "internalType": "uint64",
+              "internalType": "int64",
               "name": "totalSupply",
-              "type": "uint64"
+              "type": "int64"
             },
             {
               "internalType": "bool",
@@ -2008,9 +2008,9 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "amount",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -2040,24 +2040,24 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "numerator",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "denominator",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "minimumAmount",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "maximumAmount",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "bool",
@@ -2077,19 +2077,19 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "numerator",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "denominator",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "amount",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -2353,9 +2353,9 @@
           "type": "address"
         },
         {
-          "internalType": "uint64",
+          "internalType": "int64",
           "name": "amount",
-          "type": "uint64"
+          "type": "int64"
         },
         {
           "internalType": "bytes[]",
@@ -2371,9 +2371,9 @@
           "type": "int64"
         },
         {
-          "internalType": "uint64",
+          "internalType": "int64",
           "name": "newTotalSupply",
-          "type": "uint64"
+          "type": "int64"
         },
         {
           "internalType": "int64[]",
@@ -2400,6 +2400,24 @@
           "type": "int64"
         }
       ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "encodedFunctionSelector",
+          "type": "bytes"
+        }
+      ],
+      "name": "redirectForToken",
+      "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
     },
@@ -2708,9 +2726,9 @@
         {
           "components": [
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "second",
-              "type": "uint32"
+              "type": "int64"
             },
             {
               "internalType": "address",
@@ -2718,9 +2736,9 @@
               "type": "address"
             },
             {
-              "internalType": "uint32",
+              "internalType": "int64",
               "name": "autoRenewPeriod",
-              "type": "uint32"
+              "type": "int64"
             }
           ],
           "internalType": "struct IHederaTokenService.Expiry",
@@ -2830,9 +2848,9 @@
             {
               "components": [
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "second",
-                  "type": "uint32"
+                  "type": "int64"
                 },
                 {
                   "internalType": "address",
@@ -2840,9 +2858,9 @@
                   "type": "address"
                 },
                 {
-                  "internalType": "uint32",
+                  "internalType": "int64",
                   "name": "autoRenewPeriod",
-                  "type": "uint32"
+                  "type": "int64"
                 }
               ],
               "internalType": "struct IHederaTokenService.Expiry",
@@ -2942,9 +2960,9 @@
           "type": "address"
         },
         {
-          "internalType": "uint32",
+          "internalType": "int64",
           "name": "amount",
-          "type": "uint32"
+          "type": "int64"
         }
       ],
       "name": "wipeTokenAccount",

--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -56,6 +56,10 @@
             <template v-slot:value>
                 <StringValue v-if="decodedError" :string-value="decodedError"/>
                 <HexaValue v-else :byte-string="error" :show-none="true"/>
+                <div v-if="errorDecodingStatus" class="h-is-extra-text h-is-text-size-3">
+                    <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
+                    <span>{{ errorDecodingStatus }}</span>
+                </div>
             </template>
         </Property>
 
@@ -103,6 +107,7 @@ export default defineComponent({
             errorSignature: props.analyzer.errorSignature,
             errorHash: props.analyzer.errorHash,
             errorInputs: props.analyzer.errorInputs,
+            errorDecodingStatus: props.analyzer.errorDecodingStatus,
             decodedError,
             initialLoading
         }

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -50,6 +50,10 @@
       <template v-slot:name>Input - Function & Args</template>
       <template v-slot:value>
         <HexaValue :byte-string="input" :show-none="true"/>
+        <div v-if="inputDecodingStatus" class="h-is-extra-text h-is-text-size-3">
+            <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
+            <span>{{ inputDecodingStatus }}</span>
+        </div>
       </template>
     </Property>
   </template>
@@ -89,6 +93,7 @@ export default defineComponent({
       signature: props.analyzer.signature,
       functionHash: props.analyzer.functionHash,
       inputs: props.analyzer.inputs,
+      inputDecodingStatus: props.analyzer.inputDecodingStatus,
       initialLoading
     }
   }

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -56,6 +56,10 @@
         <template v-slot:name>Output Result</template>
         <template v-slot:value>
           <HexaValue :byte-string="output" :show-none="true"/>
+          <div v-if="outputDecodingStatus" class="h-is-extra-text h-is-text-size-3">
+            <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
+            <span>{{ outputDecodingStatus }}</span>
+          </div>
         </template>
     </Property>
 
@@ -98,6 +102,7 @@ export default defineComponent({
       output: props.analyzer.normalizedOutput,
       signature: props.analyzer.signature,
       outputs: props.analyzer.outputs,
+      outputDecodingStatus: props.analyzer.outputDecodingStatus,
       initialLoading
     }
   }

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -125,8 +125,8 @@ export class FunctionCallAnalyzer {
 
     public readonly errorInputs: ComputedRef<NameTypeValue[]> = computed(() => {
         const result: NameTypeValue[] = []
-        if (this.decodedFunctionError.value !== null) {
-            const results = this.decodedFunctionError.value
+        if (this.errorDescription.value !== null) {
+            const results = this.errorDescription.value.args
             const fragmentInputs = this.errorDescription.value?.errorFragment.inputs ?? []
             for (let i = 0, count = results.length; i < count; i += 1) {
                 const value = results[i]
@@ -172,25 +172,6 @@ export class FunctionCallAnalyzer {
         if (td !== null && i !== null && output !== null) {
             try {
                 result = i.decodeFunctionResult(td.functionFragment, output)
-            } catch {
-                result = null
-            }
-        } else {
-            result = null
-        }
-        return result
-    })
-
-    private readonly decodedFunctionError: ComputedRef<ethers.utils.Result|null> = computed(() => {
-        let result: ethers.utils.Result|null
-        const d = this.errorDescription.value
-        const i = this.contractAnalyzer.interface.value
-        const error = this.error.value
-        if (d !== null && i !== null && error !== null) {
-            try {
-                // result = i.decodeErrorResult(d.errorFragment, error)
-                const bytes = ethers.utils.arrayify(error)
-                result = ethers.utils.defaultAbiCoder.decode(d.errorFragment.inputs, bytes.slice(4))
             } catch {
                 result = null
             }

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -48,6 +48,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
         // 2) mount
         functionCallAnalyzer.mount()
@@ -58,8 +61,11 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
-        // 3) input setup
+        // 3) input setup (valid encoding)
         input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
         output.value = "0x0000000000000000000000000000000000000000000000000000000005a995c0"
         contractId.value = "0.0.359"
@@ -75,8 +81,27 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         ])
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
-        // 4) unmount
+        // 4) input setup (invalid encoding)
+        input.value = "0x618dc65e0000000000000000000000000000000000163b5a70a082310000000000000000000000005fe56763c7633efefe8c2272f19732521a48e300"
+        output.value = "0x00000000000000000000000000000000000000000000000000003dc604b33217"
+        contractId.value = "0.0.359"
+        await flushPromises()
+        expect(functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(functionCallAnalyzer.signature.value).toBeNull()
+        expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorHash.value).toBeNull()
+        expect(functionCallAnalyzer.errorSignature.value).toBeNull()
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBe("Decoding Error (data out-of-bounds)")
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
+
+
+        // 5) unmount
         functionCallAnalyzer.unmount()
         await flushPromises()
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -85,6 +110,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
     })
 

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -50,6 +50,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
         // 2) mount
@@ -63,6 +64,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
         // 3) input setup (valid encoding)
@@ -83,9 +85,10 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
-        // 4) input setup (invalid encoding)
+        // 4) input setup (invalid input encoding)
         input.value = "0x618dc65e0000000000000000000000000000000000163b5a70a082310000000000000000000000005fe56763c7633efefe8c2272f19732521a48e300"
         output.value = "0x00000000000000000000000000000000000000000000000000003dc604b33217"
         contractId.value = "0.0.359"
@@ -98,10 +101,30 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBe("Decoding Error (data out-of-bounds)")
+        expect(functionCallAnalyzer.outputDecodingStatus.value).toBe("Decoding Error (data out-of-bounds)")
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
+
+        // 5) output setup (invalid output encoding)
+        input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
+        output.value = "0x000000009999999999999999999999999"
+        contractId.value = "0.0.359"
+        await flushPromises()
+        expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
+        expect(functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
+        expect(functionCallAnalyzer.inputs.value).toStrictEqual([
+            new NameTypeValue("account", "address", "0x845b706151aEd537b1FD81c1Ea4EA03920097ABD"),
+            new NameTypeValue("token", "address", "0x0000000000000000000000000000000002E6Ae09"),
+        ])
+        expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorHash.value).toBeNull()
+        expect(functionCallAnalyzer.errorSignature.value).toBeNull()
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.outputDecodingStatus.value).toBe("Decoding Error (hex data is odd-length)")
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
 
-        // 5) unmount
+        // 6) unmount
         functionCallAnalyzer.unmount()
         await flushPromises()
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -112,6 +135,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
 
     })


### PR DESCRIPTION
**Description**:

Changes below:
- update Hedera Token Service ABI embedded in Explorer (`IHederaTokenService.json`)
- enhanced error processing when decoding input / output / error values from contract call transactions.

When a decoding error is reported by `etherjs`, Explorer now displays an error message as below:

<img width="1277" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/8b1a2165-54a0-4443-a7a9-c570021547c2">


**Related issue(s)**:

Fixes #600

**Notes for reviewer**:

Uses `mainnet` transaction [1684236107.179110285](https://hashscan.io/mainnet/transaction/1684236107.179110285) to visualize error message reported when decoding error happens.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
