### PR TITLE
00646 Contract error returns should be decoded if they are ASCII

### DIFF
--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -55,11 +55,13 @@
             <template v-slot:name>Error Message</template>
             <template v-slot:value>
                 <StringValue v-if="decodedError" :string-value="decodedError"/>
-                <HexaValue v-else :byte-string="error" :show-none="true"/>
-                <div v-if="errorDecodingStatus" class="h-is-extra-text h-is-text-size-3">
-                    <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
-                    <span>{{ errorDecodingStatus }}</span>
-                </div>
+                <template v-else>
+                    <HexaValue :byte-string="error" :show-none="true"/>
+                    <div v-if="errorDecodingStatus" class="h-is-extra-text h-is-text-size-3">
+                        <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
+                        <span>{{ errorDecodingStatus }}</span>
+                    </div>
+                </template>
             </template>
         </Property>
 

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -156,7 +156,7 @@ export class FunctionCallAnalyzer {
     public readonly outputDecodingStatus = computed(() => {
         let result: string|null
 
-        if (this.transactionDecodingFailure.value !== null) {
+        if (this.transactionDecodingFailure.value !== null && this.normalizedOutput.value !== null) {
             result = this.makeDecodingErrorMessage(this.transactionDecodingFailure.value.reason)
         } else if (this.outputDecodingFailure.value !== null) {
             result = this.makeDecodingErrorMessage(this.outputDecodingFailure.value.reason)


### PR DESCRIPTION
**Description**:

Changes below:
- implement requested feature
- fix bug related to `Output Result` field (see comments in issue)

`HederaUtils.decodeSolidityErrorMessage()` now fallbacks to string decoding using `TextDecoder` class.

Error message in transaction [1686939577.451858743](https://hashscan.io/previewnet/transaction/1686939577.451858743)  is now displayed as:

<img width="1111" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/7592b58c-cdab-42e9-9385-1c76552fd32b">

**Related issue(s)**:

Fixes #646

**Notes for reviewer**:

Use previewnet transaction transaction [1686939577.451858743](https://hashscan.io/previewnet/transaction/1686939577.451858743) to see feature and fix in action.

**Checklist**

- [] Documented (Code comments, README, etc.)
- [] Tested (unit, integration, etc.)
