### PR TITLE
00529 rewards subsection

### DIFF
--- a/src/components/contract/ContractTransactionTable.vue
+++ b/src/components/contract/ContractTransactionTable.vue
@@ -60,7 +60,7 @@
 
     <o-table-column field="transfers" label="Net Amount" v-slot="props">
       <span v-if="showPositiveNetAmount(props.row) > 0">
-        <HbarAmount v-bind:amount="computeNetAmount(props.row)"/>
+        <HbarAmount v-bind:amount="computeNetAmount(props.row.transfers, props.row.charged_tx_fee)"/>
       </span>
     </o-table-column>
 

--- a/src/components/transaction/TransactionAnalyzer.ts
+++ b/src/components/transaction/TransactionAnalyzer.ts
@@ -69,7 +69,9 @@ export class TransactionAnalyzer {
     public readonly hasSucceeded: ComputedRef<boolean> = computed(() => this.result.value == "SUCCESS")
 
     public readonly netAmount: ComputedRef<number> = computed(
-        () => this.transaction.value !== null ? computeNetAmount(this.transaction.value) : 0)
+        () => this.transaction.value !== null
+            ? computeNetAmount(this.transaction.value?.transfers, this.transaction.value?.charged_tx_fee)
+            : 0)
 
     public readonly maxFee: ComputedRef<number> = computed(() => {
         const result = this.transaction.value?.max_fee ? Number.parseFloat(this.transaction.value?.max_fee) : 0

--- a/src/components/transfer_graphs/HbarTransferGraphF.vue
+++ b/src/components/transfer_graphs/HbarTransferGraphF.vue
@@ -23,11 +23,8 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div>
-  <p class="h-is-tertiary-text mb-2">{{ title }}</p>
-
-  <div  v-if="hbarTransferLayout.rowCount >= 1">
-
+  <div v-if="hbarTransferLayout.rowCount >= 1">
+    <p class="h-is-tertiary-text mb-2">{{ title }}</p>
     <div class="graph-container" v-bind:class="{'graph-container-8': dollarVisible }">
 
       <template v-if="dollarVisible">
@@ -69,7 +66,7 @@
           <div class="justify-end">
             <HbarExtra v-if="i <= hbarTransferLayout.sources.length"
                        v-bind:tbarAmount="hbarTransferLayout.sources[i-1].transfer.amount"
-                       v-bind:timestamp="transaction.consensus_timestamp"/>
+                       v-bind:timestamp="transaction?.consensus_timestamp"/>
           </div>
 
         </template>
@@ -103,7 +100,7 @@
           <div class="justify-end" v-bind:class="{'h-has-low-contrast': hasLowContrast(i-1)}">
             <HbarExtra v-if="i <= hbarTransferLayout.destinations.length"
                        v-bind:tbarAmount="hbarTransferLayout.destinations[i-1].transfer.amount"
-                       v-bind:timestamp="transaction.consensus_timestamp"/>
+                       v-bind:timestamp="transaction?.consensus_timestamp"/>
           </div>
 
           <!-- #7 : description -->
@@ -118,11 +115,6 @@
       </template>
 
     </div>
-
-  </div>
-
-  <p v-else-if="showNone" class="has-text-grey">None</p>
-
   </div>
 </template>
 

--- a/src/components/transfer_graphs/NftTransferGraph.vue
+++ b/src/components/transfer_graphs/NftTransferGraph.vue
@@ -24,10 +24,8 @@
 
 <template>
 
-  <div>
+  <div v-if="nftTransferLayout.length >= 1">
     <div v-if="!compact" class="h-is-tertiary-text mb-2">NFT Transfers</div>
-
-    <div  v-if="nftTransferLayout.length >= 1">
 
     <div class="graph-container" v-bind:class="{'graph-container-6': !compact && descriptionVisible}">
 
@@ -60,7 +58,7 @@
         <!-- #2 : nfts -->
         <div>
           <TokenLink
-              v-bind:token-id="nftTransferLayout[i-1].token_id"
+              v-bind:token-id="nftTransferLayout[i-1].token_id ?? undefined"
               v-bind:show-extra="true"
               v-bind:no-anchor="compact"
               data-cy="nft"/>
@@ -95,9 +93,6 @@
       </template>
 
     </div>
-    </div>
-
-    <div v-else-if="!compact" class="has-text-grey">None</div>
   </div>
 
 </template>

--- a/src/components/transfer_graphs/RewardTransferGraph.vue
+++ b/src/components/transfer_graphs/RewardTransferGraph.vue
@@ -1,0 +1,157 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <div v-if="rewardTransferLayout.destinations.length">
+    <p class="h-is-tertiary-text mb-2">Staking Rewards</p>
+
+    <div class="graph-container" v-bind:class="{'graph-container-8': dollarVisible }">
+
+      <template v-if="dollarVisible">
+        <div style="grid-column-end: span 2" class="h-is-text-size-3 has-text-grey-light has-text-weight-light mb-2">Reward Account</div>
+        <div/>
+        <div style="grid-column-end: span 1" class="h-is-text-size-3 has-text-grey-light has-text-weight-light mb-2">Account</div>
+        <div style="grid-column-end: span 2" class="h-is-text-size-3 has-text-grey-light has-text-weight-light mb-2">Amount Rewarded</div>
+        <div/>
+        <div/>
+      </template>
+      <template v-else>
+        <div style="grid-column-end: span 1" class="h-is-text-size-3 has-text-grey-light has-text-weight-light mb-2">Account</div>
+        <div/>
+        <div style="grid-column-end: span 1" class="h-is-text-size-3 has-text-grey-light has-text-weight-light mb-2">Account</div>
+        <div style="grid-column-end: span 1" class="h-is-text-size-3 has-text-grey-light has-text-weight-light mb-2">Amount Rewarded</div>
+        <div/>
+      </template>
+
+      <template v-for="i in rewardTransferLayout.destinations.length" v-bind:key="i">
+
+        <!-- #0 : account id -->
+        <div>
+          <AccountLink v-if="i === 1" account-id="0.0.800" data-cy="awardSourceAccount"/>
+          <div v-else/>
+        </div>
+        <div/>
+
+        <!-- #1 : arrow -->
+        <div  style="position: relative">
+          <ArrowSegment
+              :source-count="1"
+              :dest-count="rewardTransferLayout.destinations.length"
+              :row-index="i-1"/>
+        </div>
+
+        <!-- #2 : account id -->
+        <div>
+          <AccountLink v-if="i <= rewardTransferLayout.destinations.length"
+                       v-bind:account-id="rewardTransferLayout.destinations[i-1].account"
+                       data-cy="destinationAccount"/>
+        </div>
+
+        <!-- #3 : reward amount -->
+        <div class="justify-end">
+          <HbarAmount v-if="i <= rewardTransferLayout.destinations.length"
+                      v-bind:amount="rewardTransferLayout.destinations[i-1].amount"
+                      v-bind:colored="true"/>
+        </div>
+
+        <template v-if="dollarVisible">
+
+          <!-- #4 : dollar amount -->
+          <div class="justify-end">
+            <HbarExtra v-if="i <= rewardTransferLayout.destinations.length"
+                       v-bind:tbarAmount="rewardTransferLayout.destinations[i-1].amount"
+                       v-bind:timestamp="transaction?.consensus_timestamp ?? undefined"/>
+          </div>
+
+        </template>
+        <div/>
+        <div/>
+
+      </template>
+
+    </div>
+  </div>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, inject, PropType} from "vue";
+import AccountLink from "@/components/values/AccountLink.vue";
+import ArrowSegment from "@/components/transfer_graphs/ArrowSegment.vue";
+import HbarAmount from "@/components/values/HbarAmount.vue";
+import HbarExtra from "@/components/values/HbarExtra.vue";
+import {Transaction} from "@/schemas/HederaSchemas";
+import {RewardTransferLayout} from "@/components/transfer_graphs/layout/RewardTransferLayout";
+
+export default defineComponent({
+  name: "RewardTransferGraph",
+  components: {HbarAmount, HbarExtra, ArrowSegment, AccountLink},
+  props: {
+    transaction: Object as PropType<Transaction>,
+    title: String,
+    showNone: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props) {
+
+    const rewardTransferLayout = computed(() => new RewardTransferLayout(props.transaction))
+
+    const dollarVisible = inject("isSmallScreen", true)
+
+    return {
+      rewardTransferLayout,
+      dollarVisible
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+.graph-container {
+  display: inline-grid;
+  grid-template-columns: repeat(5, auto);
+  column-gap: 1em;
+}
+
+.graph-container-8 {
+  grid-template-columns: repeat(8, auto);
+}
+
+div.graph-container > div.justify-end {
+  justify-self: end;
+}
+
+</style>

--- a/src/components/transfer_graphs/RewardTransferGraph.vue
+++ b/src/components/transfer_graphs/RewardTransferGraph.vue
@@ -23,8 +23,8 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div v-if="rewardTransferLayout.destinations.length">
-    <p class="h-is-tertiary-text mb-2">Staking Rewards</p>
+  <div v-if="rewardTransferLayout.destinations.length >= 1">
+    <p class="h-is-tertiary-text mb-2">Staking Reward Transfers</p>
 
     <div class="graph-container" v-bind:class="{'graph-container-8': dollarVisible }">
 
@@ -113,11 +113,6 @@ export default defineComponent({
   components: {HbarAmount, HbarExtra, ArrowSegment, AccountLink},
   props: {
     transaction: Object as PropType<Transaction>,
-    title: String,
-    showNone: {
-      type: Boolean,
-      default: false
-    }
   },
   setup(props) {
 

--- a/src/components/transfer_graphs/RewardTransferGraph.vue
+++ b/src/components/transfer_graphs/RewardTransferGraph.vue
@@ -24,7 +24,7 @@
 
 <template>
   <div v-if="rewardTransferLayout.destinations.length >= 1">
-    <p class="h-is-tertiary-text mb-2">Staking Reward Transfers</p>
+    <p class="h-is-tertiary-text mb-2">Staking Rewards</p>
 
     <div class="graph-container" v-bind:class="{'graph-container-8': dollarVisible }">
 

--- a/src/components/transfer_graphs/TokenTransferGraphC.vue
+++ b/src/components/transfer_graphs/TokenTransferGraphC.vue
@@ -24,9 +24,7 @@
 
 <template>
 
-  <div v-if="tokenTransferLayout.length >= 1">
-
-    <div class="graph-container">
+    <div v-if="tokenTransferLayout.length >= 1" class="graph-container">
 
       <template v-for="s in tokenTransferLayout.length" v-bind:key="s">
 
@@ -54,7 +52,7 @@
           <div class="justify-end">
             <TokenAmount v-if="i === 1"
                          v-bind:amount="BigInt(tokenTransferLayout[s-1].netAmount)"
-                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId ?? undefined"
                          v-bind:show-extra="true"/>
           </div>
 
@@ -82,8 +80,6 @@
       </template>
 
     </div>
-
-  </div>
 
 </template>
 

--- a/src/components/transfer_graphs/TokenTransferGraphF.vue
+++ b/src/components/transfer_graphs/TokenTransferGraphF.vue
@@ -24,10 +24,8 @@
 
 <template>
 
-  <div>
+  <div v-if="tokenTransferLayout.length >= 1">
     <p class="h-is-tertiary-text mb-2">Token Transfers</p>
-
-    <div v-if="tokenTransferLayout.length >= 1">
 
     <div class="graph-container" v-bind:class="{'graph-container-8': symbolVisible}">
 
@@ -64,14 +62,14 @@
           <div class="justify-end">
             <TokenAmount v-if="i <= tokenTransferLayout[s-1].sources.length"
                          v-bind:amount="BigInt(tokenTransferLayout[s-1].sources[i-1].amount)"
-                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"/>
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId ?? undefined"/>
           </div>
 
           <!-- #2 : token symbol -->
           <template v-if="symbolVisible">
             <div data-cy="tokenExtra">
               <TokenExtra v-if="i <= tokenTransferLayout[s-1].sources.length"
-                          v-bind:token-id="tokenTransferLayout[s-1].tokenId"
+                          v-bind:token-id="tokenTransferLayout[s-1].tokenId ?? undefined"
                           v-bind:use-anchor="true"/>
             </div>
           </template>
@@ -97,7 +95,7 @@
           <div>
             <TokenAmount v-if="i <= tokenTransferLayout[s-1].destinations.length"
                          v-bind:amount="BigInt(tokenTransferLayout[s-1].destinations[i-1].amount)"
-                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"/>
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId ?? undefined"/>
           </div>
 
           <template v-if="symbolVisible">
@@ -105,7 +103,7 @@
             <!-- #6 : token symbol -->
             <div data-cy="tokenExtra">
               <TokenExtra v-if="i <= tokenTransferLayout[s-1].destinations.length"
-                          v-bind:token-id="tokenTransferLayout[s-1].tokenId"
+                          v-bind:token-id="tokenTransferLayout[s-1].tokenId ?? undefined"
                           v-bind:use-anchor="true"/>
             </div>
 
@@ -123,10 +121,6 @@
       </template>
 
     </div>
-
-    </div>
-
-    <p v-else class="has-text-grey">None</p>
   </div>
 
 </template>

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -33,29 +33,29 @@
   <HbarTransferGraphF
       v-else
       data-cy="hbarTransfers"
-      title="Hbar Transfers" v-bind:transaction="transaction"/>
-  <br/>
+      title="Hbar Transfers"
+      v-bind:class="{'mb-4': displayRewardTransfers | displayNftTransfers | displayTokenTransfers}" v-bind:transaction="transaction"/>
+
+  <RewardTransferGraph
+      v-if="!compact"
+      data-cy="rewardTransfers"
+      v-bind:class="{'mb-4': displayNftTransfers | displayTokenTransfers}"
+      v-bind:transaction="transaction"/>
 
   <NftTransferGraph
       data-cy="nftTransfers"
-      :class="{'mb-4': !compact}"
+      v-bind:class="{'mb-4': !compact && displayTokenTransfers}"
       v-bind:transaction="transaction"
       v-bind:compact="compact"/>
 
   <TokenTransferGraphC
-      data-cy="tokenTransfers"
       v-if="compact"
+      data-cy="tokenTransfers"
       v-bind:transaction="transaction"/>
   <TokenTransferGraphF
-      data-cy="tokenTransfers"
       v-else
+      data-cy="tokenTransfers"
       v-bind:transaction="transaction"/>
-
-  <RewardTransferGraph
-      data-cy="rewardTransfers"
-      :class="{'mb-4': !compact}"
-      v-bind:transaction="transaction"
-      v-bind:compact="compact"/>
 
 </template>
 
@@ -98,8 +98,15 @@ export default defineComponent({
       return props.transaction ? computeNetAmount(props.transaction.transfers, props.transaction.charged_tx_fee) : 0
     })
 
+    const displayRewardTransfers = computed(() => props.transaction?.staking_reward_transfers && props.transaction?.staking_reward_transfers.length >= 1)
+    const displayNftTransfers = computed(() => props.transaction?.nft_transfers && props.transaction?.nft_transfers.length >= 1)
+    const displayTokenTransfers = computed(() => props.transaction?.token_transfers && props.transaction?.token_transfers.length >= 1)
+
     return {
       netAmount,
+      displayRewardTransfers,
+      displayNftTransfers,
+      displayTokenTransfers
     }
   }
 })

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -36,15 +36,9 @@
       title="Hbar Transfers"
       v-bind:class="{'mb-4': displayRewardTransfers | displayNftTransfers | displayTokenTransfers}" v-bind:transaction="transaction"/>
 
-  <RewardTransferGraph
-      v-if="!compact"
-      data-cy="rewardTransfers"
-      v-bind:class="{'mb-4': displayNftTransfers | displayTokenTransfers}"
-      v-bind:transaction="transaction"/>
-
   <NftTransferGraph
       data-cy="nftTransfers"
-      v-bind:class="{'mb-4': !compact && displayTokenTransfers}"
+      v-bind:class="{'mb-4': !compact && (displayTokenTransfers || displayRewardTransfers)}"
       v-bind:transaction="transaction"
       v-bind:compact="compact"/>
 
@@ -55,6 +49,12 @@
   <TokenTransferGraphF
       v-else
       data-cy="tokenTransfers"
+      v-bind:class="{'mb-4': displayRewardTransfers}"
+      v-bind:transaction="transaction"/>
+
+  <RewardTransferGraph
+      v-if="!compact"
+      data-cy="rewardTransfers"
       v-bind:transaction="transaction"/>
 
 </template>

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -105,7 +105,7 @@ export default defineComponent({
   setup(props) {
 
     const netAmount = computed(() => {
-      return props.transaction ? computeNetAmount(props.transaction) : 0
+      return props.transaction ? computeNetAmount(props.transaction.transfers, props.transaction.charged_tx_fee) : 0
     })
 
     return {

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -53,6 +53,12 @@
       v-else
       v-bind:transaction="transaction"/>
 
+  <RewardTransferGraph
+      data-cy="rewardTransfers"
+      :class="{'mb-4': !compact}"
+      v-bind:transaction="transaction"
+      v-bind:compact="compact"/>
+
   <template v-if="netAmount <= 0 && !compact">
     <HbarTransferGraphF
         data-cy="feeTransfers"
@@ -77,10 +83,12 @@ import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue"
 import TokenTransferGraphC from "@/components/transfer_graphs/TokenTransferGraphC.vue";
 import TokenTransferGraphF from "@/components/transfer_graphs/TokenTransferGraphF.vue";
 import {computeNetAmount} from "@/utils/TransactionTools";
+import RewardTransferGraph from "@/components/transfer_graphs/RewardTransferGraph.vue";
 
 export default defineComponent({
   name: "TransferGraphSection",
   components: {
+    RewardTransferGraph,
     NftTransferGraph,
     TokenTransferGraphC,
     TokenTransferGraphF,

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -24,19 +24,17 @@
 
 <template>
 
-  <template v-if="netAmount > 0">
-
+  <template v-if="compact">
     <HbarTransferGraphC
-        v-if="compact"
+        v-if="netAmount > 0"
         data-cy="hbarTransfers"
         v-bind:transaction="transaction"/>
-    <HbarTransferGraphF
-        v-else
-        data-cy="hbarTransfers"
-        v-bind:transaction="transaction" title="Hbar Transfers"/>
-    <br/>
-
   </template>
+  <HbarTransferGraphF
+      v-else
+      data-cy="hbarTransfers"
+      title="Hbar Transfers" v-bind:transaction="transaction"/>
+  <br/>
 
   <NftTransferGraph
       data-cy="nftTransfers"
@@ -58,14 +56,6 @@
       :class="{'mb-4': !compact}"
       v-bind:transaction="transaction"
       v-bind:compact="compact"/>
-
-  <template v-if="netAmount <= 0 && !compact">
-    <HbarTransferGraphF
-        data-cy="feeTransfers"
-        class="mt-4"
-        v-bind:transaction="transaction" title="Fee Transfers" :show-none="true"/>
-  </template>
-
 
 </template>
 

--- a/src/components/transfer_graphs/layout/RewardTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/RewardTransferLayout.ts
@@ -1,0 +1,50 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+    compareTransferByAccount,
+    StakingRewardTransfer,
+    Transaction,
+} from "@/schemas/HederaSchemas";
+
+export class RewardTransferLayout {
+
+    public readonly transaction: Transaction|undefined
+    public readonly destinations = Array<StakingRewardTransfer>()
+    public readonly rewardAmount: number
+
+    //
+    // Public
+    //
+
+    public constructor(transaction: Transaction|undefined) {
+
+        this.transaction = transaction
+        this.rewardAmount = 0
+
+        if (this.transaction?.staking_reward_transfers) {
+            for (const t of this.transaction.staking_reward_transfers) {
+                this.destinations.push(t)
+                this.rewardAmount += t.amount
+            }
+            this.destinations.sort(compareTransferByAccount)
+        }
+    }
+}

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -211,7 +211,7 @@
       </template>
     </DashboardCard>
 
-    <DashboardCard class="h-card">
+    <DashboardCard v-if="displayTransfers" class="h-card">
       <template v-slot:title>
         <span class="h-is-secondary-title">Transfers</span>
       </template>
@@ -324,6 +324,11 @@ export default defineComponent({
       return transactionGroupAnalyzer.childTransactions.value.length > MAX_INLINE_CHILDREN
     })
 
+    const displayTransfers = computed(() =>
+        (transactionDetail.value?.transfers && transactionDetail.value.transfers.length > 0)
+        || (transactionDetail.value?.token_transfers && transactionDetail.value.token_transfers.length > 0)
+        || (transactionDetail.value?.nft_transfers && transactionDetail.value.nft_transfers.length > 0)
+    )
 
     const routeName = computed(() => {
       return transactionAnalyzer.entityDescriptor.value?.routeName
@@ -436,6 +441,7 @@ export default defineComponent({
       makeOperatorAccountLabel,
       routeToAllTransactions,
       displayAllChildrenLinks,
+      displayTransfers,
       topicMessage: topicMessageLookup.entity,
       isTokenAssociation: transactionAnalyzer.isTokenAssociation,
       associatedTokens: transactionAnalyzer.tokens

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -149,7 +149,7 @@ export interface Transaction {
     parent_consensus_timestamp: string | null | undefined
     result: string | undefined
     scheduled: boolean | undefined
-    // staking_reward_transfers: ...
+    staking_reward_transfers: StakingRewardTransfer[] | undefined
     token_transfers: TokenTransfer[] | undefined
     transaction_hash: string | undefined
     transaction_id: string | undefined
@@ -201,6 +201,11 @@ export interface Transfer {
 
 export interface TokenTransfer extends Transfer {
     token_id: string | null                         // Network entity ID in the format of shard.realm.num
+}
+
+export interface StakingRewardTransfer {
+    account: string | null                          // Network entity ID in the format of shard.realm.num
+    amount: number
 }
 
 export interface CustomFee {
@@ -263,7 +268,7 @@ export enum TransactionResult {
     FAILURE = "fail"
 }
 
-export function compareTransferByAccount(t1: Transfer, t2: Transfer): number {
+export function compareTransferByAccount(t1: Transfer | StakingRewardTransfer, t2: Transfer | StakingRewardTransfer): number {
     let result: number
     const account1 = t1.account
     const account2 = t2.account

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -95,7 +95,7 @@ export function makeNodeOwnerDescription(node: NetworkNode, short= false): strin
     } else {
         result = description
     }
-    return short ? result.split('|')[0] : result
+    return short ? result.split('|')[0].trimEnd() : result
 }
 
 export function makeDefaultNodeDescription(nodeId: number | null): string {

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -85,7 +85,7 @@ export function makeNodeDescriptionPrefix(node: NetworkNode): string {
     return result
 }
 
-export function makeNodeOwnerDescription(node: NetworkNode): string {
+export function makeNodeOwnerDescription(node: NetworkNode, short= false): string {
     const description = makeNodeDescription(node)
     let result: string
     if (description?.slice(0, 9).toLowerCase() === "hosted by") {
@@ -95,20 +95,24 @@ export function makeNodeOwnerDescription(node: NetworkNode): string {
     } else {
         result = description
     }
-    return result
+    return short ? result.split('|')[0] : result
 }
 
 export function makeDefaultNodeDescription(nodeId: number | null): string {
     return "Node " + nodeId ?? "?"
 }
 
-export function makeOperatorDescription(accountId: string, nodes: NetworkNode[]): string | null {
+export function makeOperatorDescription(accountId: string, nodes: NetworkNode[], isFee=false): string | null {
     let result: string|null
     if (accountId === "0.0.98") {
         result = "Hedera fee collection account"
+    } else if(accountId === "0.0.800") {
+        result = isFee ? "Staking reward account fee" : "Staking reward account"
     } else {
         const node = lookupNodeByAccountId(accountId, nodes)
-        result = node !== null ? makeNodeDescription(node) : null
+        result = node !== null
+            ? isFee ? `Node fee (${makeNodeOwnerDescription(node, true)})` : makeNodeDescription(node)
+            : null
     }
     return result
 }

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -124,10 +124,10 @@ export class EntityID {
             result = compareNumber(this.realm, that.realm)
         }
         if (result == 0) {
-            if (this.num < 100 && that.num >= 100) {
+            if ((this.num < 100 || this.num === 800) && (that.num >= 100 && that.num !== 800)) {
                 // We put this.num at the end
                 result = +1
-            } else if (that.num < 100 && this.num >= 100) {
+            } else if ((that.num < 100 || that.num === 800) && (this.num >= 100 && this.num != 800)) {
                 // We put that.num at the end
                 result = -1
             } else {

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -27,7 +27,7 @@ export function makeSummaryLabel(row: Transaction): string {
 
     switch (row.name) {
         case TransactionType.CRYPTOTRANSFER:
-            netAmount = computeNetAmount(row);
+            netAmount = computeNetAmount(row.transfers, row.charged_tx_fee);
             result = makeTransferLabel(row, netAmount)
             break
         case TransactionType.CONSENSUSCREATETOPIC:
@@ -136,7 +136,7 @@ function makeTransferLabel(row: Transaction, netAmount: number): string {
 export function showPositiveNetAmount(row: Transaction): boolean {
     let result: boolean
 
-    const netAmount = computeNetAmount(row)
+    const netAmount = computeNetAmount(row.transfers, row.charged_tx_fee)
     switch (row.name) {
         case TransactionType.CRYPTOTRANSFER:
             result = true
@@ -327,16 +327,16 @@ function formatMemo(memo64: string): string {
     return result
 }
 
-export function computeNetAmount(row: Transaction): number {
+export function computeNetAmount(transfers: Transfer[] | undefined, transactionFee: number | undefined): number {
     let result = 0
-    if (row.transfers !== undefined) {
-        for (const t of row.transfers) {
+    if (transfers !== undefined) {
+        for (const t of transfers) {
             if (t.amount > 0) {
                 result += t.amount
             }
         }
     }
-    result -= row.charged_tx_fee ?? 0
+    result -= transactionFee ?? 0
     return result
 }
 

--- a/tests/e2e/specs/TransferGraphs.cy.ts
+++ b/tests/e2e/specs/TransferGraphs.cy.ts
@@ -122,7 +122,7 @@ describe('Transfer Graphs Navigation', () => {
             .then(($account) => {
                 cy.wrap($account)
                     .find('a')
-                    .click()
+                    .click({force: true})
                 cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ID:' + $account.text())
             })
@@ -135,7 +135,7 @@ describe('Transfer Graphs Navigation', () => {
             .then(($token) => {
                 cy.wrap($token)
                     .find('a')
-                    .click()
+                    .click({force: true})
                     .then(($name) => {
                         cy.url().should('include', '/mainnet/token/')
                         cy.contains('Token ')
@@ -151,7 +151,7 @@ describe('Transfer Graphs Navigation', () => {
             .then(($token) => {
                 cy.wrap($token)
                     .find('a')
-                    .click()
+                    .click({force: true})
                     .then(($name) => {
                         cy.url().should('include', '/mainnet/token/')
                         cy.contains('Token ')
@@ -166,7 +166,7 @@ describe('Transfer Graphs Navigation', () => {
             .then(($account) => {
                 cy.wrap($account)
                     .find('a')
-                    .click()
+                    .click({force: true})
                 cy.url().should('include', '/mainnet/account/' + $account.text())
                 cy.contains('Account ID:' + $account.text())
             })

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -693,6 +693,74 @@ export const SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS = {
     ]
 }
 
+export const SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE = {
+        "bytes": null,
+        "charged_tx_fee": 26494683,
+        "consensus_timestamp": "1687197609.495612761",
+        "entity_id": "0.0.3005010",
+        "max_fee": "200000000",
+        "memo_base64": "",
+        "name": "CONSENSUSCREATETOPIC",
+        "node": "0.0.25",
+        "nonce": 0,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "c2sSCuCRNOI6gvCYs5KFxe7Z60TV8vJXxuOWNEtH4doYj0MnruIi3NLFXIX6e8s1",
+        "transaction_id": "0.0.1786365-1687197599-390469131",
+        "transfers": [{"account": "0.0.25", "amount": 1190235, "is_approval": false}, {
+            "account": "0.0.98",
+            "amount": 22774004,
+            "is_approval": false
+        }, {"account": "0.0.800", "amount": 2530444, "is_approval": false}, {
+            "account": "0.0.1786365",
+            "amount": -26494683,
+            "is_approval": false
+        }],
+        "valid_duration_seconds": "120",
+        "valid_start_timestamp": "1687197599.390469131"
+}
+
+export const SAMPLE_CRYPTO_TRANSFER_WITH_REWARDS = {
+    "bytes": null,
+    "charged_tx_fee": 5351935,
+    "consensus_timestamp": "1687133236.139653690",
+    "entity_id": null,
+    "max_fee": "100000000",
+    "memo_base64": "KDAuMC4yOTk4NTU1KUNvbmZpcm0gcHVyY2hhc2Ugb2YgTkZUOiAwLjAuMjE3Mzg5OSB3aXRoIHNlcmlhbCBudW1iZXIgMTYxMiBmb3IgMjUgSEJBUg==",
+    "name": "CRYPTOTRANSFER",
+    "node": "0.0.4",
+    "nonce": 0,
+    "parent_consensus_timestamp": null,
+    "result": "SUCCESS",
+    "scheduled": false,
+    "staking_reward_transfers": [{"account": "0.0.788887", "amount": 210704256}, {
+        "account": "0.0.2254995",
+        "amount": 2289378672
+    }],
+    "transaction_hash": "9s/JADOEqzUy4yzZA0StoTfumGL0bAALPs9tKbE/ELX0AY6gkbTl4potlyd3XHeU",
+    "transaction_id": "0.0.690356-1687133220-052118241",
+    "transfers": [{"account": "0.0.4", "amount": 206713, "is_approval": false}, {
+        "account": "0.0.98",
+        "amount": 4630700,
+        "is_approval": false
+    }, {"account": "0.0.800", "amount": -2499568406, "is_approval": false}, {
+        "account": "0.0.690356",
+        "amount": -5351935,
+        "is_approval": false
+    }, {"account": "0.0.755188", "amount": 2280000000, "is_approval": false}, {
+        "account": "0.0.788887",
+        "amount": 330704256,
+        "is_approval": false
+    }, {"account": "0.0.2254995", "amount": 2389378672, "is_approval": false}, {
+        "account": "0.0.2998555",
+        "amount": -2500000000,
+        "is_approval": false
+    }],
+    "valid_duration_seconds": "120",
+    "valid_start_timestamp": "1687133220.052118241"
+}
+
 export const SAMPLE_TOKEN_CALL_TRANSACTIONS = {
     "transactions": [{
         "bytes": null,

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -78,7 +78,7 @@ describe("TransactionDetails.vue", () => {
     const matcher3 = "api/v1/network/nodes"
     mock.onGet(matcher3).reply(200, SAMPLE_NETWORK_NODES);
 
-    it("Should display transaction details with token transfers and fee transfers", async () => {
+    it("Should display transaction details with token transfers and hbar transfers", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -131,8 +131,8 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.findComponent(NftTransferGraph).exists()).toBe(true)
 
         expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe(
-            "Fee TransfersAccountHbar AmountAccountHbar Amount0.0.29624024-0.00470065-$0.00116\n\n" +
-            "0.0.40.00022028$0.00005Hosted by Hedera | East Coast, USA\n\n" +
+            "Hbar TransfersAccountHbar AmountAccountHbar Amount0.0.29624024-0.00470065-$0.00116\n\n" +
+            "0.0.40.00022028$0.00005Node fee (Hedera)\n\n" +
             "0.0.980.00448037$0.00110Hedera fee collection account")
 
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe(
@@ -744,8 +744,8 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
         expect(wrapper.findComponent(NftTransferGraph).exists()).toBe(true)
 
-        expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe("Fee TransfersAccountHbar AmountAccountHbar Amount0.0.642949-1.15905210-$0.28517\n\n" +
-            "0.0.30.05805847$0.01428Hosted by Hedera | East Coast, USA\n\n" +
+        expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe("Hbar TransfersAccountHbar AmountAccountHbar Amount0.0.642949-1.15905210-$0.28517\n\n" +
+            "0.0.30.05805847$0.01428Node fee (Hedera)\n\n" +
             "0.0.981.10099363$0.27088Hedera fee collection account")
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("")
         expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -368,7 +368,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.get('#entityIdValue').text()).toBe(entityId)
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
-        expect(wrapper.findComponent(TokenTransferGraph).text()).toContain("Token TransfersNone")
+        expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("")
         expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")
 
         wrapper.unmount()
@@ -747,7 +747,7 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.findComponent(HbarTransferGraphF).text()).toBe("Fee TransfersAccountHbar AmountAccountHbar Amount0.0.642949-1.15905210-$0.28517\n\n" +
             "0.0.30.05805847$0.01428Hosted by Hedera | East Coast, USA\n\n" +
             "0.0.981.10099363$0.27088Hedera fee collection account")
-        expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("Token TransfersNone")
+        expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("")
         expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")
 
         wrapper.unmount()

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -139,8 +139,7 @@ describe("TransactionDetails.vue", () => {
             "Token TransfersAccountToken AmountAccountToken Amount0.0.29624024-123423\n\n" +
             "0.0.29693911123423Transfer")
 
-        expect(wrapper.findComponent(NftTransferGraph).text()).toBe(
-            "NFT TransfersNone")
+        expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")
 
         wrapper.unmount()
         await flushPromises()
@@ -337,7 +336,7 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).exists()).toBe(true)
-        expect(wrapper.findComponent(NftTransferGraph).text()).toContain("NFT TransfersNone")
+        expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")
 
         const transaction = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0]
         matcher1 = "/api/v1/transactions"
@@ -370,7 +369,7 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.findComponent(HbarTransferGraphF).exists()).toBe(true)
         expect(wrapper.findComponent(TokenTransferGraph).text()).toContain("Token TransfersNone")
-        expect(wrapper.findComponent(NftTransferGraph).text()).toContain("NFT TransfersNone")
+        expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")
 
         wrapper.unmount()
         await flushPromises()
@@ -749,7 +748,7 @@ describe("TransactionDetails.vue", () => {
             "0.0.30.05805847$0.01428Hosted by Hedera | East Coast, USA\n\n" +
             "0.0.981.10099363$0.27088Hedera fee collection account")
         expect(wrapper.findComponent(TokenTransferGraph).text()).toBe("Token TransfersNone")
-        expect(wrapper.findComponent(NftTransferGraph).text()).toBe("NFT TransfersNone")
+        expect(wrapper.findComponent(NftTransferGraph).text()).toBe("")
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
@@ -51,7 +51,7 @@ describe("NftTransferGraph.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toBe("NFT TransfersNone")
+        expect(wrapper.text()).toBe("")
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -1,0 +1,112 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import router from "@/router";
+import {flushPromises, mount} from "@vue/test-utils";
+import {Transaction, TransactionDetail} from "@/schemas/HederaSchemas";
+import RewardTransferGraph from "@/components/transfer_graphs/RewardTransferGraph.vue";
+import {SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE, SAMPLE_CRYPTO_TRANSFER_WITH_REWARDS} from "../Mocks";
+
+describe("RewardTransferGraph.vue", () => {
+
+    test("Without transaction prop", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(RewardTransferGraph, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+            },
+        })
+
+        await flushPromises()
+
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe("")
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("with transfers and no rewards", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(RewardTransferGraph, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                transaction: SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE as Transaction,
+            },
+        })
+
+        await flushPromises()
+
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe("")
+
+        wrapper.unmount()
+    })
+
+    test("with multiple transfers and rewards", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(RewardTransferGraph, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                transaction: SAMPLE_CRYPTO_TRANSFER_WITH_REWARDS as TransactionDetail,
+
+            },
+        })
+
+        await flushPromises()
+
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        /*
+            0.0.800     ->      0.0.788887      2.10704256
+                        ->      0.0.2254995     22.89378672
+         */
+
+        expect(wrapper.text()).toBe(
+            "Staking Reward Transfers" +
+            "Reward AccountAccountAmount Rewarded" +
+            "0.0.800\n\n" +
+            "0.0.788887" +
+            "2.10704256\n\n" +
+            "0.0.2254995" +
+            "22.89378672")
+
+        wrapper.unmount()
+    })
+
+})
+

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -97,7 +97,7 @@ describe("RewardTransferGraph.vue", () => {
          */
 
         expect(wrapper.text()).toBe(
-            "Staking Reward Transfers" +
+            "Staking Rewards" +
             "Reward AccountAccountAmount Rewarded" +
             "0.0.800\n\n" +
             "0.0.788887" +

--- a/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
@@ -52,7 +52,7 @@ describe("TokenTransferGraphF.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toBe("Token TransfersNone")
+        expect(wrapper.text()).toBe("")
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -69,7 +69,7 @@ describe("HbarTransferLayout.vue", () => {
         const d0 = fullLayout.destinations[0]
         expect(d0.transfer.account).toBe("0.0.5")
         expect(d0.transfer.amount).toBe(+3)
-        expect(d0.description).toBe("Hosted by Hedera | Central, USA")
+        expect(d0.description).toBe("Node fee (Hedera)")
         expect(d0.payload).toBe(false)
 
         const d1 = fullLayout.destinations[1]
@@ -131,7 +131,7 @@ describe("HbarTransferLayout.vue", () => {
         const fd1 = fullLayout.destinations[1]
         expect(fd1.transfer.account).toBe("0.0.5")
         expect(fd1.transfer.amount).toBe(+3)
-        expect(fd1.description).toBe("Hosted by Hedera | Central, USA")
+        expect(fd1.description).toBe("Node fee (Hedera)")
         expect(fd1.payload).toBe(false)
 
         const fd2 = fullLayout.destinations[2]
@@ -211,7 +211,7 @@ describe("HbarTransferLayout.vue", () => {
         const d2 = fullLayout.destinations[2]
         expect(d2.transfer.account).toBe("0.0.5")
         expect(d2.transfer.amount).toBe(+3)
-        expect(d2.description).toBe("Hosted by Hedera | Central, USA")
+        expect(d2.description).toBe("Node fee (Hedera)")
         expect(d2.payload).toBe(false)
 
         const d3 = fullLayout.destinations[3]
@@ -295,7 +295,7 @@ describe("HbarTransferLayout.vue", () => {
         const d0 = fullLayout.destinations[0]
         expect(d0.transfer.account).toBe("0.0.5")
         expect(d0.transfer.amount).toBe(+3)
-        expect(d0.description).toBe("Hosted by Hedera | Central, USA")
+        expect(d0.description).toBe("Node fee (Hedera)")
         expect(d0.payload).toBe(false)
 
         const d1 = fullLayout.destinations[1]
@@ -365,7 +365,7 @@ describe("HbarTransferLayout.vue", () => {
         const d1 = fullLayout.destinations[1]
         expect(d1.transfer.account).toBe("0.0.5")
         expect(d1.transfer.amount).toBe(+3)
-        expect(d1.description).toBe("Hosted by Hedera | Central, USA")
+        expect(d1.description).toBe("Node fee (Hedera)")
         expect(d1.payload).toBe(false)
 
         const d2 = fullLayout.destinations[2]
@@ -458,7 +458,7 @@ describe("HbarTransferLayout.vue", () => {
         const d2 = fullLayout.destinations[2]
         expect(d2.transfer.account).toBe("0.0.5")
         expect(d2.transfer.amount).toBe(+3)
-        expect(d2.description).toBe("Hosted by Hedera | Central, USA")
+        expect(d2.description).toBe("Node fee (Hedera)")
         expect(d2.payload).toBe(false)
 
         const d3 = fullLayout.destinations[3]
@@ -547,7 +547,7 @@ describe("HbarTransferLayout.vue", () => {
         const d1 = fullLayout.destinations[1]
         expect(d1.transfer.account).toBe("0.0.5")
         expect(d1.transfer.amount).toBe(+1)
-        expect(d1.description).toBe("Hosted by Hedera | Central, USA")
+        expect(d1.description).toBe("Node fee (Hedera)")
         expect(d1.payload).toBe(false)
 
         const d2 = fullLayout.destinations[2]


### PR DESCRIPTION
**Description**:

This PR brings changes to the Transfers section in Transaction details:

1. Show the Staking reward transfers in a new subsection.
2. Display modified amounts in the Hbar transfers by deducing the reward amounts of those, in order to obtain a more intuitive transfer diagram — this allows for instance to distinguish the fee going to 0.0.800
3. Hide empty sub-sections

**Related issue(s)**:

Fixes #529

**Notes for reviewer**:

Note this is still a draft while we are collecting internal feedback.

Example of display without the change:
<img width="901" alt="Screenshot 2023-06-21 at 10 52 25" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/96b4c315-0b2d-49cb-a3d5-59a85f517b2b">

Display with the change:
<img width="901" alt="Screenshot 2023-06-22 at 09 41 53" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/8aba1cdc-2151-4012-90db-d52f65c09d1d">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
