### PR TITLE
00651 Hyperlink for token id in contract call trace thinks it's a contract

### DIFF
--- a/src/components/contract/ContractActionsTable.vue
+++ b/src/components/contract/ContractActionsTable.vue
@@ -26,7 +26,7 @@
 
   <div id="contractActionsTable">
     <o-table
-        :data="actions"
+        :data="actions ?? []"
         :paginated="isPaginated"
         :per-page="NB_ACTIONS_PER_PAGE"
 
@@ -100,7 +100,7 @@
     </o-table>
   </div>
 
-  <EmptyTable v-if="!actions.length"/>
+  <EmptyTable v-if="!actions?.length"/>
 
 </template>
 

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -313,33 +313,33 @@ export interface Token {
 
 export interface TokenInfo {
 
-    admin_key: Key | null | undefined
-    auto_renew_account: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    auto_renew_period: number | null | undefined
-    created_timestamp: string | undefined
-    decimals: string | undefined
-    deleted: boolean | null | undefined
-    expiry_timestamp: string | null | undefined
-    fee_schedule_key: Key | null | undefined
-    freeze_default: boolean | undefined
-    freeze_key: Key |null | undefined
-    initial_supply: string | undefined
-    kyc_key: Key | null | undefined
-    max_supply: string | undefined
-    modified_timestamp: string | undefined
-    name: string | undefined
-    memo: string | undefined
-    pause_key: Key | null | undefined
-    pause_status: string | undefined // NOT_APPLICABLE, PAUSED, UNPAUSED
-    supply_key: Key | null | undefined
-    supply_type: string | undefined // FINITE, INFINITE
-    symbol: string | undefined
-    token_id: string | null | undefined     // Network entity ID in the format of shard.realm.num
-    total_supply: string | undefined
-    treasury_account_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
+    admin_key: Key | null
+    auto_renew_account: string | null   // Network entity ID in the format of shard.realm.num
+    auto_renew_period: number | null
+    created_timestamp: string
+    decimals: string
+    deleted: boolean | null
+    expiry_timestamp: string | null
+    fee_schedule_key: Key | null
+    freeze_default: boolean
+    freeze_key: Key | null
+    initial_supply: string
+    kyc_key: Key | null
+    max_supply: string
+    modified_timestamp: string
+    name: string
+    memo: string
+    pause_key: Key | null
+    pause_status: string // NOT_APPLICABLE, PAUSED, UNPAUSED
+    supply_key: Key | null
+    supply_type: string // FINITE, INFINITE
+    symbol: string
+    token_id: string | null     // Network entity ID in the format of shard.realm.num
+    total_supply: string
+    treasury_account_id: string | null   // Network entity ID in the format of shard.realm.num
     type: string // FUNGIBLE_COMMON, NON_FUNGIBLE_UNIQUE
-    wipe_key: Key | null | undefined
-    custom_fees: CustomFees | undefined
+    wipe_key: Key | null
+    custom_fees: CustomFees
 }
 
 export interface CustomFees {
@@ -453,26 +453,26 @@ export interface ContractsResponse {
 
 export interface Contract {
 
-    admin_key: Key | null | undefined
-    auto_renew_account: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    auto_renew_period: number | null | undefined
-    contract_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    created_timestamp: string | null | undefined
-    deleted: boolean | undefined
-    evm_address: string | undefined
-    expiration_timestamp: string | null | undefined
+    admin_key: Key | null
+    auto_renew_account: string | null   // Network entity ID in the format of shard.realm.num
+    auto_renew_period: number | null
+    contract_id: string | null   // Network entity ID in the format of shard.realm.num
+    created_timestamp: string | null
+    deleted: boolean
+    evm_address: string
+    expiration_timestamp: string | null
     file_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    max_automatic_token_associations: number | null | undefined
-    memo: string | undefined
-    obtainer_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    permanent_removal: boolean | null | undefined
-    proxy_account_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    timestamp: TimestampRange | undefined   // timestamp range the entity is valid for
+    max_automatic_token_associations: number | null
+    memo: string
+    obtainer_id: string | null   // Network entity ID in the format of shard.realm.num
+    permanent_removal: boolean | null
+    proxy_account_id: string | null   // Network entity ID in the format of shard.realm.num
+    timestamp: TimestampRange   // timestamp range the entity is valid for
 }
 
 export interface ContractResponse extends Contract {
-    bytecode: string | null | undefined
-    runtime_bytecode: string | null | undefined
+    bytecode: string | null
+    runtime_bytecode: string | null
 }
 
 export interface TimestampRange {

--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -20,6 +20,7 @@
 
 import { Transaction, TransactionType } from "@/schemas/HederaSchemas";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
+import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 
 export class EntityDescriptor {
 
@@ -45,8 +46,10 @@ export class EntityDescriptor {
             case TransactionType.ETHEREUMTRANSACTION:
                 if (row.entity_id && await ContractByIdCache.instance.lookup(row.entity_id)) {
                     result = new EntityDescriptor("Contract ID", "ContractDetails")
-                } else {
+                } else if (row.entity_id && await AccountByIdCache.instance.lookup(row.entity_id)) {
                     result = new EntityDescriptor("Account ID", "AccountDetails")
+                } else {
+                    result = new EntityDescriptor("Token ID", "TokenDetails")
                 }
                 break;
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2140,7 +2140,7 @@ export const SAMPLE_ACCOUNT = {
     "max_automatic_token_associations": 0,
     "memo": "",
     "receiver_sig_required": false,
-    "evm_address": null,
+    "evm_address": "0x00000000000000000000000000000000000b2607",
     "ethereum_nonce": 0,
     "decline_reward": null,
     "staked_node_id": null,

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -788,6 +788,60 @@ export const SAMPLE_TOKEN_CALL_TRANSACTIONS = {
     }], "links": {"next": null}
 }
 
+export const SAMPLE_ETHEREUM_TRANSACTIONS_ASSOCIATING_TOKEN = {
+    "transactions": [{
+        "bytes": null,
+        "charged_tx_fee": 227282050,
+        "consensus_timestamp": "1687555828.300024003",
+        "entity_id": "0.0.230049",
+        "max_fee": "1080000000",
+        "memo_base64": "",
+        "name": "ETHEREUMTRANSACTION",
+        "nft_transfers": [],
+        "node": "0.0.6",
+        "nonce": 0,
+        "parent_consensus_timestamp": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "staking_reward_transfers": [],
+        "token_transfers": [],
+        "transaction_hash": "Ws8zcqKAVEGr2R9MP3uidkx8Uh66/6g9VfhmGTOr6DNFRSj5MbalwBkNX8WaWoe5",
+        "transaction_id": "0.0.902-1687555818-297907508",
+        "transfers": [{"account": "0.0.6", "amount": 2910, "is_approval": false}, {
+            "account": "0.0.98",
+            "amount": 227279140,
+            "is_approval": false
+        }, {"account": "0.0.902", "amount": -82050, "is_approval": false}, {
+            "account": "0.0.42224",
+            "amount": -227200000,
+            "is_approval": false
+        }],
+        "valid_duration_seconds": "120",
+        "valid_start_timestamp": "1687555818.297907508"
+    }, {
+        "bytes": null,
+        "charged_tx_fee": 0,
+        "consensus_timestamp": "1687555828.300024004",
+        "entity_id": "0.0.42224",
+        "max_fee": "0",
+        "memo_base64": "",
+        "name": "TOKENASSOCIATE",
+        "nft_transfers": [],
+        "node": null,
+        "nonce": 1,
+        "parent_consensus_timestamp": "1687555828.300024003",
+        "result": "SUCCESS",
+        "scheduled": false,
+        "staking_reward_transfers": [],
+        "token_transfers": [],
+        "transaction_hash": "uWkCIG7doSPwu0YiF1sOxiUmh5qfuVW1zsnsvmtn59Dwpu8bUDUJVsg6LMvms/ak",
+        "transaction_id": "0.0.902-1687555818-297907508",
+        "transfers": [],
+        "valid_duration_seconds": null,
+        "valid_start_timestamp": "1687555818.297907508"
+    }]
+}
+
 export const SAMPLE_CONTRACT_RESULTS = {
     "results": [
         {

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -182,6 +182,20 @@ describe("TransactionDetails.vue", () => {
         const matcher5 = "/api/v1/contracts/results/" + transactionId + "/actions"
         mock.onGet(matcher5).reply(200, "[]")
 
+        const fromContract = {
+            "contract_id": "0.0.846260",
+            "evm_address": "0x00000000000000000000000000000000000ce9b4",
+        }
+        const toContract = {
+            "contract_id": "0.0.1062787",
+            "evm_address": "0x0000000000000000000000000000000000103783",
+        }
+
+        const matcher6 = "/api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.from
+        const matcher61 = "/api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.to
+        mock.onGet(matcher6).reply(200, fromContract)
+        mock.onGet(matcher61).reply(200, toContract)
+
         const wrapper = mount(TransactionDetails, {
             global: {
                 plugins: [router, Oruga]

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -29,12 +29,14 @@ import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue"
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import axios, {AxiosRequestConfig} from "axios";
 import {
+    SAMPLE_ACCOUNT,
     SAMPLE_ASSOCIATED_TOKEN,
     SAMPLE_ASSOCIATED_TOKEN_2,
     SAMPLE_BLOCKSRESPONSE,
     SAMPLE_CONTRACT,
     SAMPLE_CONTRACT_RESULT_DETAILS,
     SAMPLE_CONTRACTCALL_TRANSACTIONS,
+    SAMPLE_ETHEREUM_TRANSACTIONS_ASSOCIATING_TOKEN,
     SAMPLE_ETHEREUM_TRANSACTIONS_ON_ACCOUNT,
     SAMPLE_ETHEREUM_TRANSACTIONS_ON_CONTRACT,
     SAMPLE_FAILED_TRANSACTION,
@@ -822,6 +824,8 @@ describe("TransactionDetails.vue", () => {
 
         const matcher2 = "/api/v1/contracts/" + entityId
         mock.onGet(matcher2).reply(404)
+        const matcher3 = "/api/v1/accounts/" + entityId
+        mock.onGet(matcher3).reply(200, SAMPLE_ACCOUNT)
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -889,4 +893,137 @@ describe("TransactionDetails.vue", () => {
         await flushPromises()
     });
 
+    it("Should display ETHEREUM TX details with link to token as entity ID", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const transaction = SAMPLE_ETHEREUM_TRANSACTIONS_ASSOCIATING_TOKEN.transactions[0]
+        const transactionId = transaction.transaction_id
+        const entityId = transaction.entity_id
+        const timestamp = transaction.consensus_timestamp
+
+        const matcher1 = "/api/v1/transactions/" + transactionId
+        mock.onGet(matcher1).reply(200, SAMPLE_ETHEREUM_TRANSACTIONS_ASSOCIATING_TOKEN);
+        const matcher11 = "/api/v1/transactions"
+        mock.onGet(matcher11).reply((config: AxiosRequestConfig) => {
+            if (config.params.timestamp == timestamp) {
+                return [200, SAMPLE_ETHEREUM_TRANSACTIONS_ASSOCIATING_TOKEN]
+            } else {
+                return [404]
+            }
+        });
+
+        const matcher2 = "/api/v1/tokens/" + entityId
+        mock.onGet(matcher2).reply(200, SAMPLE_TOKEN)
+
+        const result = {
+            "address": "0x00000000000000000000000000000000000382a1",
+            "amount": 0,
+            "bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "call_result": "0x0000000000000000000000000000000000000000000000000000000000000016",
+            "contract_id": "0.0.230049",
+            "created_contract_ids": [],
+            "error_message": null,
+            "from": "0x000000000000000000000000000000000000a4f0",
+            "function_parameters": "0x0a754de6",
+            "gas_limit": 4000000,
+            "gas_used": 3200000,
+            "timestamp": "1687555828.300024003",
+            "to": "0x00000000000000000000000000000000000382a1",
+            "hash": "0xa34851b8f0df391c38a73230265e5118741408ab982c5f64345db35cee22e360",
+            "block_hash": "0xb020ca98489bf4ceecb650332de36b22b8bfe2cb8d2234d2160e2502b44198a12342ebe427b7ec8078be4afcaadd826b",
+            "block_number": 1537712,
+            "logs": [],
+            "result": "SUCCESS",
+            "transaction_index": 0,
+            "state_changes": [],
+            "status": "0x1",
+            "failed_initcode": null,
+            "access_list": "0x",
+            "block_gas_used": 3200000,
+            "chain_id": "0x129",
+            "gas_price": "0x",
+            "max_fee_per_gas": "0x55",
+            "max_priority_fee_per_gas": "0x0",
+            "r": "0x4b09e72f5b8a779411b92325dddb7a8a0d8e921f50fa09f0207e2b456b255be8",
+            "s": "0x1506a024ac70fe91e3b1ecdd517e0ae473ba4c18af88ee63fc01285db03ada98",
+            "type": 2,
+            "v": 0,
+            "nonce": 29
+        }
+
+        const param3 = { timestamp: timestamp, internal: true }
+        const matcher3 = "/api/v1/contracts/results"
+        mock.onGet(matcher3, param3).reply(200, {
+            results: [ result ], "links": {"next": null}
+        } );
+
+        const matcher4 = "/api/v1/contracts/" + result.contract_id + "/results/" + timestamp
+        mock.onGet(matcher4).reply(200, result);
+
+        const action = {
+            "call_depth": 0,
+            "call_operation_type": "CALL",
+            "call_type": "CALL",
+            "caller": "0.0.42224",
+            "caller_type": "ACCOUNT",
+            "from": "0x000000000000000000000000000000000000a4f0",
+            "gas": 3979000,
+            "gas_used": 706972,
+            "index": 0,
+            "input": "0x0a754de6",
+            "recipient": "0.0.230049",
+            "recipient_type": "CONTRACT",
+            "result_data": "0x0000000000000000000000000000000000000000000000000000000000000016",
+            "result_data_type": "OUTPUT",
+            "timestamp": "1687555828.300024003",
+            "to": "0x00000000000000000000000000000000000382a1",
+            "value": 0
+        }
+
+        const matcher5 = "/api/v1/contracts/results/" + result.hash + "/actions?limit=100"
+        mock.onGet(matcher5).reply(200, {
+            actions: [ action ], "links": {"next": null}
+        })
+
+        const wrapper = mount(TransactionDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                transactionLoc: timestamp
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.text())
+        // console.log(wrapper.html())
+
+        expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(transactionId, true)))
+        expect(wrapper.text()).toMatch(RegExp("ETHEREUM TRANSACTION"))
+        expect(wrapper.get("#entityIdName").text()).toBe("Token ID")
+        expect(wrapper.get("#entityIdValue").text()).toMatch(entityId)
+
+        // const actionTable = wrapper.findComponent(ContractActionsTable)
+        // expect(actionTable.exists()).toBe(true)
+        // expect(actionTable.get('thead').text()).toBe("Call Type From Amount To Gas Limit")
+        // expect(actionTable.get('tbody').text()).toBe(
+        //     "1" +
+        //     "CALL" +
+        //     "0x000000000000000000000000000000000000a4f0" + "Copy" + "(0.0.42224)" +
+        //     "→" +
+        //     "0.00000000" + "$0.00000" +
+        //     "→" +
+        //     "0x00000000000000000000000000000000000382a1" + "Copy" + "(0.0.230049)" +
+        //     "3979000"
+        // )
+        //
+        // const actionTableLines = actionTable.findAll("tr")
+        // const toAddress = actionTableLines[1].findAll("td")[4]
+        // const anchor = toAddress.find("a")
+        // expect(anchor.attributes('href')).toMatch("/token/" + entityId)
+
+        wrapper.unmount()
+        await flushPromises()
+    });
 });

--- a/tests/unit/utils/EVMAddress.spec.ts
+++ b/tests/unit/utils/EVMAddress.spec.ts
@@ -44,62 +44,9 @@ describe("EVMAddress", () => {
     const matcher3 = "/api/v1/accounts/" + entityId
     mock.onGet(matcher3).reply(200, SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS);
 
-    test("Constructing with no Hedera ID and no EVM address", async () => {
-
-        const wrapper = mount(EVMAddress, {
-            global: {
-                plugins: [router, Oruga]
-            },
-            props: {
-            },
-        });
-        await flushPromises()
-
-        expect(wrapper.text()).toBe("None")
-
-        wrapper.unmount()
-        await flushPromises()
-    })
-
-    test("Constructing with Hedera ID and no EVM address", async () => {
-
-        const wrapper = mount(EVMAddress, {
-            global: {
-                plugins: [router, Oruga]
-            },
-            props: {
-                id: entityId,
-            },
-        });
-        await flushPromises()
-
-        expect(wrapper.text()).toBe( `${evmAddress}Copy(${entityId})`)
-
-        wrapper.unmount()
-        await flushPromises()
-    })
-
-    test("Constructing a compact form with Hedera ID and no EVM address", async () => {
-
-        const wrapper = mount(EVMAddress, {
-            global: {
-                plugins: [router, Oruga]
-            },
-            props: {
-                id: entityId,
-                compact: true
-            },
-        });
-        await flushPromises()
-
-        expect(wrapper.text()).toBe( `${compactAddress}Copy(${entityId})`)
-
-        wrapper.unmount()
-        await flushPromises()
-    })
-
     test("Constructing with EVM address and no Hedera ID", async () => {
 
+        await router.push("/") // To avoid "missing required param 'network'" error
         const wrapper = mount(EVMAddress, {
             global: {
                 plugins: [router, Oruga]
@@ -116,8 +63,29 @@ describe("EVMAddress", () => {
         await flushPromises()
     })
 
+    test("Constructing a compact form with EVM address and no Hedera ID", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                address: evmAddress,
+                compact: true
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${compactAddress}Copy(${entityId})`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
     test("Constructing with long-zero address and no Hedera ID", async () => {
 
+        await router.push("/") // To avoid "missing required param 'network'" error
         const wrapper = mount(EVMAddress, {
             global: {
                 plugins: [router, Oruga]
@@ -136,6 +104,7 @@ describe("EVMAddress", () => {
 
     test("Constructing with Hedera ID and EVM address", async () => {
 
+        await router.push("/") // To avoid "missing required param 'network'" error
         const wrapper = mount(EVMAddress, {
             global: {
                 plugins: [router, Oruga]
@@ -153,14 +122,37 @@ describe("EVMAddress", () => {
         await flushPromises()
     })
 
-    test("Constructing with System Contract ID and no EVM address", async () => {
+    test("Constructing with Hedera ID and EVM address, not showing ID and showing type", async () => {
 
+        await router.push("/") // To avoid "missing required param 'network'" error
         const wrapper = mount(EVMAddress, {
             global: {
                 plugins: [router, Oruga]
             },
             props: {
-                id: systemContractId,
+                address: evmAddress,
+                id: entityId,
+                showId: false,
+                showType: true
+            },
+        });
+        await flushPromises()
+
+        expect(wrapper.text()).toBe( `${evmAddress}Copy`)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    test("Constructing with System Contract address", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+        const wrapper = mount(EVMAddress, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                address: systemContractAddress,
             },
         });
         await flushPromises()


### PR DESCRIPTION
**Description**:

This PR refactors _EVMAddress_ such that it looks up the related contract to find out whether the underlying address is indeed a contract or a token (access via its proxy contract).
When the entity type is not provided, _EVMAddress_ now tries to lookup for a contract or account to determine the type and be able to display a link (notably in the Contract Result section).
_EVMAddress_ can no longer be used with just an entityID. An EVM address is required. The ID is not necessary, it may simply avoid an account lookup.

**Related issue(s)**:

Fixes #651

**Notes for reviewer**:

Deploying on staging server.
One example where the fix is visible.
https://hashscan.io/previewnet/tx/0xa34851b8f0df391c38a73230265e5118741408ab982c5f64345db35cee22e360
 - the Contract Result section should provide hlinks for the From/To fields
 - the 0.0.230049 ID should link to a TokenDetails page.
 - 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
