### PR TITLE
00662 fix discrepancies in stake for consensus (and percentage)

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -36,7 +36,7 @@
     >
 
       <o-table-column v-slot="props" field="nature" label="">
-        <span class="icon has-text-info" style="font-size: 16px">
+        <span class="icon has-text-info regular-node-column" style="font-size: 16px">
           <i v-if="isCouncilNode(props.row)" class="fas fa-building"></i>
           <i v-else class="fas fa-users"></i>
         </span>
@@ -61,27 +61,25 @@
         </div>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="stake" label="Stake" position="right">
+      <o-table-column v-slot="props" field="stake" label="Stake for Consensus" position="right">
         <o-tooltip :label="tooltipStake"
                    multiline
                    :delay="tooltipDelay"
                    class="h-tooltip">
-          <span class="regular-node-column">
-            <HbarAmount :amount="makeUnclampedStake(props.row)" :decimals="0"/>
-            <span v-if="props.row.stake" class="ml-1">{{ '(' + makeWeightPercentage(props.row) + ')' }}</span>
-            <span v-else class="ml-1 has-text-grey">(&lt;Min)</span>
-          </span>
+          <div class="regular-node-column">
+            <HbarAmount :amount="props.row.stake" :decimals="0"/>
+          </div>
         </o-tooltip>
       </o-table-column>
 
-      <o-table-column v-slot="props" field="stake_not_rewarded" label="Staked For No Reward" position="right">
+      <o-table-column v-slot="props" field="percentage" label="%" position="right">
         <o-tooltip :delay="tooltipDelay"
-                   :label="tooltipNotRewarded"
+                   :label="tooltipPercentage"
                    class="h-tooltip"
                    multiline>
-           <span class="regular-node-column">
-             <HbarAmount :amount="props.row.stake_not_rewarded ?? 0" :decimals="0"/>
-          </span>
+          <div class="regular-node-column">
+            <StringValue :string-value="makeWeightPercentage(props.row)"/>
+          </div>
         </o-tooltip>
       </o-table-column>
 
@@ -168,12 +166,9 @@ export default defineComponent({
 
   setup(props) {
     const tooltipDelay = 500
-    const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight " +
-        "(weight is absent when the amount staked is below minimum)."
-    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
-        "to decline rewards (and all accounts staked to those accounts)."
-    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward earned during the " +
-        "last 24h period."
+    const tooltipStake = "Total amount of HBAR staked to this specific validator for consensus."
+    const tooltipPercentage = "Total amount of HBAR staked to this validator for consensus / total amount of HBAR staked to all validators for consensus."
+    const tooltipRewardRate = "Approximate annual reward rate based on the reward earned during the last 24h period."
 
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
@@ -183,7 +178,7 @@ export default defineComponent({
     onBeforeUnmount(() => networkAnalyzer.unmount())
 
     const makeWeightPercentage = (node: NetworkNode) => {
-      return node.stake && props.stakeTotal ? makeStakePercentage(node, props.stakeTotal) : 0
+      return node.stake && props.stakeTotal ? makeStakePercentage(node, props.stakeTotal) : "0"
     }
 
     const handleClick = (node: NetworkNode, c: unknown, i: number, ci: number, event: MouseEvent) => {
@@ -195,7 +190,7 @@ export default defineComponent({
     return {
       tooltipDelay,
       tooltipStake,
-      tooltipNotRewarded,
+      tooltipPercentage,
       tooltipRewardRate,
       isTouchDevice,
       isMediumScreen,

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -105,7 +105,7 @@
                               title="Stake for Consensus"/>
         <p v-if="stake" id="consensusStakePercent" class="h-is-property-text h-is-extra-text mt-1">{{
             stakePercentage
-          }}% of total</p>
+          }} of total</p>
         <p v-else class="h-is-property-text h-is-extra-text mt-1">(&lt;Min)</p>
         <br/><br/>
         <div v-if="stake === 0">
@@ -163,6 +163,8 @@ import NetworkDashboardItem from "@/components/node/NetworkDashboardItem.vue";
 import {StakeCache} from "@/utils/cache/StakeCache";
 import {PathParam} from "@/utils/PathParam";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
+import {NetworkNode} from "@/schemas/HederaSchemas";
+import {makeStakePercentage} from "@/schemas/HederaUtils";
 
 export default defineComponent({
 
@@ -207,7 +209,9 @@ export default defineComponent({
 
     const stakeTotal = computed(() => stakeLookup.entity.value?.stake_total ?? 0)
     const stakePercentage = computed(() =>
-        stakeTotal.value ? Math.round(nodeAnalyzer.stake.value / stakeTotal.value * 10000) / 100 : 0)
+        nodeAnalyzer.node.value && stakeTotal.value
+            ? makeStakePercentage(nodeAnalyzer.node.value as NetworkNode, stakeTotal.value)
+            : "0")
 
     const stakeRewardedPercentage = computed(() =>
         networkAnalyzer.stakeRewardedTotal.value != 0 ? Math.round(nodeAnalyzer.stakeRewarded.value / networkAnalyzer.stakeRewardedTotal.value * 10000) / 100 : 0)

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -39,12 +39,9 @@ HMSF.forceUTC = true
 
 describe("NodeTable.vue", () => {
 
-    const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight" +
-        " (weight is absent when the amount staked is below minimum)."
-    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
-        "to decline rewards (and all accounts staked to those accounts)."
-    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward earned during the " +
-        "last 24h period."
+    const tooltipStake = "Total amount of HBAR staked to this specific validator for consensus."
+    const tooltipPercentage = "Total amount of HBAR staked to this validator for consensus / total amount of HBAR staked to all validators for consensus."
+    const tooltipRewardRate = "Approximate annual reward rate based on the reward earned during the last 24h period."
 
     const mock = new MockAdapter(axios);
     const matcher1 = "/api/v1/network/nodes"
@@ -75,25 +72,25 @@ describe("NodeTable.vue", () => {
         // console.log(wrapper.text())
         // console.log(wrapper.html())
 
-        expect(wrapper.get('thead').text()).toBe("Node Description Stake Staked For No Reward Stake Range Reward Rate")
+        expect(wrapper.get('thead').text()).toBe("Node Description Stake for Consensus % Stake Range Reward Rate")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
             "0" +
             "Hosted by Hedera | East Coast, USA" +
-            tooltipStake + "6,000,000(25%)" +
-            tooltipNotRewarded + "1,000,000" +
+            tooltipStake + "6,000,000" +
+            tooltipPercentage + "25%" +
             "Rewarded:5,000,000Not Rewarded:1,000,000Min:1,000,000Max:30,000,000" +
             tooltipRewardRate + "1%" +
             "1" +
             "Hosted by Hedera | East Coast, USA" +
-            tooltipStake + "9,000,000(37.5%)" +
-            tooltipNotRewarded + "2,000,000" +
+            tooltipStake + "9,000,000" +
+            tooltipPercentage + "37.5%" +
             "Rewarded:7,000,000Not Rewarded:2,000,000Min:1,000,000Max:30,000,000" +
             tooltipRewardRate + "2%" +
             "2" +
             "Hosted by Hedera | Central, USA" +
-            tooltipStake + "9,000,000(37.5%)" +
-            tooltipNotRewarded + "2,000,000" +
+            tooltipStake + "9,000,000" +
+            tooltipPercentage + "37.5%" +
             "Rewarded:7,000,000Not Rewarded:2,000,000Min:1,000,000Max:30,000,000" +
             tooltipRewardRate + "3%"
         )

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -41,11 +41,9 @@ HMSF.forceUTC = true
 
 describe("Nodes.vue", () => {
 
-    const tooltipStake = "This is the total amount staked to this node, followed by its consensus weight" +
-        " (weight is absent when the amount staked is below minimum)."
-    const tooltipNotRewarded = "This is the total amount staked to this node by accounts that have chosen " +
-        "to decline rewards (and all accounts staked to those accounts)."
-    const tooltipRewardRate = "This is an approximate annual reward rate based on the reward earned during the " +
+    const tooltipStake = "Total amount of HBAR staked to this specific validator for consensus."
+    const tooltipPercentage = "Total amount of HBAR staked to this validator for consensus / total amount of HBAR staked to all validators for consensus."
+    const tooltipRewardRate = "Approximate annual reward rate based on the reward earned during the " +
         "last 24h period."
 
     it("should display the nodes pages containing the node table", async () => {
@@ -87,24 +85,24 @@ describe("Nodes.vue", () => {
         expect(cards[1].text()).toMatch(RegExp("^Nodes"))
         const table = cards[1].findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Node Description Stake Staked For No Reward Stake Range Reward Rate")
+        expect(table.get('thead').text()).toBe("Node Description Stake for Consensus % Stake Range Reward Rate")
         expect(wrapper.get('tbody').text()).toBe(
             "0" +
             "Hosted by Hedera | East Coast, USA" +
-            tooltipStake + "6,000,000(25%)" +
-            tooltipNotRewarded + "1,000,000" +
+            tooltipStake + "6,000,000" +
+            tooltipPercentage + "25%" +
             "Rewarded:5,000,000Not Rewarded:1,000,000Min:1,000,000Max:30,000,000" +
             tooltipRewardRate + "1%" +
             "1" +
             "Hosted by Hedera | East Coast, USA" +
-            tooltipStake + "9,000,000(37.5%)" +
-            tooltipNotRewarded + "2,000,000" +
+            tooltipStake + "9,000,000" +
+            tooltipPercentage + "37.5%" +
             "Rewarded:7,000,000Not Rewarded:2,000,000Min:1,000,000Max:30,000,000" +
             tooltipRewardRate + "2%" +
             "2" +
             "Hosted by Hedera | Central, USA" +
-            tooltipStake + "9,000,000(37.5%)" +
-            tooltipNotRewarded + "2,000,000" +
+            tooltipStake + "9,000,000" +
+            tooltipPercentage + "37.5%" +
             "Rewarded:7,000,000Not Rewarded:2,000,000Min:1,000,000Max:30,000,000" +
             tooltipRewardRate + "3%"
         )


### PR DESCRIPTION
**Description**:

This PR fixes the NodeTable and NodeDetails views to:
 - use stake rather than unclamped stake for everything related to consensus weight
 - align number of decimals for consensus weight %
 
**Related issue(s)**:

Fixes #662

**Notes for reviewer**:

Deployed on staging. Look at LG node for instance (where stake ≠ rewarded + not rewarded)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
