### PR TITLE
00633 Display contract nonce

### DIFF
--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -161,6 +161,12 @@
                 <TimestampValue :timestamp="contract?.timestamp?.to" :show-none="true"/>
               </template>
             </Property>
+            <Property v-if="displayNonce" id="nonce">
+              <template v-slot:name>Contract Nonce</template>
+              <template v-slot:value>
+                {{ contract?.nonce }}
+              </template>
+            </Property>
             <Property id="file">
               <template v-slot:name>File</template>
               <template v-slot:value>
@@ -272,6 +278,8 @@ export default defineComponent({
     onMounted(() => accountLocParser.mount())
     onBeforeUnmount(() => accountLocParser.unmount())
 
+    const displayNonce = computed(() => contractLookup.entity.value?.nonce != undefined)
+
     const autoRenewAccount = computed(() => {
       return contractLookup.entity.value?.auto_renew_account ?? null
     })
@@ -328,6 +336,7 @@ export default defineComponent({
       balance: accountLocParser.balance,
       tokens: accountLocParser.tokens,
       ethereumAddress: accountLocParser.ethereumAddress,
+      displayNonce,
       accountChecksum,
       displayAllTokenLinks,
       notification,

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -464,6 +464,7 @@ export interface Contract {
     file_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
     max_automatic_token_associations: number | null
     memo: string
+    nonce: number | undefined
     obtainer_id: string | null   // Network entity ID in the format of shard.realm.num
     permanent_removal: boolean | null
     proxy_account_id: string | null   // Network entity ID in the format of shard.realm.num

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2392,6 +2392,7 @@ export const SAMPLE_CONTRACT = {
     "file_id": "0.0.749773",
     "max_automatic_token_associations": 0,
     "memo": "Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract",
+    "nonce": 1,
     "obtainer_id": null,
     "proxy_account_id": null,
     "timestamp": {

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -96,6 +96,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#proxyAccountValue").text()).toBe("None")
         expect(wrapper.get("#validFromValue").text()).toBe("3:09:15.9474 PMMar 7, 2022, UTC")
         expect(wrapper.get("#validUntilValue").text()).toBe("None")
+        expect(wrapper.get("#nonceValue").text()).toBe("1")
         expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address:0x00000000000000000000000000000000000b70cfCopy")
         expect(wrapper.get("#code").text()).toBe("Runtime BytecodeNone")
@@ -227,6 +228,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#keyValue").text()).toBe("None")
         expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("None")
         expect(wrapper.get("#memoValue").text()).toBe("None")
+        expect(wrapper.find("#nonce").exists()).toBe(false)
         expect(wrapper.get("#fileValue").text()).toBe("0.0.803267")
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address:0x00000000000000000000000000000000000b70cfCopy")
 
@@ -234,7 +236,7 @@ describe("ContractDetails.vue", () => {
         await flushPromises()
     });
 
-    // TODO: re-enable after Feb 9th
+    // TODO: re-enable after activation of Contract Expiry
     it.skip("Should display notification of grace period", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
@@ -276,7 +278,7 @@ describe("ContractDetails.vue", () => {
         await flushPromises()
     });
 
-    // TODO: remove after Feb 9th
+    // TODO: remove after activation of Contract Expiry
     it("Should NOT display notification of grace period", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error


### PR DESCRIPTION
**Description**:

Display the nonce property when present in the contract. When absent (i.e. in older contracts) do not display anything. 
The name of the property is "Contract Nonce", not just "Nonce", like we have "Transaction Nonce", to avoid any confusion among the various kinds of nonce.

**Related issue(s)**:

Fixes #633

**Notes for reviewer**:

<img width="1212" alt="Screenshot 2023-07-25 at 10 11 06" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/f9e9fb58-37a5-49c8-88a8-ad298e90a85d">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
