### PR TITLE
00672 RewardTransferGraph unit test randomly fails

### DIFF
--- a/tests/unit/values/HbarAmount.spec.ts
+++ b/tests/unit/values/HbarAmount.spec.ts
@@ -25,18 +25,25 @@
 
  */
 
-import {describe, test, expect} from 'vitest'
+import {afterAll, beforeAll, describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import {SAMPLE_NETWORK_EXCHANGERATE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 
-const mock = new MockAdapter(axios);
-const matcher = "api/v1/network/exchangerate"
-mock.onGet(matcher).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
-
 describe("HbarAmount.vue ", () => {
+
+    const mock = new MockAdapter(axios);
+
+    beforeAll(() => {
+        const matcher = "api/v1/network/exchangerate"
+        mock.onGet(matcher).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
+    })
+
+    afterAll(() => {
+        mock.restore()
+    })
 
     test("with amount set", async () => {
 


### PR DESCRIPTION
**Description**:

Changes below fix a latent issue in `HbarAmount` unit test causing `RewardTransferGraph` to break randomly.

`HbarAmount` defines a mock for `api/v1/network/exchangerate` at the top level (ie outside of `describe()` function).
This mock remains active during execution of all the tests.
`RewardTransferGraph` does not define any mock for `api/v1/network/exchangerate` and does not expect any dollar values.

When `RewardTransferGraph` unit test is executed before `HbarAmount`, it succeeds.
When `RewardTransferGraph` unit test is executed after, it breaks because `HbarAmount` mock returns some unexpected dollar values.

Change below make sure that `HbarAmount` dismantles its mock after its execution.

**Related issue(s)**:

Fixes #00672

**Notes for reviewer**:

It's possible to force vitest to execute `HbarAmount` before `RewardTransferGraph` using:
```
rm -rf  node_modules/.vitest # Clears vitest cache to force alphabetic (?) ordering
npx vitest run --threads false HbarAmount RewardTransferGraph
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
