### PR TITLE
Get user consent for cookies

### DIFF
--- a/.env
+++ b/.env
@@ -28,3 +28,6 @@ VITE_APP_ENABLE_STAKING=true
 
 ### The HTML content of the disclaimer popup dialog displayed by the Wallet Chooser
 # VITE_APP_WALLET_CHOOSER_DISCLAIMER_POPUP=<HTML content>
+
+### Global site tag ID for Google Analytics
+# VITE_APP_GOOGLE_TAG_ID=G-XXXX

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,16 +28,23 @@
 
   <router-view/>
 
+  <CookiesDialog v-model:show-dialog="showCookiesDialog"
+                 @onChooseNecessary="handleChooseNecessaryCookies"
+                 @onChooseAll="handleChooseAllCookies">
+  </CookiesDialog>
+
 </template>
 
 <script lang="ts">
 
-import {computed, defineComponent, onBeforeUnmount, onMounted, provide, ref} from 'vue';
+import {computed, defineComponent, onBeforeMount, onBeforeUnmount, onMounted, provide, ref, watch} from 'vue';
 import TopNavBar from "@/components/TopNavBar.vue";
 import {errorKey, explanationKey, initialLoadingKey, loadingKey, suggestionKey} from "@/AppKeys"
 import {AxiosMonitor} from "@/utils/AxiosMonitor"
 import {useRoute} from "vue-router";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
+import CookiesDialog from "@/components/CookiesDialog.vue";
+import {AppStorage} from "@/AppStorage";
 
 export const XLARGE_BREAKPOINT = 1450
 export const LARGE_BREAKPOINT = 1280
@@ -49,7 +56,7 @@ export const ORUGA_MOBILE_BREAKPOINT = "1080px"
 
 export default defineComponent({
   name: 'App',
-  components: {TopNavBar},
+  components: {CookiesDialog, TopNavBar},
 
   setup() {
     const route = useRoute()
@@ -89,11 +96,31 @@ export default defineComponent({
       windowWidth.value = window.innerWidth
     }
 
+    const showCookiesDialog = ref(false)
+
+    const acceptAllCookies = ref<boolean|null>(null)
+    watch(acceptAllCookies, (value) => {
+      if (value != null && value) {
+        insertGoogleTag(import.meta.env.VITE_APP_GOOGLE_TAG_ID)
+      }
+    })
+
     provide(loadingKey,         AxiosMonitor.instance.loading)
     provide(initialLoadingKey,  AxiosMonitor.instance.initialLoading)
     provide(errorKey,           AxiosMonitor.instance.error)
     provide(explanationKey,     AxiosMonitor.instance.explanation)
     provide(suggestionKey,      AxiosMonitor.instance.suggestion)
+
+    onBeforeMount(() => {
+      const tagId = import.meta.env.VITE_APP_GOOGLE_TAG_ID
+      if (tagId != undefined && tagId.length > 0) {
+        acceptAllCookies.value = AppStorage.getCookiePolicyAcceptAll()
+        showCookiesDialog.value = (acceptAllCookies.value == null)
+      } else {
+        acceptAllCookies.value = null
+        showCookiesDialog.value = false
+      }
+    })
 
     onMounted(() => {
       windowWidth.value = window.innerWidth
@@ -105,12 +132,42 @@ export default defineComponent({
       window.removeEventListener('resize', onResizeHandler);
     })
 
+    const handleChooseNecessaryCookies = () => {
+      acceptAllCookies.value = false
+      AppStorage.setCookiePolicyAcceptAll(false)
+    }
+
+    const handleChooseAllCookies = () => {
+      acceptAllCookies.value = true
+      AppStorage.setCookiePolicyAcceptAll(true)
+    }
+
     return {
       isMediumScreen,
-      onMainDashboardPage
+      onMainDashboardPage,
+      showCookiesDialog,
+      handleChooseNecessaryCookies,
+      handleChooseAllCookies,
     }
   },
 });
+
+function insertGoogleTag(tagId: string) {
+  const src1 = `https://www.googletagmanager.com/gtag/js?id=${tagId}`
+  let s1 = document.createElement( 'script' );
+  s1.setAttribute( 'async', '' );
+  s1.setAttribute( 'src', src1 );
+  document.head.appendChild( s1 );
+
+  const src2 = `window.dataLayer = window.dataLayer || [];
+    function gtag() {dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '${import.meta.env.VITE_APP_GOOGLE_TAG_ID}');`
+  let s2 = document.createElement( 'script' );
+  s2.innerHTML = src2;
+  document.head.appendChild( s2 );
+}
+
 </script>
 
 <style scoped>

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,8 +29,8 @@
   <router-view/>
 
   <CookiesDialog v-model:show-dialog="showCookiesDialog"
-                 @onChooseNecessary="handleChooseNecessaryCookies"
-                 @onChooseAll="handleChooseAllCookies">
+                 @onChooseReject="handleChooseRejectCookies"
+                 @onChooseAccept="handleChooseAcceptCookies">
   </CookiesDialog>
 
 </template>
@@ -98,8 +98,8 @@ export default defineComponent({
 
     const showCookiesDialog = ref(false)
 
-    const acceptAllCookies = ref<boolean|null>(null)
-    watch(acceptAllCookies, (value) => {
+    const acceptCookies = ref<boolean|null>(null)
+    watch(acceptCookies, (value) => {
       if (value != null && value) {
         insertGoogleTag(import.meta.env.VITE_APP_GOOGLE_TAG_ID)
       }
@@ -114,10 +114,10 @@ export default defineComponent({
     onBeforeMount(() => {
       const tagId = import.meta.env.VITE_APP_GOOGLE_TAG_ID
       if (tagId != undefined && tagId.length > 0) {
-        acceptAllCookies.value = AppStorage.getCookiePolicyAcceptAll()
-        showCookiesDialog.value = (acceptAllCookies.value == null)
+        acceptCookies.value = AppStorage.getAcceptCookiePolicy()
+        showCookiesDialog.value = (acceptCookies.value == null)
       } else {
-        acceptAllCookies.value = null
+        acceptCookies.value = null
         showCookiesDialog.value = false
       }
     })
@@ -132,22 +132,22 @@ export default defineComponent({
       window.removeEventListener('resize', onResizeHandler);
     })
 
-    const handleChooseNecessaryCookies = () => {
-      acceptAllCookies.value = false
-      AppStorage.setCookiePolicyAcceptAll(false)
+    const handleChooseRejectCookies = () => {
+      acceptCookies.value = false
+      AppStorage.setAcceptCookiePolicy(false)
     }
 
-    const handleChooseAllCookies = () => {
-      acceptAllCookies.value = true
-      AppStorage.setCookiePolicyAcceptAll(true)
+    const handleChooseAcceptCookies = () => {
+      acceptCookies.value = true
+      AppStorage.setAcceptCookiePolicy(true)
     }
 
     return {
       isMediumScreen,
       onMainDashboardPage,
       showCookiesDialog,
-      handleChooseNecessaryCookies,
-      handleChooseAllCookies,
+      handleChooseRejectCookies,
+      handleChooseAcceptCookies,
     }
   },
 });

--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -86,6 +86,24 @@ export class AppStorage {
     }
 
     //
+    // cookiePolicy
+    //
+
+    private static readonly COOKIE_POLICY_NAME = 'cookiePolicy'
+    private static readonly COOKIE_POLICY_ACCEPT_ALL = 'acceptAll'
+    private static readonly COOKIE_POLICY_ACCEPT_NECESSARY = 'acceptNecessary'
+
+    public static getCookiePolicyAcceptAll(): boolean|null {
+        const policy = AppStorage.readCookie(AppStorage.COOKIE_POLICY_NAME)
+        return policy != null ? policy === AppStorage.COOKIE_POLICY_ACCEPT_ALL : null
+    }
+
+    public static setCookiePolicyAcceptAll(choice: boolean): void {
+        const policy = choice ? AppStorage.COOKIE_POLICY_ACCEPT_ALL : AppStorage.COOKIE_POLICY_ACCEPT_NECESSARY
+        AppStorage.createCookie(AppStorage.COOKIE_POLICY_NAME, policy, 1)
+    }
+
+    //
     // Private
     //
 
@@ -110,5 +128,43 @@ export class AppStorage {
         } catch {
             // Ignored
         }
+    }
+
+    //
+    // cookies
+    // from routines provided at https://www.quirksmode.org/js/cookies.html
+    //
+
+    private static createCookie(name: string, value: string, days:number): void {
+        let expires
+        if (days) {
+            let date = new Date()
+            date.setTime(date.getTime() + (days*24*60*60*1000))
+            expires = `; expires=${date.toUTCString()}`
+        } else {
+            expires = ""
+        }
+        document.cookie = `${name}=${value}${expires}; path=/`
+    }
+
+    private static readCookie(name: string): string|null {
+        let result = null
+        const nameEQ = name + "="
+        const ca = document.cookie.split(';')
+        for (let i= 0; i < ca.length; i++) {
+            let c = ca[i]
+            while (c.charAt(0)==' ') {
+                c = c.substring(1, c.length)
+            }
+            if (c.indexOf(nameEQ) == 0) {
+                result = c.substring(nameEQ.length, c.length)
+                break
+            }
+        }
+        return result
+    }
+
+    private static eraseCookie(name: string): void {
+        AppStorage.createCookie(name,"",-1)
     }
 }

--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -89,18 +89,19 @@ export class AppStorage {
     // cookiePolicy
     //
 
-    private static readonly COOKIE_POLICY_NAME = 'cookiePolicy'
-    private static readonly COOKIE_POLICY_ACCEPT_ALL = 'acceptAll'
-    private static readonly COOKIE_POLICY_ACCEPT_NECESSARY = 'acceptNecessary'
+    private static readonly COOKIE_POLICY_NAME = 'cookie_policy'
+    private static readonly COOKIE_POLICY_ACCEPT = 'accept'
+    private static readonly COOKIE_POLICY_REJECT = 'reject'
+    private static readonly COOKIE_POLICY_VALIDITY = 365 // days
 
-    public static getCookiePolicyAcceptAll(): boolean|null {
+    public static getAcceptCookiePolicy(): boolean|null {
         const policy = AppStorage.readCookie(AppStorage.COOKIE_POLICY_NAME)
-        return policy != null ? policy === AppStorage.COOKIE_POLICY_ACCEPT_ALL : null
+        return policy != null ? policy === AppStorage.COOKIE_POLICY_ACCEPT : null
     }
 
-    public static setCookiePolicyAcceptAll(choice: boolean): void {
-        const policy = choice ? AppStorage.COOKIE_POLICY_ACCEPT_ALL : AppStorage.COOKIE_POLICY_ACCEPT_NECESSARY
-        AppStorage.createCookie(AppStorage.COOKIE_POLICY_NAME, policy, 1)
+    public static setAcceptCookiePolicy(accept: boolean): void {
+        const policy = accept ? AppStorage.COOKIE_POLICY_ACCEPT : AppStorage.COOKIE_POLICY_REJECT
+        AppStorage.createCookie(AppStorage.COOKIE_POLICY_NAME, policy, AppStorage.COOKIE_POLICY_VALIDITY)
     }
 
     //

--- a/src/components/CookiesDialog.vue
+++ b/src/components/CookiesDialog.vue
@@ -23,33 +23,24 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div class="modal has-text-white" v-bind:class="{'is-active': showDialog}">
-    <div class="modal-background"/>
-    <div class="modal-content" style="width: 768px; border-radius: 16px">
-      <div class="box">
-
-        <div class="is-flex is-justify-content-space-between is-align-items-baseline">
-          <div class="is-flex is-justify-content-start is-align-items-baseline">
-            <span v-if="iconClass" class="icon ml-2 mr-5"><i :class="iconClass"/></span>
-            <div class="block h-is-tertiary-text mt-2">
-              <slot name="dialogMessage"/>
-            </div>
-          </div>
-          <a v-if="showCloseIcon" @click="handleClose">
-            <img alt="Modal close icon" src="@/assets/close-icon.png" style="max-height: 20px;">
-          </a>
-
+  <ModalDialog :icon-class="iconClass" :show-dialog="showDialog" :show-close-icon="false">
+    <template v-slot:dialogMessage>
+      <span>Accept Cookies</span>
+    </template>
+    <template v-slot:dialogDetails>
+      <span class="mr-1">We use cookies to deliver the best experience on our website and to analyze traffic.
+        By continuing to use this site, you consent to our cookie policy.
+        Review our</span>
+      <a class="mr-1" href="https://swirldslabs.com/privacy-policy/">Privacy Policy</a>
+      <span>to understand how Swirlds Labs collects and uses information.</span>
+      <div class="is-flex is-justify-content-space-between is-align-items-baseline mt-4">
+        <div class="is-flex is-justify-content-flex-end">
+          <button class="button is-white is-small" @click="handleChooseNecessary">NECESSARY COOKIES</button>
+          <button class="button is-info is-small ml-4" @click="handleChooseAll">ALL COOKIES</button>
         </div>
-
-        <hr class="h-card-separator"/>
-
-        <div class="block h-is-property-text has-text-grey mb-2" style="line-height: 1.5">
-          <slot name="dialogDetails"/>
-        </div>
-
       </div>
-    </div>
-  </div>
+    </template>
+  </ModalDialog>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
@@ -59,28 +50,31 @@
 <script lang="ts">
 
 import {defineComponent} from "vue";
+import ModalDialog from "@/components/ModalDialog.vue";
 
 export default defineComponent({
-  name: "ModalDialog",
-  components: {},
+  name: "CookiesDialog",
+  components: {ModalDialog},
   props: {
     showDialog: {
       type: Boolean,
       default: false
     },
-    iconClass: String,
-    showCloseIcon: {
-      type: Boolean,
-      default: true
-    },
+    iconClass: String
   },
-
   setup(props, context) {
-    const handleClose = () => {
+    const handleChooseAll = () => {
       context.emit('update:showDialog', false)
-      context.emit('onClose')
+      context.emit('onChooseAll')
     }
-    return { handleClose }
+    const handleChooseNecessary = () => {
+      context.emit('update:showDialog', false)
+      context.emit('onChooseNecessary')
+    }
+    return {
+      handleChooseAll,
+      handleChooseNecessary
+    }
   }
 });
 
@@ -91,8 +85,5 @@ export default defineComponent({
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style scoped>
-span.icon {
-  align-items: flex-start;
-}
 </style>
 

--- a/src/components/CookiesDialog.vue
+++ b/src/components/CookiesDialog.vue
@@ -35,8 +35,8 @@
       <span>to understand how Swirlds Labs collects and uses information.</span>
       <div class="is-flex is-justify-content-space-between is-align-items-baseline mt-4">
         <div class="is-flex is-justify-content-flex-end">
-          <button class="button is-white is-small" @click="handleChooseNecessary">NECESSARY COOKIES</button>
-          <button class="button is-info is-small ml-4" @click="handleChooseAll">ALL COOKIES</button>
+          <button class="button is-white is-small" @click="handleChooseReject">REJECT</button>
+          <button class="button is-info is-small ml-4" @click="handleChooseAccept">ACCEPT</button>
         </div>
       </div>
     </template>
@@ -63,17 +63,17 @@ export default defineComponent({
     iconClass: String
   },
   setup(props, context) {
-    const handleChooseAll = () => {
+    const handleChooseAccept = () => {
       context.emit('update:showDialog', false)
-      context.emit('onChooseAll')
+      context.emit('onChooseAccept')
     }
-    const handleChooseNecessary = () => {
+    const handleChooseReject = () => {
       context.emit('update:showDialog', false)
-      context.emit('onChooseNecessary')
+      context.emit('onChooseReject')
     }
     return {
-      handleChooseAll,
-      handleChooseNecessary
+      handleChooseAccept,
+      handleChooseReject,
     }
   }
 });


### PR DESCRIPTION
Get user approval before setting up the google tag to enable google analytics:
- prompt the user for his consent (accept/reject cookies) with modal dialog
- the tag ID is set via VITE_APP_GOOGLE_TAG_ID environment variable
- the global site tag setup is no longer static in (the branded version of) index.html but instead added dynamically to the DOM after consent is given
- keep user choice for 365 days

**Related issue(s)**:
None

**Notes for reviewer**:

<img width="871" alt="Screenshot 2023-08-04 at 13 56 13" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/d9be484f-1896-4d4b-82d3-f56606902236">
