### PR TITLE
Make modal dialog responsive.

### DIFF
--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -393,6 +393,26 @@ hr.dotted {
 }
 
 //
+// MODALS
+//
+
+.h-modal-content {
+    width: 768px
+}
+
+@media (max-width: 1079px) {
+    .h-modal-content {
+        width: 640px
+    }
+}
+
+@media (max-width: 767px) {
+    .h-modal-content {
+        width: 280px
+    }
+}
+
+//
 // TOOLTIPS
 //
 

--- a/src/components/ModalDialog.vue
+++ b/src/components/ModalDialog.vue
@@ -25,7 +25,7 @@
 <template>
   <div class="modal has-text-white" v-bind:class="{'is-active': showDialog}">
     <div class="modal-background"/>
-    <div class="modal-content" style="width: 768px; border-radius: 16px">
+    <div class="modal-content h-modal-content" style="border-radius: 16px">
       <div class="box">
 
         <div class="is-flex is-justify-content-space-between is-align-items-baseline">


### PR DESCRIPTION
**Description**:

Simple change to make the modal dialog responsive, which fixes the issue of cookie consent dialog not showing up properly on a mobile screen.

**Notes for reviewer**:

![IMG_35004D056ED1-1](https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/86d0dcaf-480c-496b-8235-53930bf30e29)

