### PR TITLE
Moved vitest from 0.32.4 to 0.34.3.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "vite": "^4.4.9",
         "vite-plugin-node-polyfills": "^0.9.0",
         "vite-plugin-rewrite-all": "^1.0.1",
-        "vitest": "^0.32.4",
+        "vitest": "^0.34.3",
         "vue-tsc": "^1.8.8"
       }
     },
@@ -4661,13 +4661,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.32.4.tgz",
-      "integrity": "sha512-m7EPUqmGIwIeoU763N+ivkFjTzbaBn0n9evsTOcde03ugy2avPs3kZbYmw3DkcH1j5mxhMhdamJkLQ6dM1bk/A==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.3.tgz",
+      "integrity": "sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.32.4",
-        "@vitest/utils": "0.32.4",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "chai": "^4.3.7"
       },
       "funding": {
@@ -4675,12 +4675,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.32.4.tgz",
-      "integrity": "sha512-cHOVCkiRazobgdKLnczmz2oaKK9GJOw6ZyRcaPdssO1ej+wzHVIkWiCiNacb3TTYPdzMddYkCgMjZ4r8C0JFCw==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.3.tgz",
+      "integrity": "sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.32.4",
+        "@vitest/utils": "0.34.3",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.1"
       },
@@ -4716,12 +4716,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.32.4.tgz",
-      "integrity": "sha512-IRpyqn9t14uqsFlVI2d7DFMImGMs1Q9218of40bdQQgMePwVdmix33yMNnebXcTzDU5eiV3eUsoxxH5v0x/IQA==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.3.tgz",
+      "integrity": "sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==",
       "dev": true,
       "dependencies": {
-        "magic-string": "^0.30.0",
+        "magic-string": "^0.30.1",
         "pathe": "^1.1.1",
         "pretty-format": "^29.5.0"
       },
@@ -4730,9 +4730,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.32.4.tgz",
-      "integrity": "sha512-oA7rCOqVOOpE6rEoXuCOADX7Lla1LIa4hljI2MSccbpec54q+oifhziZIJXxlE/CvI2E+ElhBHzVu0VEvJGQKQ==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.3.tgz",
+      "integrity": "sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.1"
@@ -4742,9 +4742,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-Gwnl8dhd1uJ+HXrYyV0eRqfmk9ek1ASE/LWfTCuWMw+d07ogHqp4hEAV28NiecimK6UY9DpSEPh+pXBA5gtTBg==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.3.tgz",
+      "integrity": "sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.4.3",
@@ -13649,9 +13649,9 @@
       "dev": true
     },
     "node_modules/tinypool": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.5.0.tgz",
-      "integrity": "sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
+      "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -14215,9 +14215,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.32.4.tgz",
-      "integrity": "sha512-L2gIw+dCxO0LK14QnUMoqSYpa9XRGnTTTDjW2h19Mr+GR0EFj4vx52W41gFXfMLqpA00eK4ZjOVYo1Xk//LFEw==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.3.tgz",
+      "integrity": "sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -14269,34 +14269,34 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.32.4.tgz",
-      "integrity": "sha512-3czFm8RnrsWwIzVDu/Ca48Y/M+qh3vOnF16czJm98Q/AN1y3B6PBsyV8Re91Ty5s7txKNjEhpgtGPcfdbh2MZg==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.3.tgz",
+      "integrity": "sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.32.4",
-        "@vitest/runner": "0.32.4",
-        "@vitest/snapshot": "0.32.4",
-        "@vitest/spy": "0.32.4",
-        "@vitest/utils": "0.32.4",
+        "@vitest/expect": "0.34.3",
+        "@vitest/runner": "0.34.3",
+        "@vitest/snapshot": "0.34.3",
+        "@vitest/spy": "0.34.3",
+        "@vitest/utils": "0.34.3",
         "acorn": "^8.9.0",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
         "chai": "^4.3.7",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.3",
-        "magic-string": "^0.30.0",
+        "magic-string": "^0.30.1",
         "pathe": "^1.1.1",
         "picocolors": "^1.0.0",
         "std-env": "^3.3.3",
         "strip-literal": "^1.0.1",
         "tinybench": "^2.5.0",
-        "tinypool": "^0.5.0",
+        "tinypool": "^0.7.0",
         "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.32.4",
+        "vite-node": "0.34.3",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@types/node": "^18.17.12",
         "@vitejs/plugin-basic-ssl": "^1.0.1",
         "@vitejs/plugin-vue": "^4.3.4",
-        "@vitest/coverage-v8": "^0.33.0",
+        "@vitest/coverage-v8": "^0.34.3",
         "@vue/eslint-config-typescript": "^11.0.3",
         "@vue/test-utils": "^2.4.1",
         "@vue/tsconfig": "^0.4.0",
@@ -4627,15 +4627,15 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.33.0.tgz",
-      "integrity": "sha512-Rj5IzoLF7FLj6yR7TmqsfRDSeaFki6NAJ/cQexqhbWkHEV2htlVGrmuOde3xzvFsCbLCagf4omhcIaVmfU8Okg==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.3.tgz",
+      "integrity": "sha512-bNjP0RHe8UxdklCigZlk6FVCNbOiqVjWnpZJ1zKixpvb7YHSaZiN/w+mzpvXIoqyxyePzKC+L+G1oj7SB20PJw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@bcoe/v8-coverage": "^0.2.3",
         "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^4.0.1",
         "istanbul-reports": "^3.1.5",
         "magic-string": "^0.30.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^18.17.12",
     "@vitejs/plugin-basic-ssl": "^1.0.1",
     "@vitejs/plugin-vue": "^4.3.4",
-    "@vitest/coverage-v8": "^0.33.0",
+    "@vitest/coverage-v8": "^0.34.3",
     "@vue/eslint-config-typescript": "^11.0.3",
     "@vue/test-utils": "^2.4.1",
     "@vue/tsconfig": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sass": "^1.66.1",
     "typescript": "~5.0.4",
     "vite": "^4.4.9",
-    "vitest": "^0.32.4",
+    "vitest": "^0.34.3",
     "vite-plugin-node-polyfills": "^0.9.0",
     "vite-plugin-rewrite-all": "^1.0.1",
     "vue-tsc": "^1.8.8"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,15 +10,7 @@ export default mergeConfig(
       environment: 'jsdom',
       exclude: [...configDefaults.exclude, 'e2e/*'],
       root: fileURLToPath(new URL('./', import.meta.url)),
-      transformMode: {
-        web: [/\.[jt]sx$/]
-      },
       setupFiles: ['./tests/unit/globalSetup.js'],
-      deps: {
-          inline: [
-              "hashconnect"
-          ]
-      },
       coverage: {
         reporter: ['text', 'json-summary', 'json'],
       }


### PR DESCRIPTION
**Description**:

Changes below update release of 
- `vitest` from 0.32.4 to 0.34.3.
- `@vitest/coverage-v8` from 0.33.0 to 0.34.3.

Some configuration items in `vitest.config.ts` become obsolete and are removed.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
