### PR TITLE
Fixed test break in Staking.spec.ts and StakingDialog.spec.ts

### DIFF
--- a/tests/unit/utils/TableController.spec.ts
+++ b/tests/unit/utils/TableController.spec.ts
@@ -20,15 +20,21 @@
  *
  */
 
-import {describe, test, expect, vi} from 'vitest'
+import {afterEach, beforeEach, describe, test, expect, vi} from 'vitest'
 import {computed, nextTick, Ref, ref} from "vue";
 import {makeRouter} from "@/router";
 import {flushPromises} from "@vue/test-utils";
 import {KeyOperator, SortOrder, TableController} from "@/utils/table/TableController";
 
-vi.useFakeTimers()
-
 describe("TableController.ts", () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
 
     test("load() sanity check", async () => {
         const tc = new TestTableController(0, 50, 10)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
+      // cache: false, // If test fails in CI only, run locally with cache=false to be closer to CI environment
       exclude: [...configDefaults.exclude, 'e2e/*'],
       root: fileURLToPath(new URL('./', import.meta.url)),
       setupFiles: ['./tests/unit/globalSetup.js'],


### PR DESCRIPTION
**Description**:

Changes below fix test break in `Staking.spec.ts` and `StakingDialog.spec.ts`.

This break happens systematically when tests are executed by GitHub.
In local environment, it happens when `vitest` cache is clean (or setting `cache:false` in `vitest.config.ts`).

Root cause is usage of `vi.useFakeTimer()` in `TableController.spec.ts`
- `vi.useFakeTimer()` is called outside of `describe()` method
- `vi.useRealTimer()` is never called
- when `TableController.spec.ts` is executed first, `vi.useFakeTimer()` is active when `Staking.spec.ts` is executed
- `Staking.spec.ts` and `StakingDialog.spec.ts` breaks when `vi.useFakeTimer()` is active (not clear why)



**Related issue(s)**:

None

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
