### PR TITLE
Updated @kabuto-sh/ns to release 0.12.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fortawesome/vue-fontawesome": "^3.0.3",
         "@hashgraph/proto": "^2.12.0",
         "@hashgraph/sdk": "^2.34.1",
-        "@kabuto-sh/ns": "^0.7.0",
+        "@kabuto-sh/ns": "^0.12.0",
         "@metamask/detect-provider": "^1.2.0",
         "@metamask/providers": "^9.1.0",
         "@oruga-ui/oruga-next": "^0.6.0",
@@ -3664,14 +3664,16 @@
       }
     },
     "node_modules/@kabuto-sh/ns": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@kabuto-sh/ns/-/ns-0.7.0.tgz",
-      "integrity": "sha512-0a7nabuOGjJ745ZVKgfXI/OJ9nBaoJvV74UKy0VDG+Bl23B36owzA2+V26SPtsUlWQxfM8Rp37Ox7IeiRt6GHQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@kabuto-sh/ns/-/ns-0.12.0.tgz",
+      "integrity": "sha512-YPD4ftiMKsdUg8z2N1R/pZsdP7YgVzxIf0GqNuGRRjFhtMAa29csudkFlnvlpmA+NYkt8Cd+7HQYg/SP8n/GwA==",
       "dependencies": {
-        "@hashgraph/sdk": "^2.20.0",
-        "axios": "^1.3.3",
-        "bignumber.js": "^9.1.1",
-        "date-fns": "^2.29.3"
+        "axios": "^1.5.0",
+        "bignumber.js": "^9.1.2",
+        "date-fns": "^2.30.0"
+      },
+      "peerDependencies": {
+        "@hashgraph/sdk": "^2.32.0"
       }
     },
     "node_modules/@kabuto-sh/ns/node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.3",
     "@hashgraph/proto": "^2.12.0",
     "@hashgraph/sdk": "^2.34.1",
-    "@kabuto-sh/ns": "^0.7.0",
+    "@kabuto-sh/ns": "^0.12.0",
     "@metamask/detect-provider": "^1.2.0",
     "@metamask/providers": "^9.1.0",
     "@oruga-ui/oruga-next": "^0.6.0",


### PR DESCRIPTION
**Description**:

Changes below upgrade `@kabuto-sh/ns` from release `0.7.0` to `0.12.0`.

Manually tested:
- query with an existing name works OK
- query with an non existing name breaks on KNS side 
   - same issue happens with release 0.7.0
   - issue is being investigated by KNS team

**Related issue(s)**:

_None_
