### PR TITLE
00669 ContractResultLogEntry now displays decoded data when contract is verified.

### DIFF
--- a/src/components/contract/ContractResultLogEntry.vue
+++ b/src/components/contract/ContractResultLogEntry.vue
@@ -66,7 +66,8 @@
             </Property>
         </template>
 
-    </template><template v-else>
+    </template>
+    <template v-else>
 
       <Property id="logData" :full-width="true">
           <template v-slot:name>Data</template>

--- a/src/components/contract/ContractResultLogEntry.vue
+++ b/src/components/contract/ContractResultLogEntry.vue
@@ -31,12 +31,6 @@
         <EVMAddress :address="log.address" :id="log.contract_id"/>
       </template>
     </Property>
-    <Property id="logData" :full-width="true">
-      <template v-slot:name>Data</template>
-      <template v-slot:value>
-        <HexaValue :show-none="true" v-bind:byteString="log.data" :low-contrast="false"/>
-      </template>
-    </Property>
     <Property id="logIndex" :full-width="true">>
       <template v-slot:name>Index</template>
       <template v-slot:value>
@@ -53,6 +47,36 @@
         </div>
       </template>
     </Property>
+
+    <template v-if="signature">
+
+        <div class="h-is-tertiary-text mt-4 mb-3">Data</div>
+
+        <Property id="logSignature" :full-width="true">
+            <template v-slot:name>Signature</template>
+            <template v-slot:value>{{ signature }}</template>
+        </Property>
+
+        <template v-for="arg in args" :key="arg.name">
+            <Property :id="'logArg_' + arg.name" :full-width="true">
+                <template v-slot:name>{{ arg.name }}</template>
+                <template v-slot:value>
+                    <FunctionValue :ntv="arg"/>
+                </template>
+            </Property>
+        </template>
+
+    </template><template v-else>
+
+      <Property id="logData" :full-width="true">
+          <template v-slot:name>Data</template>
+          <template v-slot:value>
+              <HexaValue :show-none="true" v-bind:byteString="log.data" :low-contrast="false"/>
+          </template>
+      </Property>
+
+    </template>
+
   </div>
 
 </template>
@@ -63,19 +87,35 @@
 
 <script lang="ts">
 
-import {defineComponent, PropType} from "vue";
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import {ContractResultLog} from "@/schemas/HederaSchemas";
 import Property from "@/components/Property.vue";
 import StringValue from "@/components/values/StringValue.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
+import {ContractLogAnalyzer} from "@/utils/analyzer/ContractLogAnalyzer";
+import SignatureValue from "@/components/values/SignatureValue.vue";
+import FunctionValue from "@/components/values/FunctionValue.vue";
 
 export default defineComponent({
   name: "ContractResultLogEntry",
-  components: {EVMAddress, HexaValue, StringValue, Property},
+  components: {FunctionValue, SignatureValue, EVMAddress, HexaValue, StringValue, Property},
   props: {
-    log: Object as PropType<ContractResultLog | undefined>
+    log: {
+        type: Object as PropType<ContractResultLog | null>,
+        default: null
+    }
   },
+  setup(props) {
+      const logAnalyzer = new ContractLogAnalyzer(computed(() => props.log))
+      onMounted(() => logAnalyzer.mount())
+      onBeforeUnmount(() => logAnalyzer.unmount())
+
+      return {
+          args: logAnalyzer.args,
+          signature: logAnalyzer.signature
+      }
+  }
 })
 
 </script>

--- a/src/components/contract/ContractResultLogs.vue
+++ b/src/components/contract/ContractResultLogs.vue
@@ -26,7 +26,7 @@
 
   <DashboardCard v-if="logs?.length" class="h-card">
     <template v-slot:title>
-      <span class="h-is-secondary-title">Logs</span>
+      <span class="h-is-secondary-title">Events</span>
     </template>
 
     <template v-slot:control v-if="logs.length > 2">

--- a/src/utils/analyzer/ContractLogAnalyzer.ts
+++ b/src/utils/analyzer/ContractLogAnalyzer.ts
@@ -1,0 +1,96 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, ComputedRef, Ref, shallowRef, watch, WatchStopHandle} from "vue";
+import {ContractResultLog} from "@/schemas/HederaSchemas";
+import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer";
+import {ethers} from "ethers";
+import {NameTypeValue} from "@/utils/analyzer/FunctionCallAnalyzer";
+
+export class ContractLogAnalyzer {
+
+    public readonly log: Ref<ContractResultLog|null>
+    private readonly contractAnalyzer: ContractAnalyzer
+    private readonly logDescription = shallowRef<ethers.utils.LogDescription|null>(null)
+    private watchHandle: WatchStopHandle|null = null
+
+    //
+    // Public
+    //
+
+    public constructor(log: Ref<ContractResultLog|null>) {
+        this.log = log
+        this.contractAnalyzer = new ContractAnalyzer(computed(() => log.value?.contract_id ?? null))
+    }
+
+    public mount(): void {
+        this.watchHandle = watch([
+            this.log,
+            this.contractAnalyzer.interface
+        ], this.updateLogDescription, { immediate: true})
+        this.contractAnalyzer.mount()
+    }
+
+    public unmount(): void {
+        this.contractAnalyzer.unmount()
+        if (this.watchHandle !== null) {
+            this.watchHandle()
+            this.watchHandle = null
+        }
+        this.logDescription.value = null
+    }
+
+    public readonly signature = computed(
+        () => this.logDescription.value?.signature ?? null)
+
+    public readonly args: ComputedRef<NameTypeValue[]> = computed(() => {
+        const result: NameTypeValue[] = []
+        if (this.logDescription.value) {
+            const args = this.logDescription.value.args
+            const fragmentInputs = this.logDescription.value.eventFragment.inputs
+            for (let i = 0; i < args.length; i+= 1) {
+                const value = args[i]
+                const name = i < fragmentInputs.length ? fragmentInputs[i].name : "?"
+                const type = i < fragmentInputs.length ? fragmentInputs[i].type : "?"
+                result.push(new NameTypeValue(name, type, value))
+            }
+        }
+        return result
+    })
+
+    //
+    // Private
+    //
+
+    private readonly updateLogDescription = () => {
+        const i = this.contractAnalyzer.interface.value
+        const l = this.log.value
+        if (i !== null && l !== null && l.topics && l.data) {
+            try {
+                this.logDescription.value = i.parseLog({topics: l.topics, data: l.data})
+            } catch {
+                this.logDescription.value = null
+            }
+        } else {
+            this.logDescription.value = null
+        }
+    }
+
+}

--- a/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -1,0 +1,82 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import router, {routeManager} from "@/router";
+import axios from "axios";
+import {SAMPLE_CONTRACT} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import {HMSF} from "@/utils/HMSF";
+import Oruga from "@oruga-ui/oruga-next";
+import ContractResultLogEntry from "@/components/contract/ContractResultLogEntry.vue";
+import {SAMPLE_LOG_RESULT, SAMPLE_SOURCIFY_RESPONSE} from "../utils/analyzer/ContractLogAnalyzer.spec";
+
+/*
+    Bookmarks
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+describe("ContractResultLogEntry.vue", () => {
+
+    it("Should display the contract result and logs, given consensus timestamp", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const matcher1 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        const mock = new MockAdapter(axios);
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT)
+
+        const networkEntry = routeManager.currentNetworkEntry.value
+        const requestURL = networkEntry.sourcifySetup?.makeRequestURL(SAMPLE_CONTRACT.evm_address)
+        // const contractURL = networkEntry.sourcifySetup?.makeContractLookupURL(SAMPLE_CONTRACT.evm_address)
+        mock.onGet(requestURL).reply(200, SAMPLE_SOURCIFY_RESPONSE)
+
+        const wrapper = mount(ContractResultLogEntry, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                log: SAMPLE_LOG_RESULT
+            },
+        });
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.get("#logAddress").text()).toBe("Address0x00000000000000000000000000000000000b70cfCopy(0.0.749775)")
+        expect(wrapper.get("#logIndex").text()).toBe("Index0")
+        expect(wrapper.get("#logTopics").text()).toBe("Topics(0) 01f7 89d6 70af a303 0578 cc57 0ac4 d43a ce6f 1575 dd6c 395a 711e 72a3 0051 efd2Copy")
+        expect(wrapper.get("#logSignature").text()).toBe("SignatureFlightEvent(string,int256,int256)")
+        expect(wrapper.get("#logArg_phase").text()).toBe("phaseHolding pointstring")
+        expect(wrapper.get("#logArg_airspeed").text()).toBe("airspeed0int256")
+        expect(wrapper.get("#logArg_verticalSpeed").text()).toBe("verticalSpeed0int256")
+
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+});
+

--- a/tests/unit/utils/analyzer/ContractLogAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractLogAnalyzer.spec.ts
@@ -1,0 +1,111 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, test} from 'vitest'
+import {SAMPLE_CONTRACT} from "../../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {ref, Ref} from "vue";
+import {ContractLogAnalyzer} from "@/utils/analyzer/ContractLogAnalyzer";
+import {ContractResultLog} from "@/schemas/HederaSchemas";
+import {routeManager} from "@/router";
+import {SourcifyResponse} from "@/utils/cache/SourcifyCache";
+import {flushPromises} from "@vue/test-utils";
+import {ethers} from "ethers";
+
+describe("ContractLogAnalyzer.spec.ts", () => {
+
+
+    test("TestEvent.sol", async () => {
+
+        const matcher1 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        const mock = new MockAdapter(axios);
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT)
+
+        const networkEntry = routeManager.currentNetworkEntry.value
+        const requestURL = networkEntry.sourcifySetup?.makeRequestURL(SAMPLE_CONTRACT.evm_address)
+        // const contractURL = networkEntry.sourcifySetup?.makeContractLookupURL(SAMPLE_CONTRACT.evm_address)
+        mock.onGet(requestURL).reply(200, SAMPLE_SOURCIFY_RESPONSE)
+
+        // 1) new
+        const contractLog: Ref<ContractResultLog|null> = ref(null)
+        const logAnalyzer = new ContractLogAnalyzer(contractLog)
+        expect(logAnalyzer.signature.value).toBeNull()
+        expect(logAnalyzer.args.value).toStrictEqual([])
+
+        // 2) mount log analyzer
+        logAnalyzer.mount()
+        expect(logAnalyzer.signature.value).toBeNull()
+        expect(logAnalyzer.args.value).toStrictEqual([])
+
+        // 3) setup log analyzer
+        contractLog.value = SAMPLE_LOG_RESULT
+        await flushPromises()
+        // expect(logAnalyzer.signature.value).toBe("FlightEvent(string,int256,int256)")
+        expect(logAnalyzer.args.value.length).toBe(3)
+        expect(logAnalyzer.args.value[0].name).toBe("phase")
+        expect(logAnalyzer.args.value[0].type).toBe("string")
+        expect(logAnalyzer.args.value[0].value).toBe("Holding point")
+        expect(logAnalyzer.args.value[1].name).toBe("airspeed")
+        expect(logAnalyzer.args.value[1].type).toBe("int256")
+        expect(logAnalyzer.args.value[1].value).toStrictEqual(ethers.BigNumber.from(0))
+        expect(logAnalyzer.args.value[2].name).toBe("verticalSpeed")
+        expect(logAnalyzer.args.value[2].type).toBe("int256")
+        expect(logAnalyzer.args.value[2].value).toStrictEqual(ethers.BigNumber.from(0))
+
+        // 4) mount log analyzer
+        logAnalyzer.unmount()
+        expect(logAnalyzer.signature.value).toBeNull()
+        expect(logAnalyzer.args.value).toStrictEqual([])
+
+    })
+
+
+})
+
+
+export const SAMPLE_SOURCIFY_RESPONSE: SourcifyResponse = {
+    "status": "full",
+    "files": [
+        {
+            "name": "metadata.json",
+            "path": "/home/data/repository/contracts/full_match/297/0x000000000000000000000000000000000000BE0D/metadata.json",
+            "content": "{\"compiler\":{\"version\":\"0.8.17+commit.8df45f5f\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"string\",\"name\":\"phase\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"int256\",\"name\":\"airspeed\",\"type\":\"int256\"},{\"indexed\":false,\"internalType\":\"int256\",\"name\":\"verticalSpeed\",\"type\":\"int256\"}],\"name\":\"FlightEvent\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"flight\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"TestEvent.sol\":\"TestEvent\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"TestEvent.sol\":{\"keccak256\":\"0x0b43f90058f0db1650b050d9bd9336160ac306c77794b2d3604076143cf232eb\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://f2d727b9c673d82880530e8ffa055e5ac6b275d04e31f7c53235ca653fb380e7\",\"dweb:/ipfs/QmQTD72f5NNTjAZqJSBSbK8itwTkLTCA5v2yGcgV49yy4p\"]}},\"version\":1}"
+        },
+        {
+            "name": "TestEvent.sol",
+            "path": "/home/data/repository/contracts/full_match/297/0x000000000000000000000000000000000000BE0D/sources/TestEvent.sol",
+            "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.4;\n\nerror SimpleError();\nerror ComplexError(string name, int256 temperature);\n\n// https://blog.soliditylang.org/2021/04/21/custom-errors/\n\ncontract TestEvent {\n\n    event FlightEvent(string phase, int airspeed, int verticalSpeed);\n\n    function flight() public {\n        emit FlightEvent(\"Holding point\", 0, 0);\n        emit FlightEvent(\"Taking Off\", 110, 0);\n        emit FlightEvent(\"Climbing\", 150, 500);\n        emit FlightEvent(\"Cruising\", 200, 0);\n        emit FlightEvent(\"Descending\", 200, -500);\n        emit FlightEvent(\"Landing\", 130, -250);\n        emit FlightEvent(\"Runway Cleared\", 10, 0);\n    }\n\n}\n"
+        }
+    ]
+}
+
+export const SAMPLE_LOG_RESULT = {
+    "address": SAMPLE_CONTRACT.evm_address,
+    "bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000408000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000020000000000000000000000000000000000",
+    "contract_id": SAMPLE_CONTRACT.contract_id,
+    "data": "0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d486f6c64696e6720706f696e7400000000000000000000000000000000000000",
+    "index": 0,
+    "topics": [
+        "0x01f789d670afa3030578cc570ac4d43ace6f1575dd6c395a711e72a30051efd2"
+    ]
+}


### PR DESCRIPTION
**Description**:

Changes below implement contract event decoding and add unit tests.

When events are decoded `ContractResultLogEntry` displays event data as below:
<img width="1201" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/50cfe11a-f112-4b4b-a760-b771596f7d2a">

When events decoded enabled (ie target contract is verified), `ContractResultLogEntry` displays the following:
<img width="1201" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/781ca624-5725-40e3-af79-b858af5d35cc">


**Related issue(s)**:

Fixes #00669

**Notes for reviewer**:

Contract [0.0.40537](https://hashscan.io/previewnet/contract/0.0.40537) and [0.0.28117](https://hashscan.io/previewnet/contract/0.0.28117) are [TestEvent.sol](https://github.com/ericleponner/hedera-contract-album/blob/main/src/main/java/test_event/TestEvent.sol) instances.
- [0.0.40537](https://hashscan.io/previewnet/contract/0.0.40537) is not verified and contract call [0.0.17590@1695917074.820719243](https://hashscan.io/previewnet/transaction/1695917087.683970028) show undecoded event data
- [0.0.28117](https://hashscan.io/previewnet/contract/0.0.28117) is verified and contract call [0.0.17590@1695800490.553937714](https://hashscan.io/previewnet/transaction/1695800501.443492003) show decoded event data

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
