### PR TITLE
00711 Restored logic which initializes SearchRequest.ethereumAddress and added extra checks in unit tests

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -162,12 +162,15 @@ export default defineComponent({
                 routeManager.routeToTopic(topicId)
               }
               searchDidEnd(true)
-            }else if (r.ethereumAddress != null) {
-              routeManager.routeToAccount(r.ethereumAddress)
-              searchDidEnd(true)
             } else {
-              routeManager.routeToNoSearchResult(searchedId.value, r.getErrorCount())
-              searchDidEnd(false)
+                // No match => if searchId looks like an EVM address we say "inactive" else we say "not found"
+                if (r.ethereumAddress !== null) {
+                    routeManager.routeToAccount(r.ethereumAddress) // Will display inactive
+                    searchDidEnd(true)
+                } else {
+                    routeManager.routeToNoSearchResult(searchedId.value, r.getErrorCount())
+                    searchDidEnd(false)
+                }
             }
           } catch {
             console.trace("Failed to route")

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -150,6 +150,7 @@ export class SearchRequest {
                         this.searchContract(hexBytes),
                         this.searchToken(hexBytes),
                     ]
+                    this.ethereumAddress = "0x" + byteToHex(hexBytes)
                     break
                 default:
                     promises = [
@@ -162,6 +163,7 @@ export class SearchRequest {
                             this.searchContract(evmAddress),
                             this.searchToken(evmAddress),
                         ])
+                        this.ethereumAddress = "0x" + byteToHex(evmAddress)
                     }
                     break
             }

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -119,6 +119,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -135,6 +136,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBe("0x" + SAMPLE_ACCOUNT_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -151,6 +153,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -167,6 +170,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -184,6 +188,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -204,6 +209,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -220,6 +226,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -236,6 +243,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -256,6 +264,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toStrictEqual(SAMPLE_BLOCKSRESPONSE.blocks[0])
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -272,6 +281,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toStrictEqual(SAMPLE_BLOCKSRESPONSE.blocks[0])
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -292,6 +302,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -308,6 +319,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBe("0x" + SAMPLE_TOKEN_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -328,6 +340,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual(SAMPLE_TOPIC_MESSAGES.messages)
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -348,6 +361,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -364,6 +378,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toStrictEqual(SAMPLE_CONTRACT)
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBe(SAMPLE_CONTRACT.evm_address)
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -381,6 +396,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -397,6 +413,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBe("0x000000" + INVALID_EVM_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
         const aliasHex2 = "0x" + INVALID_EVM_ADDRESS
@@ -411,6 +428,7 @@ describe("SearchRequest.ts", () => {
         expect(r2.topicMessages).toStrictEqual([])
         expect(r2.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBe("0x000000" + INVALID_EVM_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
     })
@@ -428,6 +446,7 @@ describe("SearchRequest.ts", () => {
         expect(r.topicMessages).toStrictEqual([])
         expect(r.contract).toBeNull()
         expect(r.block).toBeNull()
+        expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
     })


### PR DESCRIPTION
**Description**:

Changes below fix a regression introduced by #482 and add some additional checks in unit tests.

**Related issue(s)**:

Fixes #711.

**Notes for reviewer**:

See #711 for testing samples.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
