### PR TITLE
fix: allow Helm templating for proxyPass value

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -46,7 +46,7 @@ data:
           
           {{- range $path, $backend := .Values.proxyPass }}
           location {{ $path }} {
-            proxy_pass {{ $backend }};
+            proxy_pass {{ tpl $backend $ }};
           }
           {{- end }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -158,10 +158,13 @@ volumes:
     configMap:
       name: '{{ include "hedera-explorer.fullname" . }}-config'
 
-# Add custom reverse proxy configuration
+# Add custom reverse proxy configuration.
+# It is a key-value map where key is the path and value being a URL.
 # Primary use case is to allow access to mirror node api via hedera explorer url
+# Note that templating is allowed in the values
+# Example:
+#   /api: "http://{{ .Release.Name }}-rest"
 proxyPass: {}
-#  /api: "http://{{ .Release.Name }}-rest" # Note: templating is allowed
 
 config: |
   [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -161,7 +161,7 @@ volumes:
 # Add custom reverse proxy configuration
 # Primary use case is to allow access to mirror node api via hedera explorer url
 proxyPass: {}
-  # /api: http://fst-rest
+#  /api: "http://{{ .Release.Name }}-rest" # Note: templating is allowed
 
 config: |
   [


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR allows helm templating for `proxyPass` value so that end-user is able to deploy their chart with any custom release name without hardcoding the `proxyPass` value in their values.yaml file

**Related issue(s)**:

Fixes #725

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
I have tested it in FST chart and a relevant fix is here: https://github.com/hashgraph/full-stack-testing/pull/413

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
