### PR TITLE
00720 incomplete list of token balances

### DIFF
--- a/src/components/account/TokenRelationshipsTableController.ts
+++ b/src/components/account/TokenRelationshipsTableController.ts
@@ -61,11 +61,9 @@ export class TokenRelationshipsTableController extends TableController<TokenRela
             if (tokenId !== null) {
                 params["token.id"] = operator + ":" + tokenId
             }
-            const cb = (r: AxiosResponse<TokenRelationshipResponse>): Promise<TokenRelationship[] | null> => {
-                return Promise.resolve(r.data.tokens ?? [])
-            }
             const url = `api/v1/accounts/${this.accountId.value}/tokens`
-            result = axios.get<TokenRelationshipResponse>(url, {params: params}).then(cb)
+            const r = await axios.get<TokenRelationshipResponse>(url, {params: params})
+            result  = Promise.resolve(r.data.tokens ?? [])
         } else {
             result = Promise.resolve(null)
         }

--- a/src/components/account/TokenRelationshipsTableController.ts
+++ b/src/components/account/TokenRelationshipsTableController.ts
@@ -18,16 +18,9 @@
  *
  */
 
-import {
-    Contract,
-    ContractsResponse,
-    Token,
-    TokenRelationship,
-    TokenRelationshipResponse,
-    TokensResponse
-} from "@/schemas/HederaSchemas";
+import {TokenRelationship, TokenRelationshipResponse,} from "@/schemas/HederaSchemas";
 import {ComputedRef, Ref} from "vue";
-import axios, {AxiosResponse} from "axios";
+import axios from "axios";
 import {KeyOperator, SortOrder, TableController} from "@/utils/table/TableController";
 import {Router} from "vue-router";
 

--- a/src/components/account/TokenRelationshipsTableController.ts
+++ b/src/components/account/TokenRelationshipsTableController.ts
@@ -1,0 +1,86 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+    Contract,
+    ContractsResponse,
+    Token,
+    TokenRelationship,
+    TokenRelationshipResponse,
+    TokensResponse
+} from "@/schemas/HederaSchemas";
+import {ComputedRef, Ref} from "vue";
+import axios, {AxiosResponse} from "axios";
+import {KeyOperator, SortOrder, TableController} from "@/utils/table/TableController";
+import {Router} from "vue-router";
+
+export class TokenRelationshipsTableController extends TableController<TokenRelationship, string> {
+
+    private readonly accountId: Ref<string | null>
+
+    //
+    // Public
+    //
+
+    public constructor(router: Router, accountId: Ref<string | null>, pageSize: ComputedRef<number>) {
+        super(router, pageSize, 10 * pageSize.value, 5000, 10, 100)
+        this.accountId = accountId
+    }
+
+    //
+    // TableController
+    //
+
+    public async load(tokenId: string | null, operator: KeyOperator, order: SortOrder, limit: number): Promise<TokenRelationship[] | null> {
+        let result
+        if (this.accountId.value !== null) {
+            const params = {} as {
+                limit: number
+                "token.id": string | undefined
+                order: string
+            }
+            params.limit = limit
+            params.order = order
+            if (tokenId !== null) {
+                params["token.id"] = operator + ":" + tokenId
+            }
+            const cb = (r: AxiosResponse<TokenRelationshipResponse>): Promise<TokenRelationship[] | null> => {
+                return Promise.resolve(r.data.tokens ?? [])
+            }
+            const url = `api/v1/accounts/${this.accountId.value}/tokens`
+            result = axios.get<TokenRelationshipResponse>(url, {params: params}).then(cb)
+        } else {
+            result = Promise.resolve(null)
+        }
+        return result
+    }
+
+    public keyFor(row: TokenRelationship): string {
+        return row.token_id ?? ""
+    }
+
+    public stringFromKey(key: string): string {
+        return key;
+    }
+
+    public keyFromString(s: string): string | null {
+        return s;
+    }
+}

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -23,7 +23,7 @@
 // Fungible token inspired from https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.29662956
 //
 
-import {KeyType, TokenRelationshipResponse} from "@/schemas/HederaSchemas";
+import {KeyType} from "@/schemas/HederaSchemas";
 
 export const SAMPLE_TOKEN = {
     "admin_key": null,
@@ -2106,15 +2106,8 @@ export const SAMPLE_ASSOCIATED_TOKEN_2 = {
 // Inspired from https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.642949/tokens
 //
 
-export const SAMPLE_TOKEN_ASSOCIATIONS: TokenRelationshipResponse = {
+export const SAMPLE_TOKEN_ASSOCIATIONS = {
     "tokens": [{
-        "automatic_association": false,
-        "balance": 0,
-        "created_timestamp": "1647994323.478512577",
-        "freeze_status": "NOT_APPLICABLE",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": "0.0.26568643"
-    }, {
         "automatic_association": false,
         "balance": 0,
         "created_timestamp": SAMPLE_TOKEN_ASSOCIATE_TRANSACTION.consensus_timestamp,

--- a/tests/unit/account/AccountBalances.spec.ts
+++ b/tests/unit/account/AccountBalances.spec.ts
@@ -22,10 +22,13 @@ import {describe, test, expect} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
-import {SAMPLE_ACCOUNT_BALANCES, SAMPLE_NONFUNGIBLE, SAMPLE_TOKEN} from "../Mocks";
+import {
+    SAMPLE_ASSOCIATED_TOKEN, SAMPLE_ASSOCIATED_TOKEN_2,
+    SAMPLE_TOKEN_ASSOCIATIONS
+} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
-import BalanceTable from "@/components/account/BalanceTable.vue";
+import AccountBalances from "@/pages/AccountBalances.vue";
 import {HMSF} from "@/utils/HMSF";
 
 /*
@@ -37,25 +40,29 @@ import {HMSF} from "@/utils/HMSF";
 
 HMSF.forceUTC = true
 
-describe("BalanceTable.vue", () => {
+describe("AccountBalances.vue", () => {
 
     test("all props", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios);
+        const accountId = "0.0.935559"
+        const matcher1 = `/api/v1/accounts/${accountId}/tokens`
+        mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_ASSOCIATIONS)
 
+        const token1 = SAMPLE_ASSOCIATED_TOKEN.token_id
+        const token2 = SAMPLE_ASSOCIATED_TOKEN_2.token_id
         const matcher2 = "/api/v1/tokens/"
-        mock.onGet(matcher2 + SAMPLE_TOKEN.token_id).reply(200, SAMPLE_TOKEN)
-        mock.onGet(matcher2 + SAMPLE_NONFUNGIBLE.token_id).reply(200, SAMPLE_NONFUNGIBLE)
+        mock.onGet(matcher2 + token1).reply(200, SAMPLE_ASSOCIATED_TOKEN)
+        mock.onGet(matcher2 + token2).reply(200, SAMPLE_ASSOCIATED_TOKEN_2)
 
-        const wrapper = mount(BalanceTable, {
+        const wrapper = mount(AccountBalances, {
             global: {
                 plugins: [router, Oruga]
             },
             props: {
-                balances: SAMPLE_ACCOUNT_BALANCES.balances[0].tokens,
-                nbItems: 42
+                accountId: accountId
             },
         });
 
@@ -65,12 +72,8 @@ describe("BalanceTable.vue", () => {
 
         expect(wrapper.find('thead').text()).toBe("Token Balance")
         expect(wrapper.find('tbody').text()).toBe(
-            "0.0.2966295623423" +
-            "998" +
-            "0.0.748383" +
-            "Ħ Frens Kingdom" +
-            "1"
-        )
+            "0.0.34332104" + "HSuite" + "0.0000" +
+            "0.0.49292859" + "TokenA7" + "0.00000000")
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -24,6 +24,8 @@ import {flushPromises, mount} from "@vue/test-utils";
 import {Transaction, TransactionDetail} from "@/schemas/HederaSchemas";
 import RewardTransferGraph from "@/components/transfer_graphs/RewardTransferGraph.vue";
 import {SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE, SAMPLE_CRYPTO_TRANSFER_WITH_REWARDS} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
 
 describe("RewardTransferGraph.vue", () => {
 
@@ -77,6 +79,10 @@ describe("RewardTransferGraph.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
+        const mock = new MockAdapter(axios);
+        const matcher1 = "/api/v1/network/exchangerate"
+        mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
+
         const wrapper = mount(RewardTransferGraph, {
             global: {
                 plugins: [router]
@@ -102,9 +108,9 @@ describe("RewardTransferGraph.vue", () => {
             "Reward AccountAccountAmount Rewarded" +
             "0.0.800\n\n" +
             "0.0.788887" +
-            "2.10704256\n\n" +
+            "2.10704256" + "$0.51840\n\n" +
             "0.0.2254995" +
-            "22.89378672")
+            "22.89378672" + "$5.63263")
 
         wrapper.unmount()
     })

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -23,7 +23,11 @@ import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import {Transaction, TransactionDetail} from "@/schemas/HederaSchemas";
 import RewardTransferGraph from "@/components/transfer_graphs/RewardTransferGraph.vue";
-import {SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE, SAMPLE_CRYPTO_TRANSFER_WITH_REWARDS} from "../Mocks";
+import {
+    SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE,
+    SAMPLE_CRYPTO_TRANSFER_WITH_REWARDS,
+    SAMPLE_NETWORK_EXCHANGERATE
+} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 


### PR DESCRIPTION
**Description**:

In this PR, we:
- use the API call api/v1/accounts/{id}/tokens to be able to retrieve the complete list of token associated with an account
- use a TableController instead of a Cache to retrieve the data in a paginated manner.
- fix unrelated unit test issue (was depending upon another test's mock side-effect)

**Related issue(s)**:

Fixes #720 #706 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
