### PR TITLE
Fix initialisation of verify contract URL

### DIFF
--- a/public/networks-config.json
+++ b/public/networks-config.json
@@ -5,10 +5,10 @@
     "url": "https://mainnet-public.mirrornode.hedera.com/",
     "ledgerID": "00",
     "sourcifySetup": {
-      "activate": false,
-      "repoURL": "https://repository.sourcify-integration.hedera-devops.com/contracts/",
-      "serverURL": "https://server.sourcify-integration.hedera-devops.com/",
-      "verifierURL": "https://sourcify-integration.hedera-devops.com/#/",
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
       "chainID": 295
     }
   },
@@ -18,10 +18,10 @@
     "url": "https://testnet.mirrornode.hedera.com/",
     "ledgerID": "01",
     "sourcifySetup": {
-      "activate": false,
-      "repoURL": "https://repository.sourcify-integration.hedera-devops.com/contracts/",
-      "serverURL": "https://server.sourcify-integration.hedera-devops.com/",
-      "verifierURL": "https://sourcify-integration.hedera-devops.com/#/",
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
       "chainID": 296
     }
   },
@@ -31,10 +31,10 @@
     "url": "https://previewnet.mirrornode.hedera.com/",
     "ledgerID": "02",
     "sourcifySetup": {
-      "activate": false,
-      "repoURL": "https://repository.sourcify-integration.hedera-devops.com/contracts/",
-      "serverURL": "https://server.sourcify-integration.hedera-devops.com/",
-      "verifierURL": "https://sourcify-integration.hedera-devops.com/#/",
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
       "chainID": 297
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -120,12 +120,12 @@ export default defineComponent({
         acceptCookies.value = null
         showCookiesDialog.value = false
       }
+      networkRegistry.readCustomConfig()
     })
 
     onMounted(() => {
       windowWidth.value = window.innerWidth
       window.addEventListener('resize', onResizeHandler);
-      networkRegistry.readCustomConfig()
     })
 
     onBeforeUnmount(() => {

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -34,7 +34,7 @@
       <div v-if="sourcifyURL" id="showSource" class="is-inline-block ml-3">
         <a :href="sourcifyURL" target="_blank">View Contract (beta)</a>
       </div>
-      <div v-else id="showVerifier" class="is-inline-block ml-3">
+      <div v-else-if="verifierURL" id="showVerifier" class="is-inline-block ml-3">
         <a :href="verifierURL" target="_blank">Verify Contract (beta)</a>
       </div>
     </template>
@@ -148,7 +148,7 @@ export default defineComponent({
       isVerificationEnabled,
       tooltipText,
       sourcifyURL: props.contractAnalyzer.sourcifyURL,
-      verifierURL: routeManager.currentNetworkEntry.value.sourcifySetup?.verifierURL,
+      verifierURL: routeManager.currentVerifierUrl,
       isVerified,
       isFullMatch
     }

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -70,6 +70,9 @@ export class RouteManager {
         return networkEntry != null ? networkEntry : networkRegistry.getDefaultEntry()
     })
 
+    public currentVerifierUrl = computed(
+        () => this.currentNetworkEntry.value.sourcifySetup?.verifierURL)
+
     public selectedNetwork = ref(networkRegistry.getDefaultEntry().name)
 
     public selectedNetworkWatchHandle: WatchStopHandle|undefined

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -41,6 +41,7 @@ import NotificationBanner from "@/components/NotificationBanner.vue";
 import {TransactionID} from "@/utils/TransactionID";
 import ContractResultTable from "@/components/contract/ContractResultTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
+import {NetworkRegistry} from "../../../src/schemas/NetworkRegistry";
 
 /*
     Bookmarks
@@ -429,7 +430,16 @@ describe("ContractDetails.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
+        const mock = new MockAdapter(axios);
+
+        const contract = SAMPLE_CONTRACT_WITH_SWARM_HASH
         const contractId = SAMPLE_CONTRACT_WITH_SWARM_HASH.contract_id
+        const matcher1 = "/api/v1/contracts/" + contractId
+        mock.onGet(matcher1).reply(200, contract);
+
+        const matcher2 = "/api/v1/contracts/" + contractId + "/results"
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_RESULTS);
+
         const wrapper = mount(ContractDetails, {
             global: {
                 plugins: [router, Oruga]

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -41,7 +41,6 @@ import NotificationBanner from "@/components/NotificationBanner.vue";
 import {TransactionID} from "@/utils/TransactionID";
 import ContractResultTable from "@/components/contract/ContractResultTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
-import {NetworkRegistry} from "../../../src/schemas/NetworkRegistry";
 
 /*
     Bookmarks


### PR DESCRIPTION
**Description**:

Make the URL of the 'Verify Contract' reactive such that it displays the value read from config.json once the read is completed, which takes a tiny bit longer than the initialisation of the page.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
