### PR TITLE
Downgrade crypto-js from 4.2.0 to 4.1.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "base32-encode": "^1.2.0",
         "bulma": "^0.9.4",
         "core-js": "^3.33.1",
+        "crypto-js": "4.1.1",
         "ethers": "^5.7.2",
         "hashconnect": "^0.1.10",
         "vue": "^3.3.4",
@@ -7055,9 +7056,9 @@
       "integrity": "sha512-UUqiVJ2gUuZFmbFsKmud3uuLcNP2+Opt+5ysmljycFCyhA0+T16XJmo1ev/t5kMChMqWh7IEvURNCqsg+SjZGQ=="
     },
     "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "base32-encode": "^1.2.0",
     "bulma": "^0.9.4",
     "core-js": "^3.33.1",
+    "crypto-js": "4.1.1",
     "ethers": "^5.7.2",
     "hashconnect": "^0.1.10",
     "vue": "^3.3.4",


### PR DESCRIPTION
**Description**:

Recent move to crypto-js@4.2.0 breaks hashconnect@0.1.10.
Changes below downgrade crypto-js by adding an explicit dependency to 4.1.1 release.

**Related issue(s)**:

_None_

