### PR TITLE
fix: disable refreshes when navigating away from account details

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -387,7 +387,9 @@ export default defineComponent({
     })
     onBeforeUnmount(() => {
       mounted = false
-      transactionTableController.unmount()
+      if (transactionTableController.mounted.value) {
+        transactionTableController.unmount()
+      }
     })
     watch(accountId, () => {
       if (mounted) {

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -387,9 +387,7 @@ export default defineComponent({
     })
     onBeforeUnmount(() => {
       mounted = false
-      if (accountId.value !== null) {
-        transactionTableController.unmount()
-      }
+      transactionTableController.unmount()
     })
     watch(accountId, () => {
       if (mounted) {

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -307,7 +307,7 @@ export abstract class TableController<R, K> {
         this.autoRefreshRef.value = true
         await this.buffer.refresh()
         await this.bufferDidChange()
-        if (this.refreshCountRef.value < this.maxAutoUpdateCount) {
+        if (this.refreshCountRef.value < this.maxAutoUpdateCount && this.mounted) {
             this.timeoutID = window.setTimeout(() => {
                 this.refreshCountRef.value += 1
                 this.refreshBuffer().catch(this.errorHandler)

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -307,7 +307,7 @@ export abstract class TableController<R, K> {
         this.autoRefreshRef.value = true
         await this.buffer.refresh()
         await this.bufferDidChange()
-        if (this.refreshCountRef.value < this.maxAutoUpdateCount && this.mounted) {
+        if (this.refreshCountRef.value < this.maxAutoUpdateCount) {
             this.timeoutID = window.setTimeout(() => {
                 this.refreshCountRef.value += 1
                 this.refreshBuffer().catch(this.errorHandler)


### PR DESCRIPTION
**Description**:
Correctly unmount table controller and disable refreshes when it is unmounted

**Related issue(s)**:

Fixes #730 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
