### PR TITLE
Add mount point for networks-config.json when running in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,10 @@ coverage
 
 /dist
 
-# local env files
+# local env and configuration files
 .env.local
 .env.*.local
+networks-config.json
 
 # Editor directories and files
 .vscode

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm run test:e2e
 # Build the Docker image locally
 npm run docker:build
 
+# Copy and adjust configuration of Hedera networks as needed
+cp networks-config-example.json networks-config.json
+
 # Start the Docker container
 # (if not built locally, this will fetch a pre-built image from Google Container Registry)
 npm run docker:start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
     restart: "always"
     ports:
       - "8080:8080"
+    volumes:
+      - ./networks-config.json:/app/networks-config.json

--- a/networks-config-example.json
+++ b/networks-config-example.json
@@ -1,0 +1,54 @@
+[
+  {
+    "name": "mainnet",
+    "displayName": "MAINNET",
+    "url": "https://mainnet-public.mirrornode.hedera.com/",
+    "ledgerID": "00",
+    "sourcifySetup": {
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
+      "chainID": 295
+    }
+  },
+  {
+    "name": "testnet",
+    "displayName": "TESTNET",
+    "url": "https://testnet.mirrornode.hedera.com/",
+    "ledgerID": "01",
+    "sourcifySetup": {
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
+      "chainID": 296
+    }
+  },
+  {
+    "name": "previewnet",
+    "displayName": "PREVIEWNET",
+    "url": "https://previewnet.mirrornode.hedera.com/",
+    "ledgerID": "02",
+    "sourcifySetup": {
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
+      "chainID": 297
+    }
+  },
+  {
+    "name": "localnode",
+    "displayName": "LOCAL NODE",
+    "url": "http://127.0.0.1:5551",
+    "ledgerID": "FF",
+    "sourcifySetup": {
+      "activate": true,
+      "repoURL": "http://localhost:10000/contracts/",
+      "serverURL": "http://localhost:5002/",
+      "verifierURL": "http://localhost:3000/#/",
+      "chainID": 298
+    }
+  }
+]


### PR DESCRIPTION
**Description**:

This allows to provide a custom `networks-config.json` when running the explorer from a Docker container, for instance to easily:
 - use connection to a LocalNode
 - use a completely custom (set of) network(s) for testing purposes
