### PR TITLE
00765 Explorer should not report "Decoding Error" when error is empty in a contract result

### DIFF
--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -224,7 +224,7 @@ export class FunctionCallAnalyzer {
     private readonly updateErrorDescription = async() => {
         const i = this.contractAnalyzer.interface.value
         const error = this.error.value
-        if (i !== null && error !== null) {
+        if (i !== null && error !== null && error !== "0x") {
             try {
                 const ed = i.parseError(error)
                 this.errorDescription.value = Object.preventExtensions(ed)

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -108,6 +108,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         // 5) output setup (invalid output encoding)
         input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
         output.value = "0x000000009999999999999999999999999"
+        error.value = "0x"
         contractId.value = "0.0.359"
         await flushPromises()
         expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
@@ -122,7 +123,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBe("Decoding Error (hex data is odd-length)")
-        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
+        expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull() // 0x is considered as no error
 
 
         // 6) unmount


### PR DESCRIPTION
**Description**:

Changes below fix false decoding error reported in `Contract Result` section.
They also add a unit test case for asserting this.

**Related issue(s)**:

Fixes #765

**Notes for reviewer**:

Use mainnet transaction [1700549131.961381389](https://hashscan.io/mainnet/transaction/1700549131.961381389).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
