### PR TITLE
00749 wrong hbar price and market cap when switching from previewnet

### DIFF
--- a/src/components/dashboard/HbarMarketDashboard.vue
+++ b/src/components/dashboard/HbarMarketDashboard.vue
@@ -110,9 +110,8 @@ export default defineComponent({
     const hbarTotalLabel = 'HBAR TOTAL'
 
     // marketDataCache
-    const marketDataCache = new MarketDataCache()
-    onMounted(() => marketDataCache.mount())
-    onBeforeUnmount(() => marketDataCache.unmount())
+    onMounted(() => MarketDataCache.instance.mount())
+    onBeforeUnmount(() => MarketDataCache.instance.unmount())
 
     return {
       isMainNetwork,
@@ -123,13 +122,13 @@ export default defineComponent({
       hbarMarketCapLabel,
       hbarReleasedLabel,
       hbarTotalLabel,
-      marketDataCache, // For testing purpose
-      hbarReleased: marketDataCache.hbarReleased,
-      hbarTotal: marketDataCache.hbarTotal,
-      hbarPrice: marketDataCache.hbarPrice,
-      hbarPriceVariation: marketDataCache.hbarPriceVariation,
-      hbarMarketCap: marketDataCache.hbarMarketCap,
-      hbarMarketCapVariation: marketDataCache.hbarMarketCapVariation,
+      marketDataCache: MarketDataCache.instance, // For testing purpose
+      hbarReleased: MarketDataCache.instance.hbarReleased,
+      hbarTotal: MarketDataCache.instance.hbarTotal,
+      hbarPrice: MarketDataCache.instance.hbarPrice,
+      hbarPriceVariation: MarketDataCache.instance.hbarPriceVariation,
+      hbarMarketCap: MarketDataCache.instance.hbarMarketCap,
+      hbarMarketCapVariation: MarketDataCache.instance.hbarMarketCapVariation,
     }
   },
 });

--- a/src/components/dashboard/HbarPriceLoader.ts
+++ b/src/components/dashboard/HbarPriceLoader.ts
@@ -52,9 +52,7 @@ export class HbarPriceLoader extends AutoRefreshLoader<NetworkExchangeRateSetRes
             timestamp: string
         }
         if (this.deltaSeconds) {
-            const now = new Date()
-            const target = new Date(now.getTime() - this.deltaSeconds * 1000)
-            params.timestamp = (target.getTime() / 1000).toString()
+            params.timestamp = (new Date().getTime() / 1000 - this.deltaSeconds).toString()
         }
 
         return axios.get<NetworkExchangeRateSetResponse>("api/v1/network/exchangerate", {params: params})

--- a/src/components/dashboard/HbarPriceLoader.ts
+++ b/src/components/dashboard/HbarPriceLoader.ts
@@ -23,7 +23,7 @@ import axios, {AxiosResponse} from "axios";
 import {computed} from "vue";
 import {NetworkExchangeRateSetResponse} from "@/schemas/HederaSchemas";
 
-export class HbarPriceCache extends AutoRefreshLoader<NetworkExchangeRateSetResponse> {
+export class HbarPriceLoader extends AutoRefreshLoader<NetworkExchangeRateSetResponse> {
 
     //
     // Public

--- a/src/components/dashboard/HbarSupplyLoader.ts
+++ b/src/components/dashboard/HbarSupplyLoader.ts
@@ -23,7 +23,7 @@ import axios, {AxiosResponse} from "axios";
 import {computed} from "vue";
 import {NetworkSupplyResponse} from "@/schemas/HederaSchemas";
 
-export class HbarSupplyCache extends AutoRefreshLoader<NetworkSupplyResponse> {
+export class HbarSupplyLoader extends AutoRefreshLoader<NetworkSupplyResponse> {
 
     //
     // Public

--- a/src/components/dashboard/MarketDataCache.ts
+++ b/src/components/dashboard/MarketDataCache.ts
@@ -20,7 +20,7 @@
 
 import {computed} from "vue";
 import {HbarPriceLoader} from "@/components/dashboard/HbarPriceLoader";
-import {HbarSupplyCache} from "@/components/dashboard/HbarSupplyCache";
+import {HbarSupplyLoader} from "@/components/dashboard/HbarSupplyLoader";
 
 export class MarketDataCache {
 
@@ -29,8 +29,8 @@ export class MarketDataCache {
     //
     public readonly hbarPriceCache = new HbarPriceLoader()
     public readonly hbarPrice24hCache = new HbarPriceLoader(86400)
-    public readonly hbarSupplyCache = new HbarSupplyCache()
-    public readonly hbarSupply24hCache = new HbarSupplyCache(86400)
+    public readonly hbarSupplyCache = new HbarSupplyLoader()
+    public readonly hbarSupply24hCache = new HbarSupplyLoader(86400)
 
     public readonly hbarPrice = computed(() => {
         const currentPrice = this.hbarPriceCache.hbarPrice.value

--- a/src/components/dashboard/MarketDataCache.ts
+++ b/src/components/dashboard/MarketDataCache.ts
@@ -27,6 +27,8 @@ export class MarketDataCache {
     //
     // Public
     //
+    public static readonly instance = new MarketDataCache()
+
     public readonly hbarPriceCache = new HbarPriceLoader()
     public readonly hbarPrice24hCache = new HbarPriceLoader(86400)
     public readonly hbarSupplyCache = new HbarSupplyLoader()
@@ -90,5 +92,12 @@ export class MarketDataCache {
         this.hbarPrice24hCache.mounted.value = false
         this.hbarSupplyCache.mounted.value = false
         this.hbarSupply24hCache.mounted.value = false
+    }
+
+    public clear(): void {
+        this.hbarPriceCache.requestLoad()
+        this.hbarPrice24hCache.requestLoad()
+        this.hbarSupplyCache.requestLoad()
+        this.hbarSupply24hCache.requestLoad()
     }
 }

--- a/src/components/dashboard/MarketDataCache.ts
+++ b/src/components/dashboard/MarketDataCache.ts
@@ -19,7 +19,7 @@
  */
 
 import {computed} from "vue";
-import {HbarPriceCache} from "@/components/dashboard/HbarPriceCache";
+import {HbarPriceLoader} from "@/components/dashboard/HbarPriceLoader";
 import {HbarSupplyCache} from "@/components/dashboard/HbarSupplyCache";
 
 export class MarketDataCache {
@@ -27,8 +27,8 @@ export class MarketDataCache {
     //
     // Public
     //
-    public readonly hbarPriceCache = new HbarPriceCache()
-    public readonly hbarPrice24hCache = new HbarPriceCache(86400)
+    public readonly hbarPriceCache = new HbarPriceLoader()
+    public readonly hbarPrice24hCache = new HbarPriceLoader(86400)
     public readonly hbarSupplyCache = new HbarSupplyCache()
     public readonly hbarSupply24hCache = new HbarSupplyCache(86400)
 

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -45,6 +45,7 @@ import {ContractResultByTransactionIdCache} from "@/utils/cache/ContractResultBy
 import {ContractResultByTsCache} from "@/utils/cache/ContractResultByTsCache";
 import {SourcifyCache} from "@/utils/cache/SourcifyCache";
 import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache";
+import {MarketDataCache} from "@/components/dashboard/MarketDataCache";
 
 export class CacheUtils {
 
@@ -62,6 +63,7 @@ export class CacheUtils {
         ContractResultByHashCache.instance.clear()
         ContractResultByTransactionIdCache.instance.clear()
         ContractResultByTsCache.instance.clear()
+        MarketDataCache.instance.clear()
         HbarPriceCache.instance.clear()
         // IPFSCache.instance => no clear: we preserve it because IPFS content is valid for all networks
         NetworkCache.instance.clear()


### PR DESCRIPTION
**Description**:

- Rename `components/dashboard/HbarPriceCache` to `HbarPriceLoader` (this is in fact a loader) to avoid possible confusion with `utils/cache/HbarPriceCache`
- Also rename `HbarSupplyCache` to `HbarSupplyLoader`
- Make `MarketDataCache` a singleton with a `clear() `method that can be called from `CacheUtils.clearAll()` when switching networks, to avoid retaining the _rate_ & _market cap_ obtained from the network in use when the page was loaded. In the case of _previewnet_, these values are completely off.

**Related issue(s)**:

Fixes #749 
