### PR TITLE
Clean-up smart contract verification feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -2,9 +2,6 @@
 ### The variables set in this file will be taken into account at build time.
 ###
 
-### When set to 'true', this variable will enable contract verification UI phase 2
-VITE_APP_ENABLE_VERIFICATION_UI_PHASE2=true
-
 ### When set to 'true', this variable will enable 'Metamask' support
 VITE_APP_ENABLE_METAMASK=true
 

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -38,22 +38,16 @@
         <template v-slot:control>
             <template v-if="isVerificationEnabled">
                 <template v-if="isVerified">
-                    <div v-if="isVerificationPhase2 && sourcifyURL" id="showSource" class="is-inline-block ml-3">
+                    <div v-if="sourcifyURL" id="showSource" class="is-inline-block ml-3">
                         <a :href="sourcifyURL" target="_blank">View contract sources</a>
-                    </div>
-                    <div v-else-if="sourcifyURL" id="showSourceBeta" class="is-inline-block ml-3">
-                        <a :href="sourcifyURL" target="_blank">View contract (beta)</a>
                     </div>
                 </template>
                 <template v-else>
-                    <button v-if="isVerificationPhase2" id="verify-button"
+                    <button id="verify-button"
                             class="button is-white is-small has-text-right"
                             @click="showVerifyDialog = true">
                         VERIFY CONTRACT
                     </button>
-                    <div v-else id="showVerifier" class="is-inline-block ml-3">
-                        <a :href="verifierURL" target="_blank">Verify contract (beta)</a>
-                    </div>
                 </template>
             </template>
         </template>
@@ -153,10 +147,6 @@ export default defineComponent({
         return sourcifySetup !== null && sourcifySetup.activate
     })
 
-    const isVerificationPhase2 = computed(() => {
-        return import.meta.env.VITE_APP_ENABLE_VERIFICATION_UI_PHASE2 === "true"
-    })
-
     const showVerifyDialog = ref(false)
     const verifyDidComplete = () => {
         props.contractAnalyzer.verifyDidComplete()
@@ -176,7 +166,6 @@ export default defineComponent({
       swarmHash: props.contractAnalyzer.byteCodeAnalyzer.swarmHash,
       contractName,
       isVerificationEnabled,
-      isVerificationPhase2,
       tooltipText,
       sourcifyURL: props.contractAnalyzer.sourcifyURL,
       verifierURL: routeManager.currentVerifierUrl,

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -165,39 +165,21 @@ export class NetworkRegistry {
             displayName: 'MAINNET',
             url: "https://mainnet-public.mirrornode.hedera.com/",
             ledgerID: '00',
-            sourcifySetup: new SourcifySetup(
-                true,
-                "http://localhost:10000/contracts/",
-                "http://localhost:5002/",
-                "http://localhost:3000/#/",
-                0x127
-            )
+            sourcifySetup: new SourcifySetup(true, "", "", "", 0x127)
         },
         {
             name: 'testnet',
             displayName: 'TESTNET',
             url: "https://testnet.mirrornode.hedera.com/",
             ledgerID: '01',
-            sourcifySetup: new SourcifySetup(
-                true,
-                "http://localhost:10000/contracts/",
-                "http://localhost:5002/",
-                "http://localhost:3000/#/",
-                0x128
-            )
+            sourcifySetup: new SourcifySetup(true, "", "", "", 0x128)
         },
         {
             name: 'previewnet',
             displayName: 'PREVIEWNET',
             url: "https://previewnet.mirrornode.hedera.com/",
             ledgerID: '02',
-            sourcifySetup: new SourcifySetup(
-                true,
-                "http://localhost:10000/contracts/",
-                "http://localhost:5002/",
-                "http://localhost:3000/#/",
-                0x129
-            )
+            sourcifySetup: new SourcifySetup(true, "", "", "", 0x129)
         }
     ])
 

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -74,7 +74,7 @@ export class NetworkEntry {
             if (sourcifySetupEncoding !== undefined && sourcifySetupEncoding !== null) {
                 const sourcifySetup = SourcifySetup.decode(sourcifySetupEncoding as Record<string, unknown>)
                 if (sourcifySetup !== null) {
-                    result = new NetworkEntry(name, tidyDisplayName.toUpperCase(), url, ledgerID, sourcifySetup)
+                    result = new NetworkEntry(name, tidyDisplayName, url, ledgerID, sourcifySetup)
                 } else {
                     result = null
                 }

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -64,14 +64,14 @@ export class NetworkEntry {
             (typeof displayName == "string" || typeof displayName == "undefined") &&
             typeof url == "string" &&
             typeof ledgerID == "string" &&
-            typeof sourcifySetupEncoding == "object") {
+            (typeof sourcifySetupEncoding == "object" || typeof sourcifySetupEncoding == "undefined")) {
 
             let tidyDisplayName = (displayName ?? name).toUpperCase()
             if (tidyDisplayName.length > this.NETWORK_NAME_MAX_LENGTH) {
                 tidyDisplayName = tidyDisplayName.slice(0, this.NETWORK_NAME_MAX_LENGTH) + '…'
             }
 
-            if (sourcifySetupEncoding !== null) {
+            if (sourcifySetupEncoding !== undefined && sourcifySetupEncoding !== null) {
                 const sourcifySetup = SourcifySetup.decode(sourcifySetupEncoding as Record<string, unknown>)
                 if (sourcifySetup !== null) {
                     result = new NetworkEntry(name, tidyDisplayName.toUpperCase(), url, ledgerID, sourcifySetup)

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -434,8 +434,6 @@ describe("ContractDetails.vue", () => {
 
     it("Should display contract verification link and properties", async () => {
 
-        process.env = Object.assign(process.env, { VITE_APP_ENABLE_VERIFICATION_UI_PHASE2: false });
-
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios);
@@ -463,7 +461,7 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Contract Contract ID:" + contractId))
         const cards = wrapper.findAllComponents(DashboardCard)
         expect(cards[1].text()).toMatch(RegExp("^Contract Bytecode"))
-        expect(cards[1].get('a').text()).toBe("Verify contract (beta)")
+        expect(cards[1].get('#verify-button').text()).toBe("VERIFY CONTRACT")
 
         mock.restore()
         wrapper.unmount()

--- a/tests/unit/schema/NetworkRegistry.spec.ts
+++ b/tests/unit/schema/NetworkRegistry.spec.ts
@@ -1,0 +1,190 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, it, expect} from 'vitest'
+import {flushPromises} from "@vue/test-utils"
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import {HMSF} from "@/utils/HMSF";
+import {networkRegistry, NetworkRegistry} from "../../../src/schemas/NetworkRegistry";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+describe("NetworkRegistry.ts", () => {
+
+    it("Should read configuration from networks-config.json", async () => {
+
+        const config = [
+            {
+                "name": "mainnet",
+                "displayName": "MAINNET",
+                "url": "https://mainnet-public.mirrornode.hedera.com/",
+                "ledgerID": "00",
+                "sourcifySetup": {
+                    "activate": true,
+                    "repoURL": "http://localhost:10000/contracts/",
+                    "serverURL": "http://localhost:5002/",
+                    "verifierURL": "http://localhost:3000/#/",
+                    "chainID": 295
+                }
+            }
+        ]
+
+        const mock = new MockAdapter(axios);
+        const configUrl = NetworkRegistry.NETWORKS_CONFIG_URL
+        mock.onGet(configUrl).reply(200, config)
+
+        networkRegistry.readCustomConfig()
+        await flushPromises()
+        expect(networkRegistry.entries.value.length).toBe(config.length)
+        const defaultEntry = networkRegistry.getDefaultEntry()
+        expect(defaultEntry.name).toBe(config[0].name)
+        expect(defaultEntry.displayName).toBe(config[0].displayName)
+        expect(defaultEntry.url).toBe(config[0].url)
+        expect(defaultEntry.ledgerID).toBe(config[0].ledgerID)
+        expect(defaultEntry.sourcifySetup.activate).toBe(config[0].sourcifySetup.activate)
+        expect(defaultEntry.sourcifySetup.repoURL).toBe(config[0].sourcifySetup.repoURL)
+        expect(defaultEntry.sourcifySetup.serverURL).toBe(config[0].sourcifySetup.serverURL)
+        expect(defaultEntry.sourcifySetup.verifierURL).toBe(config[0].sourcifySetup.verifierURL)
+        expect(defaultEntry.sourcifySetup.chainID).toBe(config[0].sourcifySetup.chainID)
+
+        mock.restore()
+    });
+
+    it("Should truncate and capitalize network displayName", async () => {
+
+        const config = [
+            {
+                "name": "customnet",
+                "displayName": "A WayTooLongNetworkDisplayName",
+                "url": "",
+                "ledgerID": "FF"
+            }
+        ]
+
+        const mock = new MockAdapter(axios);
+        const configUrl = NetworkRegistry.NETWORKS_CONFIG_URL
+        mock.onGet(configUrl).reply(200, config)
+
+        networkRegistry.readCustomConfig()
+        await flushPromises()
+        expect(networkRegistry.entries.value.length).toBe(config.length)
+        const defaultEntry = networkRegistry.getDefaultEntry()
+        expect(defaultEntry.name).toBe(config[0].name)
+        expect(defaultEntry.displayName).toBe("A WAYTOOLONGNET…")
+
+        mock.restore()
+    });
+
+    it("Should deactivate SC verif when activate = false in networks-config.json", async () => {
+
+        const config = [
+            {
+                "name": "mainnet",
+                "displayName": "MAINNET",
+                "url": "https://mainnet-public.mirrornode.hedera.com/",
+                "ledgerID": "00",
+                "sourcifySetup": {
+                    "activate": false,
+                    "repoURL": "http://localhost:10000/contracts/",
+                    "serverURL": "http://localhost:5002/",
+                    "verifierURL": "http://localhost:3000/#/",
+                    "chainID": 295
+                }
+            }
+        ]
+        const mock = new MockAdapter(axios);
+        const configUrl = NetworkRegistry.NETWORKS_CONFIG_URL
+        mock.onGet(configUrl).reply(200, config)
+
+        networkRegistry.readCustomConfig()
+        await flushPromises()
+        expect(networkRegistry.entries.value.length).toBe(config.length)
+        const defaultEntry = networkRegistry.getDefaultEntry()
+        expect(defaultEntry.name).toBe(config[0].name)
+        expect(defaultEntry.sourcifySetup.activate).toBe(false)
+
+        mock.restore()
+    });
+
+    it("Should deactivate SC verif when sourcifySetup null in networks-config.json", async () => {
+
+        const config = [
+            {
+                "name": "mainnet",
+                "displayName": "MAINNET",
+                "url": "https://mainnet-public.mirrornode.hedera.com/",
+                "ledgerID": "00",
+                "sourcifySetup": null
+            }
+        ]
+        const mock = new MockAdapter(axios);
+        const configUrl = NetworkRegistry.NETWORKS_CONFIG_URL
+        mock.onGet(configUrl).reply(200, config)
+
+        networkRegistry.readCustomConfig()
+        await flushPromises()
+        expect(networkRegistry.entries.value.length).toBe(config.length)
+        const defaultEntry = networkRegistry.getDefaultEntry()
+        expect(defaultEntry.name).toBe(config[0].name)
+        expect(defaultEntry.sourcifySetup).toBe(null)
+
+        mock.restore()
+    });
+
+    it("Should deactivate SC verif when sourcifySetup undefined in networks-config.json", async () => {
+
+        const config =  [
+            {
+                "name": "mainnet",
+                "displayName": "MAINNET",
+                "url": "https://mainnet-public.mirrornode.hedera.com/",
+                "ledgerID": "00"
+            }
+        ]
+        const mock = new MockAdapter(axios);
+        const configUrl = NetworkRegistry.NETWORKS_CONFIG_URL
+        mock.onGet(configUrl).reply(200, config)
+
+        networkRegistry.readCustomConfig()
+        await flushPromises()
+        expect(networkRegistry.entries.value.length).toBe(config.length)
+        const defaultEntry = networkRegistry.getDefaultEntry()
+        expect(defaultEntry.name).toBe(config[0].name)
+        expect(defaultEntry.sourcifySetup).toBe(null)
+
+        mock.restore()
+    });
+
+});
+
+
+
+
+
+
+


### PR DESCRIPTION
**Description**:

- Remove the `VITE_APP_ENABLE_VERIFICATION_UI_PHASE2` environment variable
- Update the processing of the `networks-config.`json file such that (for each configured network) the SC verification may be disabled in either of the following cases:
  - `sourcifySetup` property is omitted from the configuration (this ensures compatibility with `networks-config.json` used before the introduction of SC verification)
  - `sourcifySetup = null`
  - `sourcifySetup.activate = false`

**Related issue(s)**:

Fixes #769

**Notes for reviewer**:

In the static networks configuration, we leave the `activate` flag to true with empty verification URLs. The static activation is currently needed by unit tests. In an ideal world, since the static config is the fallback in case a custom `networks-config.json` file fails to be read/decoded, we would want `activate = false`.
