### PR TITLE
00450 Supporting both EIP3091 and human URLs 

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -66,6 +66,10 @@ const routes: Array<RouteRecordRaw> = [
     component: PageNotFound
   },
   {
+    path: '/:network',
+    redirect: { name: 'MainDashboard' }
+  },
+  {
     path: '/:network/dashboard',
     name: 'MainDashboard',
     component: MainDashboard,

--- a/tests/e2e/specs/HomePage.cy.ts
+++ b/tests/e2e/specs/HomePage.cy.ts
@@ -31,6 +31,13 @@ describe('Hedera Explorer home page', () => {
     cy.contains('Smart Contract Calls')
     cy.contains('HCS Messages')
   })
+  it('Visits the /network URL', () => {
+    cy.visit('/' + defaultNetwork)
+    cy.url().should('include', '/' + defaultNetwork + '/dashboard')
+    cy.contains('Crypto Transfers')
+    cy.contains('Smart Contract Calls')
+    cy.contains('HCS Messages')
+  })
   it('Visits an old hash-based URL', () => {
     cy.visit('/#/testnet/token/0.0.48789573')
     cy.url().should('include', '/' + defaultNetwork + '/dashboard')


### PR DESCRIPTION
**Description**:

Changes below enable the following redirection:
`<explorer_url>/mainnet `=> `<explorer_url>/mainnet/dashboard`
`<explorer_url>/testnet` => `<explorer_url>/testnet/dashboard`
`<explorer_url>/previewnet` => `<explorer_url>/previewnet/dashboard`

They also add a new e2e test case to assert this behavior.


**Related issue(s)**:

Fixes #450

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
