### PR TITLE
00694 display both raw and b64-decoded values of memo when relevant

### DIFF
--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -37,11 +37,13 @@
       <span id="blob-main">
         {{ (b64EncodingFound && showBase64AsExtra) ? blobValue : decodedValue }}
       </span>
-      <div v-if="b64EncodingFound && showBase64AsExtra"  id="blob-extra" class="h-is-extra-text h-is-text-size-3 mt-1">
+      <div v-if="b64EncodingFound && showBase64AsExtra" class="h-is-extra-text h-is-text-size-3 mt-1">
         <span class="has-text-grey">
           Base64:
         </span>
-        {{decodedValue }}
+        <span id="blob-extra">
+          {{decodedValue }}
+        </span>
       </div>
     </div>
   </template>

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -33,7 +33,17 @@
          :style="{'max-width': windowWidth-limitingFactor + 'px'}">{{ decodedValue }}</div>
     <div v-else-if="limitingFactor" class="h-is-one-line is-inline-block"
          :style="{'max-width': windowWidth-limitingFactor+200 + 'px'}">{{ decodedValue }}</div>
-    <div v-else style="word-break: break-word">{{ decodedValue }}</div>
+    <div v-else style="word-break: break-word">
+      <span id="blob-main">
+        {{ (b64EncodingFound && showBase64AsExtra) ? blobValue : decodedValue }}
+      </span>
+      <div v-if="b64EncodingFound && showBase64AsExtra"  id="blob-extra" class="h-is-extra-text h-is-text-size-3 mt-1">
+        <span class="has-text-grey">
+          Base64:
+        </span>
+        {{decodedValue }}
+      </div>
+    </div>
   </template>
   <span v-else-if="showNone && !initialLoading" class="has-text-grey">None</span>
   <span v-else/>
@@ -61,6 +71,10 @@ export default defineComponent({
       default: false
     },
     base64: {
+      type: Boolean,
+      default: false
+    },
+    showBase64AsExtra: {
       type: Boolean,
       default: false
     },
@@ -114,15 +128,19 @@ export default defineComponent({
       return result
     })
 
+    const b64EncodingFound = ref(false)
+
     const decodedValue = computed(() => {
 
       const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-
       let result: string
+      b64EncodingFound.value = false
+
       if (props.blobValue) {
         if (props.base64 && base64regex.test(props.blobValue)) {
           try {
             result = Buffer.from(props.blobValue, 'base64').toString()
+            b64EncodingFound.value = true
           } catch {
             result = props.blobValue
           }
@@ -149,6 +167,7 @@ export default defineComponent({
       windowWidth,
       isURL,
       jsonValue,
+      b64EncodingFound,
       decodedValue,
       initialLoading,
       ipfsAddress,

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -164,7 +164,7 @@
         <Property id="memo">
           <template v-slot:name>Memo</template>
           <template v-slot:value>
-            <BlobValue v-bind:base64="true" v-bind:blob-value="account?.memo" v-bind:show-none="true"/>
+            <BlobValue v-bind:base64="true" v-bind:blob-value="account?.memo" v-bind:show-none="true" :show-base64-as-extra="true"/>
           </template>
         </Property>
 

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -92,7 +92,7 @@
             <Property id="memo">
               <template v-slot:name>Memo</template>
               <template v-slot:value>
-                <BlobValue :blob-value="contract?.memo" :show-none="true" :base64="true"/>
+                <BlobValue :blob-value="contract?.memo" :show-none="true" :base64="true" :show-base64-as-extra="true"/>
               </template>
             </Property>
             <Property id="createTransaction">

--- a/tests/unit/values/BlobValue.spec.ts
+++ b/tests/unit/values/BlobValue.spec.ts
@@ -130,8 +130,61 @@ describe("BlobValue.vue", () => {
 
         await flushPromises()
 
-        expect(wrapper.text()).toBe(BLOB_PLAIN_TEXT)
-        expect(btoa(wrapper.text())).toBe(BLOB_BASE64)
+        const blobMain = wrapper.get("#blob-main").text()
+        expect(blobMain).toBe(BLOB_PLAIN_TEXT)
+        expect(btoa(blobMain)).toBe(BLOB_BASE64)
+
+        expect(wrapper.find("#blob-extra").exists()).toBe(false)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    it("should display raw value and base64-decoded value as extra", async () => {
+
+        const wrapper = mount(BlobValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                blobValue: BLOB_BASE64,
+                base64: true,
+                showBase64AsExtra: true
+            },
+        });
+
+        await flushPromises()
+
+        const blobMain = wrapper.get("#blob-main").text()
+        expect(blobMain).toBe(BLOB_BASE64)
+
+        const blobExtra = wrapper.get("#blob-extra").text()
+        expect(blobExtra).toBe(BLOB_PLAIN_TEXT)
+        expect(btoa(blobExtra)).toBe(BLOB_BASE64)
+
+        wrapper.unmount()
+        await flushPromises()
+    })
+
+    it("should display the (unencoded) blob value and ignore the showBase64AsExtra prop", async () => {
+
+        const wrapper = mount(BlobValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                blobValue: BLOB_PLAIN_TEXT,
+                base64: true,
+                showBase64AsExtra: true
+            },
+        });
+
+        await flushPromises()
+
+        const blobMain = wrapper.get("#blob-main").text()
+        expect(blobMain).toBe(BLOB_PLAIN_TEXT)
+
+        expect(wrapper.find("#blob-extra").exists()).toBe(false)
 
         wrapper.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

In AccountDetails and ContractDetails views, when we find that the memo  is candidate to Base64 decoding, we now show both the raw value and the decoded value. So if the value is, in fact, not encoded, it is still legible.

This happens only in case the value has not been interpreted (as a URL, an IPFS hash...) since that would mean we were indeed not confused about the encoding.

**Related issue(s)**:

Fixes #694 

**Notes for reviewer**:

Visible on staging server.
Examples:
 - actual B64 encoding <img width="928" alt="Screenshot 2023-11-28 at 12 42 37" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/59c28a89-ae1c-4a80-a5c9-b8fdff6f1eef">
 - not a B64 encoding <img width="928" alt="Screenshot 2023-11-28 at 12 44 00" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/4abb682d-13aa-4ac3-bfd3-a169cd30400f">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
