### PR TITLE
00778 replace copy action by a navigation link

### DIFF
--- a/src/components/Copyable.vue
+++ b/src/components/Copyable.vue
@@ -54,10 +54,12 @@ export default defineComponent({
       default: true
     },
   },
-  setup(props) {
+  emits: ['copyMade'],
+  setup(props, context) {
     const copyToClipboard = (): void => {
       if (props.contentToCopy?.length) {
         navigator.clipboard.writeText(props.contentToCopy)
+          context.emit('copyMade')
       }
     }
     return {

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -148,7 +148,7 @@
         <WalletInfo 
           :connected="connected" 
           :accountIds="accountIds"
-          :showWalletInfo="showWalletInfo" 
+          v-model:show-wallet-info="showWalletInfo"
           :accountId="accountId || undefined" 
           :walletIconURL="walletIconURL || undefined" 
           @wallet-disconnect="disconnectFromWallet"

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -336,13 +336,13 @@ export default defineComponent({
         position:relative;
         display:grid;
         column-gap:1.2rem;
-        grid-template-columns:repeat(20, minmax(0, 25px));
+        grid-template-columns:repeat(17, minmax(0, 35px));
     }
     #search-bar {
-        grid-column: span 12;
+        grid-column: span 10;
     }
     #drop-down-menu {
-        grid-column: span 4;
+        grid-column: span 3;
     }
     #connect-button {
         grid-column: span 4;
@@ -357,13 +357,13 @@ export default defineComponent({
         position:relative;
         display:grid;
         column-gap:1.2rem;
-        grid-template-columns:repeat(20, minmax(0, 18px));
+        grid-template-columns:repeat(18, minmax(0, 24px));
     }
     #search-bar {
-        grid-column: span 10;
+        grid-column: span 9;
     }
     #drop-down-menu {
-        grid-column: span 5;
+        grid-column: span 4;
     }
     #connect-button {
         grid-column: span 5;

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -126,19 +126,21 @@
             {{ connecting ? "Connecting..." : "CONNECT WALLET..." }}
           </button>
 
-          <div v-else @click="showWalletInfo = !showWalletInfo" id="walletInfoBanner" class="is-flex is-align-items-center" style="outline: none; height: 40px; width: 100%; font-size: 0.9rem; border: 0.5px solid white; display: flex; justify-content: space-between; cursor: pointer;">
-            <figure style="width: 50px; height: 100%; display: flex; align-items: center; margin-left: 0.15rem;">
-                <img :src="walletIconURL ?? undefined" alt="wallet logo" style="object-fit: contain; aspect-ratio: 3/2;display: flex; height: 90%;">
-            </figure>
+          <div v-else @click="showWalletInfo = !showWalletInfo" id="walletInfoBanner"
+                 class="is-flex is-align-items-center is-justify-content-space-between"
+                 style="outline: none; height: 40px; width: 100%; font-size: 0.9rem; border: 0.5px solid white; cursor: pointer;">
 
-            <p>
-              {{ accountId }}
-            </p>
-
-            <div class="is-flex is-align-items-center" style="width: 30px; justify-content: center;">
-              <i v-if="!showWalletInfo" class="fas fa-solid fa-angle-down is-flex is-align-items-center"/>
-              <i v-else class="fas fa-solid fa-angle-up is-flex is-align-items-center"/>
-            </div>
+              <div class="is-flex is-align-items-center is-justify-content-flex-start">
+                  <figure class="is-flex is-align-items-center mx-1" style="height: 40px;" >
+                      <img :src="walletIconURL ?? undefined" alt="wallet logo"
+                           style="object-fit: contain; aspect-ratio: 3/2; height: 60%;">
+                  </figure>
+                  {{ accountId }}
+              </div>
+              <div class="is-flex is-align-items-center is-justify-content-center" style="width: 30px;">
+                  <i v-if="!showWalletInfo" class="fas fa-solid fa-angle-down is-flex is-align-items-center"/>
+                  <i v-else class="fas fa-solid fa-angle-up is-flex is-align-items-center"/>
+              </div>
 
           </div>
         </div>

--- a/src/components/wallet/WalletInfo.vue
+++ b/src/components/wallet/WalletInfo.vue
@@ -33,7 +33,7 @@
             </figure>
 
             <!-- accountID-checksum -->
-            <div class="is-flex is-align-items-baseline ml-3" style="font-size: 1.35rem;">
+            <div @click="hideWalletInfo" class="is-flex is-align-items-baseline ml-3" style="font-size: 1.35rem;">
                 <AccountLink :account-id="accountId"/>
                 <span class="has-text-grey h-is-smaller">
                     -{{ accountChecksum }}
@@ -45,7 +45,7 @@
           <div class="p-2" style="border: 0.5px solid white;">
             <p class="has-text-grey h-is-smaller">EVM ADDRESS</p>
 
-            <Copyable :content-to-copy="accountEthereumAddress ?? ''">
+            <Copyable @copy-made="hideWalletInfo" :content-to-copy="accountEthereumAddress ?? ''">
               <template v-slot:content>
                 <div class="is-flex is-align-items-center" style="gap: 0.5rem">
                   <p v-if="accountEthereumAddress">
@@ -136,7 +136,7 @@ export default defineComponent({
             default: undefined,
         },
     },
-    emit: ['walletDisconnect', 'changeAccount'],
+    emit: ['walletDisconnect', 'changeAccount', 'update:showWalletInfo'],
     
     setup(props, ctx) {
         const isSmallScreen = inject('isSmallScreen', true)
@@ -185,6 +185,7 @@ export default defineComponent({
         const changeAccount = (accountId: string) => {
           ctx.emit('changeAccount', accountId)
           showAccountIdsModal.value = false;
+          hideWalletInfo()
         }
 
         // 
@@ -193,6 +194,10 @@ export default defineComponent({
         const disconnectFromWallet = () => {
           ctx.emit('walletDisconnect', true)
           showAccountIdsModal.value = false;
+        }
+
+        const hideWalletInfo = () => {
+            ctx.emit('update:showWalletInfo', false)
         }
 
         return {
@@ -205,6 +210,7 @@ export default defineComponent({
             chosenAccountId,
             showAccountIdsModal,
             disconnectFromWallet,
+            hideWalletInfo,
             accountEthereumAddress,
             tbarBalance: balanceAnalyzer.hbarBalance,
             accountChecksum: accountLocParser.accountChecksum,

--- a/src/components/wallet/WalletInfo.vue
+++ b/src/components/wallet/WalletInfo.vue
@@ -24,29 +24,25 @@
 
 <template>
     <div v-if="connected && showWalletInfo" :class="{'box': !isTouchDevice && isSmallScreen, 'h-box-border': !isTouchDevice && isSmallScreen}" 
-                style="position: absolute; display: flex; flex-direction: column; gap: 1rem; width: 380px; top: 45px; right: 0; z-index: 10; border: 1px solid white; padding: 16px 12px;">
+                style="position: absolute; display: flex; flex-direction: column; gap: 1rem; width: 380px; top: 45px; right: 0; z-index: 10; border: 0.5px solid white; padding: 16px 12px;">
           <!-- header -->
-          <div style="display: flex; gap: 1rem">
+          <div class="is-flex is-align-items-center">
             <!-- logo icon -->
-            <figure style="width: 50px; height: 50px; display: flex; align-items: center;">
-                <img :src="walletIconURL ?? undefined" alt="wallet logo" style="object-fit: contain; aspect-ratio: 3/2;display: flex; height: 90%;">
+            <figure class="is-flex is-align-items-center" style="width: 50px; height: 50px;">
+                <img :src="walletIconURL ?? undefined" alt="wallet logo" style="object-fit: contain; aspect-ratio: 3/2; height: 90%;">
             </figure>
 
             <!-- accountID-checksum -->
-            <div class="is-flex is-align-items-center">
-              <Copyable :content-to-copy="accountId ?? ''">
-                <template v-slot:content>
-                  <p style="font-size: 1.35rem;">
-                      <span class="is-numeric">{{ accountId }}</span>
-                  </p>
-                </template>
-              </Copyable>
-              <span class="has-text-grey h-is-smaller">-{{ accountChecksum }}</span>
+            <div class="is-flex is-align-items-baseline ml-3" style="font-size: 1.35rem;">
+                <AccountLink :account-id="accountId"/>
+                <span class="has-text-grey h-is-smaller">
+                    -{{ accountChecksum }}
+                </span>
             </div>
           </div>
 
           <!-- EVM address -->
-          <div class="p-2" style="border: 1px solid white;">
+          <div class="p-2" style="border: 0.5px solid white;">
             <p class="has-text-grey h-is-smaller">EVM ADDRESS</p>
 
             <Copyable :content-to-copy="accountEthereumAddress ?? ''">
@@ -63,7 +59,7 @@
           </div>
 
           <!-- balance -->
-          <div class="p-2" style="border: 1px solid white;">
+          <div class="p-2" style="border: 0.5px solid white;">
             <p class="has-text-grey h-is-smaller">BALANCE</p>
             <p class="has-text-white" style="font-size: 1.2rem">{{ formattedAmount }} ℏ</p>
 
@@ -111,12 +107,13 @@ import HbarExtra from "@/components/values/HbarExtra.vue";
 import { AccountLocParser } from '@/utils/parser/AccountLocParser';
 import { BalanceAnalyzer } from '@/utils/analyzer/BalanceAnalyzer';
 import { computed, defineComponent, inject, onBeforeUnmount, onMounted, ref } from 'vue';
+import AccountLink from "@/components/values/AccountLink.vue";
 
 
 
 export default defineComponent({
     name: "WalletInfo",
-    components: {HbarExtra, Copyable},
+    components: {AccountLink, HbarExtra, Copyable},
     props: {
         connected: {
             type: Boolean,
@@ -223,7 +220,7 @@ export default defineComponent({
 
 <style>
   .is-hover:hover {
-    color: gray;
+    color: grey;
   }
 </style>
 


### PR DESCRIPTION
**Description**:

 - Replace the Copyable Account ID in WalletInfo by a navigation link to the AccountDetails view (AccountLink)
 - Also dismiss the WalletInfo dialog when the user takes one of the available actions:
   - Navigate to one's account
   - Copy EVM Address
   - Switch accounts
 - Bring minor visual adjustments 

In an ideal world, we would dismiss the dialog when the user clicks anywhere outside. This is not covered with this PR.

**Related issue(s)**:

Fixes #778

**Notes for reviewer**:

Deployed on staging server.
