### PR TITLE
fix: 00786 ContractVerificationDialog.dialogTitle must be a computed value.

### DIFF
--- a/src/components/verification/ContractVerificationDialog.vue
+++ b/src/components/verification/ContractVerificationDialog.vue
@@ -180,7 +180,7 @@ export default defineComponent({
     emits: ["update:showDialog", "verifyDidComplete"],
     setup(props, context) {
 
-        const dialogTitle = `Verify contract ${props.contractId}`
+        const dialogTitle = computed(() => `Verify contract ${props.contractId}`)
 
         // File Chooser
         const fileChooser = ref<HTMLInputElement | null>(null)


### PR DESCRIPTION
**Description**:

Changes below fix `Contract Verification` dialog : `dialogTitle` must be a computed value.

**Related issue(s)**:

Fixes #786 

**Notes for reviewer**:

See instructions to reproduce and verify from #786

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
