### PR TITLE
feat: contract URL should accept both contract id and evm address (#432)

### DIFF
--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -81,6 +81,10 @@ export class PathParam { // Block Hash or Number
         return result
     }
 
+    public static parseContractLoc(l: string): EntityID|EthereumAddress|null {
+        return EntityID.parse(l) ?? EthereumAddress.parse(l)
+    }
+
     public static parseNodeId(s: string|undefined): number|null {
         let result: number|null
 

--- a/src/utils/parser/ContractLocParser.ts
+++ b/src/utils/parser/ContractLocParser.ts
@@ -1,0 +1,131 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, ComputedRef, Ref, ref, watch, WatchStopHandle} from "vue";
+import {ContractResponse} from "@/schemas/HederaSchemas";
+import {EntityID} from "@/utils/EntityID";
+import {EthereumAddress} from "@/utils/EthereumAddress";
+import {PathParam} from "@/utils/PathParam";
+import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
+import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
+
+export class ContractLocParser {
+
+    public readonly contractLoc: Ref<string|null>
+    public readonly contractResponse: Ref<ContractResponse|null> = ref(null)
+
+    private watchHandle: Ref<WatchStopHandle|null> = ref(null)
+    private readonly loadCounter: Ref<number> = ref(0)
+
+    //
+    // Public
+    //
+
+    public constructor(contractLoc: Ref<string|null>) {
+        this.contractLoc = contractLoc
+    }
+
+    public mount(): void {
+        this.watchHandle.value = watch(this.contractLocObj, this.contractLocObjDidChange, { immediate: true})
+    }
+
+    public unmount(): void {
+        if (this.watchHandle.value !== null) {
+            this.watchHandle.value()
+            this.watchHandle.value = null
+        }
+        this.contractResponse.value = null
+        this.loadCounter.value = 0
+    }
+
+    public readonly contractId: ComputedRef<string|null>
+        = computed(() => this.contractResponse.value?.contract_id ?? null)
+
+    public readonly ethereumAddress: ComputedRef<string|null>
+        = computed(() => this.contractResponse.value?.evm_address ?? null)
+
+    public readonly entity: ComputedRef<ContractResponse|null>
+        = computed(() => this.contractResponse.value ?? null)
+
+    public readonly errorNotification: Ref<string|null> = computed(() => {
+        let result: string|null
+        const l = this.contractLoc.value
+        const o = this.contractLocObj.value
+        const r = this.contractResponse.value
+        if (l !== null && this.watchHandle.value !== null) {
+            if (o !== null) {
+                if (r !== null) {
+                    if (r.deleted) {
+                        result = "Contract is deleted"
+                    } else {
+                        result = null
+                    }
+                } else if (this.loadCounter.value >= 1) {
+                    if (o instanceof EntityID) {
+                        result = "Contract with ID " + o + " was not found"
+                    } else { // o instanceof Ethereum address
+                        result = "Contract with address " + o + " was not found"
+                    }
+                } else { // this.loadCounter.value === 0 => not loaded yet
+                    result = null
+                }
+            } else {
+                result = "Invalid contract ID or address: " + l
+            }
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    //
+    // Private
+    //
+
+    private readonly contractLocObjDidChange = async () => {
+        const l = this.contractLocObj.value
+        if (l !== null && this.watchHandle.value !== null) {
+            try {
+                if (l instanceof EntityID) {
+                    this.contractResponse.value = await ContractByIdCache.instance.lookup(l.toString())
+                } else {
+                    this.contractResponse.value = await ContractByAddressCache.instance.lookup(l.toString())
+                }
+            } catch(error) {
+                this.contractResponse.value = null
+            } finally {
+                this.loadCounter.value += 1
+            }
+        } else {
+            this.contractResponse.value = null
+        }
+    }
+
+    private readonly contractLocObj = computed(() => {
+        let result: EntityID|EthereumAddress|null
+        if (this.contractLoc.value !== null && this.watchHandle.value !== null) {
+            result = PathParam.parseContractLoc(this.contractLoc.value)
+        } else {
+            result = null
+        }
+        return result
+    })
+
+}

--- a/tests/e2e/specs/ContractNavigation.cy.ts
+++ b/tests/e2e/specs/ContractNavigation.cy.ts
@@ -59,6 +59,22 @@ describe('Contract Navigation', () => {
         cy.url().should('include', '/mainnet/contract/' + contractId)
     })
 
+    it ('should display contract details using contract ID', () => {
+        const contractId = "0.0.1186129"
+        cy.visit('mainnet/contract/' + contractId)
+        cy.url().should('include', '/mainnet/contract/' + contractId)
+        cy.contains('Contract ID:' + contractId)
+    })
+
+    it ('should display contract details using contract evm address', () => {
+        const contractId = "0.0.1186129"
+        const evmAddress = "0x0000000000000000000000000000000000121951"
+
+        cy.visit('mainnet/contract/' + evmAddress)
+        cy.url().should('include', '/mainnet/contract/' + evmAddress)
+        cy.contains('Contract ID:' + contractId)
+    })
+
     it('should detect navigation to unknown contract ID', () => {
         const unknownID = '9.9.9'
         cy.visit('testnet/contract/' + unknownID)

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2428,7 +2428,7 @@ export const SAMPLE_CONTRACT_DUDE = {
     "contract_id": "0.0.803295",
     "created_timestamp": "1648377044.798291252",
     "deleted": false,
-    "evm_address": "0x00000000000000000000000000000000000c41df",
+    "evm_address": "0x00000000000000000000000000000000000b70cf",
     "expiration_timestamp": "1649648001.410978000",
     "file_id": "0.0.803267",
     "memo": "",
@@ -2482,7 +2482,203 @@ export const SAMPLE_CONTRACTS = {
 }
 
 export const SAMPLE_CONTRACT_AS_ACCOUNT = {
-    "account": "0.0.200611",
+    "account": "0.0.749775",
+    "alias": "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ",
+    "auto_renew_period": 7890000,
+    "balance": {
+        "balance": 200000000,
+        "timestamp": "1646734500.576308000",
+        "tokens": []
+    },
+    "deleted": false,
+    "expiry_timestamp": null,
+    "evm_address": "0x00000000000000000000000000000000000b70cf",
+    "key": {
+        "_type": "ED25519",
+        "key": "f6628ec23113678f60cb6e7e3972ac0bfdec0c43c787c25fd626a05627700ba5"
+    },
+    "max_automatic_token_associations": null,
+    "memo": "",
+    "receiver_sig_required": null,
+    "transactions": [
+        {
+            "bytes": null,
+            "charged_tx_fee": 75871170,
+            "consensus_timestamp": "1645373467.889797098",
+            "entity_id": "0.0.200611",
+            "max_fee": "200000000",
+            "memo_base64": "c21hcnRDb250cmFjdEZ1bmN0aW9uRXhlY3V0ZTo6LXRyYW5zZmVyQW1vdW50LTo6VGFza2Jhcjo6U21hcnQgY29udHJhY3Qgc3RhdGUgY2hhbmdlIGNhbGwu",
+            "name": "CONTRACTCALL",
+            "node": "0.0.8",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "N174IhVVDxEtHG9iE3RKGhLgzWnKrTnPDolPjDVNLOldF3lU6IQdUVmM3zp8coQy",
+            "transaction_id": "0.0.178899-1645373457-761328453",
+            "transfers": [
+                {
+                    "account": "0.0.8",
+                    "amount": 891611
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 74979559
+                },
+                {
+                    "account": "0.0.178899",
+                    "amount": -75871170
+                },
+                {
+                    "account": "0.0.200611",
+                    "amount": -100000000
+                },
+                {
+                    "account": "0.0.689670",
+                    "amount": 100000000
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1645373457.761328453"
+        },
+        {
+            "bytes": null,
+            "charged_tx_fee": 18787079,
+            "consensus_timestamp": "1645373400.586655580",
+            "entity_id": "0.0.200611",
+            "max_fee": "200000000",
+            "memo_base64": "c21hcnRDb250cmFjdEZ1bmN0aW9uRXhlY3V0ZTo6LWFkZEhiYXJzLTo6VGFza2Jhcjo6IEFkZGluZyBhbW91bnQgdG8gdGFzayBzbWFydC1jb250cmFjdA==",
+            "name": "CONTRACTCALL",
+            "node": "0.0.5",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "H9P5awEyK5ApqNxwMVwQBUzshRJfIwWPVj/QPl5qL3qrqTTSzPIHqI/+A202qhpg",
+            "transaction_id": "0.0.178899-1645373391-947654307",
+            "transfers": [
+                {
+                    "account": "0.0.5", "amount": 885182
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 17901897
+                },
+                {
+                    "account": "0.0.178899",
+                    "amount": -118787079
+                },
+                {
+                    "account": "0.0.200611",
+                    "amount": 100000000
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1645373391.947654307"
+        }
+    ],
+}
+
+export const SAMPLE_CONTRACT_DUDE_AS_ACCOUNT = {
+    "account": "0.0.803295",
+    "alias": "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ",
+    "auto_renew_period": 7890000,
+    "balance": {
+        "balance": 200000000,
+        "timestamp": "1646734500.576308000",
+        "tokens": []
+    },
+    "deleted": false,
+    "expiry_timestamp": null,
+    "evm_address": "0x00000000000000000000000000000000000b70cf",
+    "key": {
+        "_type": "ED25519",
+        "key": "f6628ec23113678f60cb6e7e3972ac0bfdec0c43c787c25fd626a05627700ba5"
+    },
+    "max_automatic_token_associations": null,
+    "memo": "",
+    "receiver_sig_required": null,
+    "transactions": [
+        {
+            "bytes": null,
+            "charged_tx_fee": 75871170,
+            "consensus_timestamp": "1645373467.889797098",
+            "entity_id": "0.0.200611",
+            "max_fee": "200000000",
+            "memo_base64": "c21hcnRDb250cmFjdEZ1bmN0aW9uRXhlY3V0ZTo6LXRyYW5zZmVyQW1vdW50LTo6VGFza2Jhcjo6U21hcnQgY29udHJhY3Qgc3RhdGUgY2hhbmdlIGNhbGwu",
+            "name": "CONTRACTCALL",
+            "node": "0.0.8",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "N174IhVVDxEtHG9iE3RKGhLgzWnKrTnPDolPjDVNLOldF3lU6IQdUVmM3zp8coQy",
+            "transaction_id": "0.0.178899-1645373457-761328453",
+            "transfers": [
+                {
+                    "account": "0.0.8",
+                    "amount": 891611
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 74979559
+                },
+                {
+                    "account": "0.0.178899",
+                    "amount": -75871170
+                },
+                {
+                    "account": "0.0.200611",
+                    "amount": -100000000
+                },
+                {
+                    "account": "0.0.689670",
+                    "amount": 100000000
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1645373457.761328453"
+        },
+        {
+            "bytes": null,
+            "charged_tx_fee": 18787079,
+            "consensus_timestamp": "1645373400.586655580",
+            "entity_id": "0.0.200611",
+            "max_fee": "200000000",
+            "memo_base64": "c21hcnRDb250cmFjdEZ1bmN0aW9uRXhlY3V0ZTo6LWFkZEhiYXJzLTo6VGFza2Jhcjo6IEFkZGluZyBhbW91bnQgdG8gdGFzayBzbWFydC1jb250cmFjdA==",
+            "name": "CONTRACTCALL",
+            "node": "0.0.5",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "transaction_hash": "H9P5awEyK5ApqNxwMVwQBUzshRJfIwWPVj/QPl5qL3qrqTTSzPIHqI/+A202qhpg",
+            "transaction_id": "0.0.178899-1645373391-947654307",
+            "transfers": [
+                {
+                    "account": "0.0.5", "amount": 885182
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 17901897
+                },
+                {
+                    "account": "0.0.178899",
+                    "amount": -118787079
+                },
+                {
+                    "account": "0.0.200611",
+                    "amount": 100000000
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1645373391.947654307"
+        }
+    ],
+}
+
+export const SAMPLE_CONTRACT_DELETED_AS_ACCOUNT = {
+    "account": "0.0.803295",
     "alias": "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ",
     "auto_renew_period": 7890000,
     "balance": {

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -26,7 +28,9 @@ import {
     SAMPLE_CONTRACT,
     SAMPLE_CONTRACT_AS_ACCOUNT,
     SAMPLE_CONTRACT_DELETED,
+    SAMPLE_CONTRACT_DELETED_AS_ACCOUNT,
     SAMPLE_CONTRACT_DUDE,
+    SAMPLE_CONTRACT_DUDE_AS_ACCOUNT,
     SAMPLE_CONTRACT_RESULTS,
     SAMPLE_NETWORK_EXCHANGERATE,
     SAMPLE_TRANSACTION,
@@ -51,7 +55,7 @@ HMSF.forceUTC = true
 
 describe("ContractDetails.vue", () => {
 
-    it("Should display contract details", async () => {
+    it("Should display contract details (using contract id)", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -78,6 +82,71 @@ describe("ContractDetails.vue", () => {
             },
             props: {
                 contractId: SAMPLE_CONTRACT.contract_id
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(wrapper.text()).toMatch(RegExp("^Contract Contract ID:" + SAMPLE_CONTRACT.contract_id))
+        expect(wrapper.get("#balanceValue").text()).toBe("2.00000000$0.49207")
+        expect(wrapper.get("#keyValue").text()).toBe("4210 5082 0e14 85ac dd59 7260 88e0 e4a2 130e bbbb 7000 9f64 0ad9 5c78 dd5a 7b38CopyED25519")
+        expect(wrapper.get("#memoValue").text()).toBe("Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract")
+        expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
+        expect(wrapper.get("#expiresAtValue").text()).toBe("None")
+        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("90 days")
+        expect(wrapper.get("#autoRenewAccountValue").text()).toBe("0.0.730632")
+        expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("0")
+        expect(wrapper.get("#obtainerValue").text()).toBe("None")
+        expect(wrapper.get("#proxyAccountValue").text()).toBe("None")
+        expect(wrapper.get("#validFromValue").text()).toBe("3:09:15.9474 PMMar 7, 2022, UTC")
+        expect(wrapper.get("#validUntilValue").text()).toBe("None")
+        expect(wrapper.get("#nonceValue").text()).toBe("1")
+        expect(wrapper.get("#fileValue").text()).toBe("0.0.749773")
+        expect(wrapper.get("#evmAddress").text()).toBe("EVM Address:0x00000000000000000000000000000000000b70cfCopy")
+        expect(wrapper.get("#code").text()).toBe("Runtime Bytecode")
+        expect(wrapper.get("#solcVersion").text()).toBe("Compiler Version0.8.4")
+
+        // None of the elements related to contract verification should be present in this context
+        expect(wrapper.find('#verify-button').exists()).toBe(false)
+        expect(wrapper.find('#showSource').exists()).toBe(false)
+        expect(wrapper.find('#verificationStatus').exists()).toBe(false)
+        expect(wrapper.find('#contractName').exists()).toBe(false)
+
+        expect(wrapper.findComponent(ContractResultTable).exists()).toBe(true)
+
+        mock.restore()
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("Should display contract details (using evm address)", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios);
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        const matcher2 = "/api/v1/accounts/" + SAMPLE_CONTRACT.contract_id
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_AS_ACCOUNT);
+
+        const matcher3 = "/api/v1/transactions"
+        mock.onGet(matcher3).reply(200, SAMPLE_TRANSACTIONS);
+
+        const matcher4 = "/api/v1/network/exchangerate"
+        mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
+
+        const matcher5 = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results"
+        mock.onGet(matcher5).reply(200, SAMPLE_CONTRACT_RESULTS);
+
+        const wrapper = mount(ContractDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                contractId: SAMPLE_CONTRACT.evm_address
             },
         });
 
@@ -220,7 +289,7 @@ describe("ContractDetails.vue", () => {
         mock.onGet(matcher1).reply(200, contract2);
 
         matcher2 = "/api/v1/accounts/" + contract2.contract_id
-        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_AS_ACCOUNT);
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_DUDE_AS_ACCOUNT);
 
         matcher5 = "/api/v1/contracts/" + contract2.contract_id + "/results"
         mock.onGet(matcher5).reply(200, SAMPLE_CONTRACT_RESULTS);
@@ -299,7 +368,7 @@ describe("ContractDetails.vue", () => {
         mock.onGet(matcher1).reply(200, contract);
 
         const matcher2 = "/api/v1/accounts/" + contract.contract_id
-        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_AS_ACCOUNT);
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_DUDE_AS_ACCOUNT);
 
         const matcher3 = "/api/v1/transactions"
         mock.onGet(matcher3).reply(200, SAMPLE_TRANSACTIONS);
@@ -340,7 +409,7 @@ describe("ContractDetails.vue", () => {
         mock.onGet(matcher1).reply(200, contract);
 
         const matcher2 = "/api/v1/accounts/" + contract.contract_id
-        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_AS_ACCOUNT);
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_DELETED_AS_ACCOUNT);
 
         const matcher3 = "/api/v1/transactions"
         mock.onGet(matcher3).reply(200, SAMPLE_TRANSACTIONS);
@@ -388,7 +457,7 @@ describe("ContractDetails.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.get("#notificationBanner").text()).toBe("Invalid contract ID: " + invalidContractId)
+        expect(wrapper.get("#notificationBanner").text()).toBe("Invalid contract ID or address: " + invalidContractId)
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/utils/ContractLocParser.spec.ts
+++ b/tests/unit/utils/ContractLocParser.spec.ts
@@ -1,0 +1,428 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, test} from 'vitest'
+import {Ref, ref} from "vue";
+import {flushPromises} from "@vue/test-utils";
+import {SAMPLE_CONTRACT} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {ContractLocParser} from "@/utils/parser/ContractLocParser";
+
+describe("ContractLocParser.ts", () => {
+
+    //
+    // mount + set/unset contract loc + unmount
+    //
+
+    test("mount + set/unset contract loc + unmount", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        // 0) Creates parser
+        const contractLoc: Ref<string|null> = ref(null)
+        const parser = new ContractLocParser(contractLoc)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 1) Mounts parser
+        parser.mount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Sets with account id
+        contractLoc.value = SAMPLE_CONTRACT.contract_id
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.contractResponse.value).toStrictEqual(SAMPLE_CONTRACT)
+        expect(parser.contractId.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.ethereumAddress.value).toBe(SAMPLE_CONTRACT.evm_address)
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 3) Unsets
+        contractLoc.value = null
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 4) Unmounts parser
+        parser.unmount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        mock.restore()
+    })
+
+    //
+    // set contract loc + mount + unmount + unset contract loc
+    //
+
+    test("set contract loc + mount + unmount + unset account loc", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        // 0) Creates parser
+        const contractLoc: Ref<string|null> = ref(null)
+        const parser = new ContractLocParser(contractLoc)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Sets with contract id
+        contractLoc.value = SAMPLE_CONTRACT.contract_id
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Mounts parser
+        parser.mount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.contractResponse.value).toStrictEqual(SAMPLE_CONTRACT)
+        expect(parser.contractId.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.ethereumAddress.value).toBe(SAMPLE_CONTRACT.evm_address)
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 3) Unmounts parser
+        parser.unmount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // Unsets
+        contractLoc.value = null
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        mock.restore()
+    })
+
+    //
+    // set contract loc with contract address
+    //
+
+    test("set contract with contract address", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        // 0) Creates parser
+        const contractLoc: Ref<string|null> = ref(null)
+        const parser = new ContractLocParser(contractLoc)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 1) Mounts parser
+        parser.mount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Sets with account address
+        contractLoc.value = SAMPLE_CONTRACT.evm_address
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.evm_address)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(SAMPLE_CONTRACT.evm_address)
+        expect(parser.contractResponse.value).toStrictEqual(SAMPLE_CONTRACT)
+        expect(parser.contractId.value).toBe(SAMPLE_CONTRACT.contract_id)
+        expect(parser.ethereumAddress.value).toBe(SAMPLE_CONTRACT.evm_address)
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 3) Unsets
+        contractLoc.value = null
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 4) Unmounts parser
+        parser.unmount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        mock.restore()
+    })
+
+    //
+    // set account loc with unknown account id
+    //
+
+    test("set contract loc with unknown contract id", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const UNKNOWN_ACCOUNT_ID = "0.0.42"
+        const matcher1 = "/api/v1/contracts/" + UNKNOWN_ACCOUNT_ID
+        mock.onGet(matcher1).reply(404);
+
+        // 0) Creates parser
+        const contractLoc: Ref<string|null> = ref(null)
+        const parser = new ContractLocParser(contractLoc)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 1) Mounts parser
+        parser.mount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Sets with contract id
+        contractLoc.value = UNKNOWN_ACCOUNT_ID
+        expect(parser.contractLoc.value).toBe(UNKNOWN_ACCOUNT_ID)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(UNKNOWN_ACCOUNT_ID)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBe("Contract with ID " + UNKNOWN_ACCOUNT_ID + " was not found")
+
+        // 3) Unsets
+        contractLoc.value = null
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 4) Unmounts parser
+        parser.unmount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        mock.restore()
+    })
+
+    //
+    // set account loc with unknown contract address
+    //
+
+    test("set contract loc with unknown contract address", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const UNKNOWN_ACCOUNT_ADDRESS = "0x0001020304050607080900010203040506070809"
+        const matcher1 = "/api/v1/contracts/" + UNKNOWN_ACCOUNT_ADDRESS
+        mock.onGet(matcher1).reply(404);
+
+        // 0) Creates parser
+        const contractLoc: Ref<string|null> = ref(null)
+        const parser = new ContractLocParser(contractLoc)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 1) Mounts parser
+        parser.mount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Sets with contract id
+        contractLoc.value = UNKNOWN_ACCOUNT_ADDRESS
+        expect(parser.contractLoc.value).toBe(UNKNOWN_ACCOUNT_ADDRESS)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(UNKNOWN_ACCOUNT_ADDRESS)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBe("Contract with address " + UNKNOWN_ACCOUNT_ADDRESS + " was not found")
+
+        // 3) Unsets
+        contractLoc.value = null
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 4) Unmounts parser
+        parser.unmount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        mock.restore()
+    })
+
+
+    //
+    // set account loc with dummy value
+    //
+
+    test("set contract loc with dummy value", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const DUMMY_LOC = "dummy loc"
+        const matcher1 = "/api/v1/accounts/" + DUMMY_LOC
+        mock.onGet(matcher1).reply(404);
+
+
+        // 0) Creates parser
+        const contractLoc: Ref<string|null> = ref(null)
+        const parser = new ContractLocParser(contractLoc)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 1) Mounts parser
+        parser.mount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 2) Sets with contract id
+        contractLoc.value = DUMMY_LOC
+        expect(parser.contractLoc.value).toBe(DUMMY_LOC)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBe("Invalid contract ID or address: " + DUMMY_LOC)
+        await flushPromises()
+        expect(parser.contractLoc.value).toBe(DUMMY_LOC)
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBe("Invalid contract ID or address: " + DUMMY_LOC)
+
+        // 3) Unsets
+        contractLoc.value = null
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        // 4) Unmounts parser
+        parser.unmount()
+        await flushPromises()
+        expect(parser.contractLoc.value).toBeNull()
+        expect(parser.contractResponse.value).toBeNull()
+        expect(parser.contractId.value).toBeNull()
+        expect(parser.ethereumAddress.value).toBeNull()
+        expect(parser.errorNotification.value).toBeNull()
+
+        mock.restore()
+    })
+
+})


### PR DESCRIPTION
**Description**:
Changes below add support for URL:
`<HEDERA_EXPLORER_URL>/<NETWORK>/contract/<CONTRACT_ADDRESS>`
The also include unit and e2e tests.

**Related issue(s)**:

Fixes #432 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
