### PR TITLE
chore: move to latest release of @bladelabs/blade-web3.js.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hedera-explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@bladelabs/blade-web3.js": "1.1.1",
+        "@bladelabs/blade-web3.js": "1.2.2",
         "@ethereum-sourcify/bytecode-utils": "^1.2.3",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-brands-svg-icons": "^6.5.1",
@@ -1837,11 +1837,12 @@
       "dev": true
     },
     "node_modules/@bladelabs/blade-web3.js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bladelabs/blade-web3.js/-/blade-web3.js-1.1.1.tgz",
-      "integrity": "sha512-qmXtT846G/QinLVl94aTSqQ1sOlQ1ZQLdzquUfK+bP9gU0zQrByLWei5koLMK6Zk6Be1oFgT4+Sserpt/IUW6Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@bladelabs/blade-web3.js/-/blade-web3.js-1.2.2.tgz",
+      "integrity": "sha512-U/oRT8SUf1IBBqo3FrR8CWQeKOi2+/7AUZoxZxeLINRXviKaP4qHVvE8QmeVcIFg6A/FfdVH0kpi3kSatzZIbg==",
       "dependencies": {
         "@hashgraph/hedera-wallet-connect": "^0.1.0",
+        "@walletconnect/modal": "^2.6.2",
         "rxjs": "^7.8.0"
       },
       "peerDependencies": {
@@ -3513,6 +3514,19 @@
         "@hashgraph/sdk": "^2.32.0"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
+      "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "node_modules/@metamask/detect-provider": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
@@ -3635,6 +3649,117 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@motionone/animation": {
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.16.3.tgz",
+      "integrity": "sha512-QUGWpLbMFLhyqKlngjZhjtxM8IqiJQjLK0DF+XOF6od9nhSvlaeEpOY/UMCRVcZn/9Tr2rZO22EkuCIjYdI74g==",
+      "dependencies": {
+        "@motionone/easing": "^10.16.3",
+        "@motionone/types": "^10.16.3",
+        "@motionone/utils": "^10.16.3",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/animation/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@motionone/dom": {
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.4.tgz",
+      "integrity": "sha512-HPHlVo/030qpRj9R8fgY50KTN4Ko30moWRTA3L3imrsRBmob93cTYmodln49HYFbQm01lFF7X523OkKY0DX6UA==",
+      "dependencies": {
+        "@motionone/animation": "^10.16.3",
+        "@motionone/generators": "^10.16.4",
+        "@motionone/types": "^10.16.3",
+        "@motionone/utils": "^10.16.3",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/dom/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@motionone/easing": {
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.16.3.tgz",
+      "integrity": "sha512-HWTMZbTmZojzwEuKT/xCdvoMPXjYSyQvuVM6jmM0yoGU6BWzsmYMeB4bn38UFf618fJCNtP9XeC/zxtKWfbr0w==",
+      "dependencies": {
+        "@motionone/utils": "^10.16.3",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/easing/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@motionone/generators": {
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.16.4.tgz",
+      "integrity": "sha512-geFZ3w0Rm0ZXXpctWsSf3REGywmLLujEjxPYpBR0j+ymYwof0xbV6S5kGqqsDKgyWKVWpUInqQYvQfL6fRbXeg==",
+      "dependencies": {
+        "@motionone/types": "^10.16.3",
+        "@motionone/utils": "^10.16.3",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/generators/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@motionone/svelte": {
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.4.tgz",
+      "integrity": "sha512-zRVqk20lD1xqe+yEDZhMYgftsuHc25+9JSo+r0a0OWUJFocjSV9D/+UGhX4xgJsuwB9acPzXLr20w40VnY2PQA==",
+      "dependencies": {
+        "@motionone/dom": "^10.16.4",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/svelte/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@motionone/types": {
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.16.3.tgz",
+      "integrity": "sha512-W4jkEGFifDq73DlaZs3HUfamV2t1wM35zN/zX7Q79LfZ2sc6C0R1baUHZmqc/K5F3vSw3PavgQ6HyHLd/MXcWg=="
+    },
+    "node_modules/@motionone/utils": {
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.16.3.tgz",
+      "integrity": "sha512-WNWDksJIxQkaI9p9Z9z0+K27xdqISGNFy1SsWVGaiedTHq0iaT6iZujby8fT/ZnZxj1EOaxJtSfUPCFNU5CRoA==",
+      "dependencies": {
+        "@motionone/types": "^10.16.3",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/utils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@motionone/vue": {
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.4.tgz",
+      "integrity": "sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==",
+      "dependencies": {
+        "@motionone/dom": "^10.16.4",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/vue/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@noble/curves": {
       "version": "1.1.0",
@@ -4478,6 +4603,11 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5365,6 +5495,34 @@
       "version": "2.0.0-alpha.20",
       "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-2.0.0-alpha.20.tgz",
       "integrity": "sha512-Qunuhp6dnjkIQgVWRRktLE3KGRbNw7AgZnLAoTsOakOLLVL+l9zOIUuowRcbCOpPzDK8Vb5Y2gWSPR1tce0hAg=="
+    },
+    "node_modules/@walletconnect/modal": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.2.tgz",
+      "integrity": "sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.6.2",
+        "@walletconnect/modal-ui": "2.6.2"
+      }
+    },
+    "node_modules/@walletconnect/modal-core": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.2.tgz",
+      "integrity": "sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==",
+      "dependencies": {
+        "valtio": "1.11.2"
+      }
+    },
+    "node_modules/@walletconnect/modal-ui": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.2.tgz",
+      "integrity": "sha512-rbdstM1HPGvr7jprQkyPggX7rP4XiCG85ZA+zWBEX0dVQg8PpAgRUqpeub4xQKDgY7pY/xLRXSiCVdWGqvG2HA==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.6.2",
+        "lit": "2.8.0",
+        "motion": "10.16.2",
+        "qrcode": "1.5.3"
+      }
     },
     "node_modules/@walletconnect/qrcode-modal": {
       "version": "2.0.0-alpha.20",
@@ -9624,6 +9782,11 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
     },
+    "node_modules/hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -10589,8 +10752,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -10946,6 +11108,34 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -11240,6 +11430,18 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -11478,6 +11680,19 @@
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "ufo": "^1.3.0"
+      }
+    },
+    "node_modules/motion": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
+      "dependencies": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/dom": "^10.16.2",
+        "@motionone/svelte": "^10.16.2",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "@motionone/vue": "^10.16.2"
       }
     },
     "node_modules/mri": {
@@ -12955,6 +13170,11 @@
         "varint": "^5.0.0"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.1.tgz",
+      "integrity": "sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA=="
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -13289,6 +13509,18 @@
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -15327,6 +15559,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
@@ -15380,6 +15620,30 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.2.tgz",
+      "integrity": "sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==",
+      "dependencies": {
+        "proxy-compare": "2.5.1",
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/varint": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docker:stop": "docker-compose down"
   },
   "dependencies": {
-    "@bladelabs/blade-web3.js": "1.1.1",
+    "@bladelabs/blade-web3.js": "1.2.2",
     "@ethereum-sourcify/bytecode-utils": "^1.2.3",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-brands-svg-icons": "^6.5.1",


### PR DESCRIPTION
**Description**:

Changes below update release of [@blandelabs/blade-web3](https://www.npmjs.com/package/@bladelabs/blade-web3.js) from 1.1.1 to 1.2.2.

Straight move to `1.2.2` release breaks all unit tests.
After investigations, it turns out that `import @blandelabs/blade-web3.js` now executes some code with dependency on `window.matchMedia()`. Although `vitest` is setup to mock `window.matchMedia()` (see `globalSetup.js`), it does not prevent crashing.
To avoid that, `WalletDriver_Blade` class now performs a dynamic import of `@blandelabs/blade-web3.js`.

**Related issue(s)**:

None

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
