### PR TITLE
fix: Revert recent axios updates (go back to 1.6.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@metamask/detect-provider": "^2.0.0",
         "@metamask/providers": "^14.0.2",
         "@oruga-ui/oruga-next": "^0.7.0",
-        "axios": "^1.6.4",
+        "axios": "^1.6.3",
         "base32-decode": "^1.0.0",
         "base32-encode": "^1.2.0",
         "bulma": "^0.9.4",
@@ -6273,11 +6273,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
-      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -9163,9 +9163,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@metamask/detect-provider": "^2.0.0",
         "@metamask/providers": "^14.0.2",
         "@oruga-ui/oruga-next": "^0.7.0",
-        "axios": "^1.6.3",
+        "axios": "^1.6.2",
         "base32-decode": "^1.0.0",
         "base32-encode": "^1.2.0",
         "bulma": "^0.9.4",
@@ -6273,9 +6273,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@metamask/detect-provider": "^2.0.0",
     "@metamask/providers": "^14.0.2",
     "@oruga-ui/oruga-next": "^0.7.0",
-    "axios": "^1.6.3",
+    "axios": "^1.6.2",
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.2.0",
     "bulma": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@metamask/detect-provider": "^2.0.0",
     "@metamask/providers": "^14.0.2",
     "@oruga-ui/oruga-next": "^0.7.0",
-    "axios": "^1.6.4",
+    "axios": "^1.6.3",
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.2.0",
     "bulma": "^0.9.4",


### PR DESCRIPTION
**Description**:

Try reverting the last 2 axios updates (1.6.2->1.6.3 and 1.6.3->1.6.4) since they are concomitant with the recent regression of the contract verification functionality.

**Related issue(s)**:

Related to #834 
