### PR TITLE
fix: allow wallet chooser to wrap

### DIFF
--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -46,7 +46,7 @@
           </div>
         </div>
 
-        <div class="is-flex is-justify-content-flex-end">
+        <div class="is-flex is-justify-content-flex-end mt-4">
           <button id="cancelButton" class="button is-white is-small" @click="handleCancel">CANCEL</button>
           <button id="connectButton" :disabled="!chosenWallet" class="button is-info is-small ml-4" @click="handleConnect">CONNECT
           </button>

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -26,7 +26,7 @@
 
   <div :class="{'is-active': showDialog}" class="modal has-text-white">
     <div class="modal-background"/>
-    <div class="modal-content" style="width: 768px; border-radius: 16px">
+    <div class="modal-content" style="width: 634px; border-radius: 16px">
       <div class="box">
         <div class="is-flex is-justify-content-space-between is-align-items-self-end">
           <span class="h-is-primary-title">Connect Wallet</span>
@@ -36,7 +36,7 @@
         </div>
         <hr class="h-card-separator"/>
 
-        <div class="is-flex is-justify-content-left is-align-items-center">
+        <div class="is-flex is-justify-content-left is-align-items-center is-flex-wrap-wrap">
           <div v-for="d in drivers" :key="d.name">
             <a :id="d.name" @click="chosenWallet=d" @dblclick="handleConnect">
               <figure :class="{'selected':isSelected(d)}" class="h-chooser-figure my-4 mr-6">


### PR DESCRIPTION
**Description**:

Allow wallet chooser to properly display more than 3 drivers.

**Notes for reviewer**:

<img width="875" alt="Screenshot 2024-01-09 at 16 10 16" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/0a96a8ea-4ad8-4268-8f98-e65f6655a1e0">
<img width="875" alt="Screenshot 2024-01-09 at 16 12 05" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/cc0f65de-cf49-46ff-b544-2a23eaf3642f">
