### PR TITLE
chore: some refactoring in WalletDriver class hierarchy

### DIFF
--- a/.env
+++ b/.env
@@ -2,9 +2,6 @@
 ### The variables set in this file will be taken into account at build time.
 ###
 
-### When set to 'true', this variable will enable 'Metamask' support
-VITE_APP_ENABLE_METAMASK=true
-
 ### When set to 'true', this variable will enable the 'Staking' page
 VITE_APP_ENABLE_STAKING=true
 

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -220,19 +220,21 @@ export default defineComponent({
       walletManager
           .connect()
           .catch((reason) => {
-            console.warn("Failed to connect wallet - reason:" + reason.toString())
-            showProgressDialog.value = true
-            progressDialogMode.value = Mode.Error
-            progressDialogTitle.value = "Could not connect wallet"
-            showProgressSpinner.value = false
-            progressExtraTransactionId.value = null
-            if (reason instanceof WalletDriverError) {
-              progressMainMessage.value = reason.message
-              progressExtraMessage.value = reason.extra
-            } else {
-              progressMainMessage.value = "Unexpected error"
-              progressExtraMessage.value = JSON.stringify(reason)
-            }
+              if (!(reason instanceof WalletDriverCancelError)) {
+                  console.warn("Failed to connect wallet - reason:" + reason.toString())
+                  showProgressDialog.value = true
+                  progressDialogMode.value = Mode.Error
+                  progressDialogTitle.value = "Could not connect wallet"
+                  showProgressSpinner.value = false
+                  progressExtraTransactionId.value = null
+                  if (reason instanceof WalletDriverError) {
+                      progressMainMessage.value = reason.message
+                      progressExtraMessage.value = reason.extra
+                  } else {
+                      progressMainMessage.value = "Unexpected error"
+                      progressExtraMessage.value = JSON.stringify(reason)
+                  }
+              }
           })
           .finally(() => connecting.value = false)
       walletIconURL.value = walletManager.getActiveDriver().iconURL || ""

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -174,7 +174,7 @@ import AxiosStatus from "@/components/AxiosStatus.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import WalletChooser from "@/components/staking/WalletChooser.vue";
 import { WalletDriver } from '@/utils/wallet/WalletDriver';
-import { WalletDriverError } from '@/utils/wallet/WalletDriverError';
+import {WalletDriverCancelError, WalletDriverError} from '@/utils/wallet/WalletDriverError';
 import ProgressDialog, { Mode } from './staking/ProgressDialog.vue';
 import {defineComponent, inject, ref} from "vue";
 import WalletInfo from '@/components/wallet/WalletInfo.vue'

--- a/src/utils/wallet/WalletDriver.ts
+++ b/src/utils/wallet/WalletDriver.ts
@@ -84,7 +84,7 @@ export abstract class WalletDriver {
     }
 
     public silentMessage(): string {
-        return this.name + " wallet is silent";
+        return this.name + " is silent";
     }
 
     //

--- a/src/utils/wallet/WalletDriver_Metamask.ts
+++ b/src/utils/wallet/WalletDriver_Metamask.ts
@@ -18,12 +18,8 @@
  *
  */
 
-import {HederaLogo} from "@/utils/wallet/WalletDriver"
 import detectEthereumProvider from "@metamask/detect-provider";
-import {EntityID} from "@/utils/EntityID";
 import {BrowserProvider, ethers} from "ethers";
-import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
-import {makeTokenSymbol} from "@/schemas/HederaUtils";
 import {WalletDriver_Ethereum} from "@/utils/wallet/WalletDriver_Ethereum";
 import {MetaMaskInpageProvider} from "@metamask/providers";
 
@@ -48,32 +44,6 @@ export class WalletDriver_Metamask extends WalletDriver_Ethereum {
         super("Metamask",
             "https://freelogopng.com/images/all_img/1683020860metamask-logo-white.png",
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAJNElEQVRogd2ZXWxcRxXHfzP37r3rXX+snZo6jluvaS3cSDRBoklRm9bmgUhICPuhCB6QkwdA9KWRaKM8tGpQqVRCEekTEhXUfapKkeKA1D4gsNMWKhKkOkFJA03ijeM0aePaG+96P+7HDA/rXe9m7921k6gV/CVL67lzzpwz859zzszA/wv2DScSn7cNNwOz/KPbir//h+91pB68y57oO/SfVz9Po4Iwuy+ZIBoZPX3FHf/HJXf7c3+93AkgAA4M9wwrJacAtm2OsKvfSqOZ9A396sAL56Y/V8MPDA1L7Y8WPcZPzDuJk1dcAJRSIy++e3XaBPCU3CNXBU5ecbmw6CXGtkb3tNtyz9z+wZRATHjSeXXghVTqMzF6XzJhWtYTSrAPrRKZombydJ7loq70MaQYBaYFwP5HemeBZLUS2xDs6LPYttlca9RMSyEmXMc5OnA4lb7tRtv2uEaNasRwuf3UFZfj8w5FT98okj709kedopo+Qbiv2+ThfgvbFLUfNBO3g2KzB4aGDe2Pa8QoUAkkRU/zbsrh7DU3VFYpNSKefKR3QsJ4o0HabMHY1ijttgz6nLJNNR1rcS9uxPBMPpJwfWO82ugyFnKKt87WUiYIAv2SCKJPGHb0Wezoi9QrEtDV5qzP8lUsZi2UFnXtp664vJMqrldN2iRgBsJwfN5hIad4uD9Ssxpag+sJImbjGSvD9WSd8UVP89a/C1xe9tdrDkBCathQZLmw6HHkTP1AjmesW0fBq6Xi5es+vz+V26jxaK2nJYhjG5ICMkXNkTMFjs+vbbCiWz+rwYOCU+XAiUsOk2ea8z0IUnDSRDND83EDcXze4cKixze/ZNNuSxxPEI00NqToSbQWZIqKv5wrbnjWa6DVlDQM/5bC4EJOceRMgQ+ueThOYJSqQdE1uLDo8fqp/K0ZDyhDXSwnsiU2sJnDsKPPYvd9IEXwKvhK8KfTmnI5cItIH3r7o04JoLWeuR0aj887zH6qQr+nltTtMr5iswQQiFsuC2yzlOw2t5mhfTa3mnz3/hba7ZvcdFUo2yx+sqt31BAcuRVl1Zm6xfaJ2cHczhUN8kVjNYrdXOSphvbcrxjvzWXOfu2u+DEhxJ6bUbKlXTK2tYW4VdrAhgQrEkyjomvgK4FtCoa6TdIFzVI+nHKNrWfsF3/7eNoAeCjZfkRAz0Z1bOsx2T0YxZRrlDANHeqA40l8VeprSsHgphLdLi/fhBOCoQcGjNclgCHVGLChfbCr32JX0q5r1w1YoQLsDKuvmiAtHTV2eDqdNgF83xgWQjcMo1ETtvVKkl2StohJ1AguHRo5EIYdfRY77zL4JO9x9hPFxUVFutBQJOGZJIFUZe337+o9gmC0uld/pyDZJUl2CpJdpa5FR5IthEcaKTWdrcGhMr1i4vvhya495lYKwqsZTWpRlxxaumFWNJOH3vloDKoO9Y5h7U0YTnKwW25PdgqG7hREbzjE+KoUSW4WWjUOn9mCSUfcQwpNT5ugp03wYL+k4GlSi3D2E8WltEpdLeT2lmVqNGZ/dveEQIQebrJ5g6Lb2IFGZ4PFTATdpOCLWj7xaHiJobV+qfWZuX3l/2u4IIR4lBAOFxzJ4nUTIUCslgrV26D8WzSwz/PXPvp+2aC1za21YCVnEtmksEKKQiHEOFDvQOa55DBah57MopZCCsisNC7YhIBN7aKuHtIaFtMGuknEbIuHG7+KROa5vuG2Z+anYbWUKA2smiay7k6XeEvjMGOamqBV1FpghBR5ZcRjmu7O5rWSQFaCTZUD4tFmgralSLR7dU6czkZ5c6ENKCUyFWCnr6jM7PRSnNPZaJ3xbXEf22qe1FZpVBoPmtOnGi22jxuTCCH4YMnmd/NdnFkpGfNAe56BmBOaC6QB1xyTX1+6A4Ct8QLfunOZXV/IEW9RoTVUACo0Wt0DapR1HssipiZiKjpa4Rs9y3R2e/xxroMTCzHeXGjjiTs+DZW1TM0bH3fQG3P5+uYMI5uzDHUU0E6pxFjP7JexSqPSzdzK8/2z6PVdrUDpBmKlYJBo9WrarxcNhCdosf26GwrXE2RzJnkTemO1PF9eMYlaKrSGCkE6/vTFTpF9PrldaP3+RiQBsnmT1havrn0lb2BFVKADjmsQD5DJ5kxaY/XtzaC0PyK1ah59ghDGV8MIjzQRM1gm1iBxNYJEDpvpbATRhP+ZrMRx6y+uerpd7BuW3TI1fggTZEAKKboGV6+t5VOlBL6CqK2IxxqHXUPoftPzxaQhxRONOkZbNLmixC2sOSpEiUZK+bRUrYaUOvB+SIr61ckVDPKOQd6RNQlOSrBsmt4zCZiUeN4MTc4ChoT21tppNVdXI1c0SGcjlYNKuX+djirjfQXpbIS8Y6z2r3UsHlOBOm7Elp+fOyoHDqfSaJreStiWxrbWBqqueXwlWM6ZuF6p8XLGZ35Z1f1BaTMvr4Q7HLU1LdHmhwqtxVFYTWRa66NCrD0qhKG9TbGwVKpnbpw1pQRL0SF++68Cv/nzmUD5p3YP8NgXNVIv1bSXVkcgJcTj6wul5YsICaA8b2I9QkKsUam6EvW77iG383FyOx/n+OXwiPL3xQQrw0+T2/k4ftc9lfby5l4vdQBc6RyD1RUYOJxKzz01OI2g6SqUqWSaJcOLg7trjMmu5EJlz6fmgDWHjcXzROZPIM//c93UAdAwU36vq8QvLfQxQXMaAem2Vn9m6ct7ktbd99dl73MXL4UKXr1WW2b4XffgJgYobnkotem9wyloPoEACFW5Ua84oBTThuTZoP5a6xmkPqZ8MYnnzQwcTqWnXtuStNKLv4rY9mjUimIYBlprnvzR94m3RIPUsJIvsJxdob01jlKKfDFPoVCY9jOxsa/+8sM0wOyT9w5LQ4+ixKNCiO1BepQvJiu+VH+Y2z9YvuQtvRPDMVx3stGL5NQbLx+U0njWtmxs2+b68vWwrgAkOhI4rkM+n0cp/6cjj/3gYFjf2QNDSXx/2BD62yC2U3oKS9196MOBQAdmD9w7jAcDL27s5XHqtVeSIqKmWMdbmxACrXVKK39s5Ds/3NCl8uxTg9sRKjlw6HzwCtwqpt54+aAQMpCGZWj0S2SMgyN7996Wd+bb6gDA1CuvJEgUQi/JRsZ+/Jm89v/P4L+xWv0RTE0K4AAAAABJRU5ErkJggg==")
-    }
-
-    public async watchToken(accountId: string, tokenId: string): Promise<void> {
-        const tokenAddress = EntityID.parse(tokenId)?.toAddress() ?? null
-        if (accountId !== null && tokenAddress !== null && this.provider !== null) {
-            const tokenInfo = await TokenInfoCache.instance.lookup(tokenId)
-            const symbol = makeTokenSymbol(tokenInfo, 11)
-            const decimals = tokenInfo?.decimals
-            const params = {
-                "type": "ERC20",
-                "options": {
-                    "address": tokenAddress,
-                    "symbol": symbol,
-                    "decimals": decimals,
-                    "image": HederaLogo
-                }
-            }
-            try {
-                await this.provider.send("metamask_watchAsset", params)
-            } catch(reason) {
-                throw this.makeCallFailure(reason, "watchToken")
-            }
-        } else {
-            throw this.callFailure("Invalid arguments")
-        }
-        return Promise.resolve()
     }
 
     //

--- a/src/utils/wallet/WalletDriver_Metamask.ts
+++ b/src/utils/wallet/WalletDriver_Metamask.ts
@@ -59,10 +59,6 @@ export class WalletDriver_Metamask extends WalletDriver_Ethereum {
         return Promise.resolve(result)
     }
 
-    public isCancelError(reason: unknown): boolean {
-        return WalletDriver_Metamask.fetchMetamaskErrorCode(reason) == 4001
-    }
-
     public async connect(network: string): Promise<string[]> {
         const result = await super.connect(network)
         this.metamaskProvider?.once('chainChanged', this.handleDisconnect)
@@ -80,20 +76,6 @@ export class WalletDriver_Metamask extends WalletDriver_Ethereum {
     //
 
     private readonly handleDisconnect = () => this.disconnect()
-
-    private static fetchMetamaskErrorCode(reason: unknown): number|null {
-        let result: number|null
-        if (typeof reason == "object" && reason != null) {
-            if ("code" in reason && typeof reason.code == "number") {
-                result = reason.code
-            } else {
-                result = null
-            }
-        } else {
-            result = null
-        }
-        return result
-    }
 
 
 }

--- a/src/utils/wallet/WalletManager.ts
+++ b/src/utils/wallet/WalletManager.ts
@@ -26,6 +26,7 @@ import {WalletDriver_Hashpack} from "@/utils/wallet/WalletDriver_Hashpack";
 import {timeGuard, TimeGuardError} from "@/utils/TimerUtils";
 import {WalletDriver_Hedera} from "@/utils/wallet/WalletDriver_Hedera";
 import {WalletDriver_Metamask} from "@/utils/wallet/WalletDriver_Metamask";
+import {WalletDriver_Ethereum} from "@/utils/wallet/WalletDriver_Ethereum";
 
 export class WalletManager {
 
@@ -203,7 +204,7 @@ export class WalletManager {
 
     public async watchToken(token: string): Promise<void> {
         if (this.accountIdRef.value !== null) {
-            if (this.activeDriver instanceof WalletDriver_Metamask) {
+            if (this.activeDriver instanceof WalletDriver_Ethereum) {
                 return this.activeDriver.watchToken(this.accountIdRef.value, token)
             } else {
                 throw this.activeDriver.unsupportedOperation()

--- a/src/utils/wallet/WalletManager.ts
+++ b/src/utils/wallet/WalletManager.ts
@@ -34,7 +34,7 @@ export class WalletManager {
     private readonly bladeDriver = new WalletDriver_Blade()
     private readonly hashpackDriver = new WalletDriver_Hashpack()
     private readonly metamaskDriver = new WalletDriver_Metamask()
-    private readonly drivers: Array<WalletDriver> = [this.bladeDriver, this.hashpackDriver]
+    private readonly drivers: Array<WalletDriver> = [this.bladeDriver, this.hashpackDriver, this.metamaskDriver]
     private readonly timeout = 30000; // milliseconds
 
 
@@ -52,9 +52,6 @@ export class WalletManager {
 
     public constructor(routeManager: RouteManager) {
         this.routeManager = routeManager
-        if (import.meta.env.VITE_APP_ENABLE_METAMASK === "true") {
-            this.drivers.push(this.metamaskDriver)
-        }
         watch(this.routeManager.currentNetwork, () => this.disconnect())
     }
 


### PR DESCRIPTION
**Description**:
Changes include some refactoring:
1) `WalletDriver_Metamask.watchToken()` becomes a generic method and moves to `WalletDriver_Ethereum`
2) `WalletDriver_Ethereum.isCancelError()` has now a generic implementation (works on all subclasses)
3) Removed metamask feature flag (now obsolete)

`WalletDriver_Ethereum.connect()` now sends `wallet_requestPermissions` request to force wallet to interact wit user (and let her chooses another account).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
