### PR TITLE
fix: conflict between MetaMask and Coinbase wallet extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@hashgraph/proto": "^2.13.0",
         "@hashgraph/sdk": "^2.39.0",
         "@kabuto-sh/ns": "^0.12.0",
-        "@metamask/detect-provider": "^2.0.0",
         "@metamask/providers": "^14.0.2",
         "@oruga-ui/oruga-next": "^0.7.0",
         "axios": "^1.6.5",
@@ -3524,14 +3523,6 @@
       "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@metamask/detect-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
-      "integrity": "sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@metamask/json-rpc-engine": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@hashgraph/proto": "^2.13.0",
     "@hashgraph/sdk": "^2.39.0",
     "@kabuto-sh/ns": "^0.12.0",
-    "@metamask/detect-provider": "^2.0.0",
     "@metamask/providers": "^14.0.2",
     "@oruga-ui/oruga-next": "^0.7.0",
     "axios": "^1.6.5",

--- a/src/utils/wallet/WalletDriver_Metamask.ts
+++ b/src/utils/wallet/WalletDriver_Metamask.ts
@@ -18,8 +18,6 @@
  *
  */
 
-import detectEthereumProvider from "@metamask/detect-provider";
-import {BrowserProvider, ethers} from "ethers";
 import {WalletDriver_Ethereum} from "@/utils/wallet/WalletDriver_Ethereum";
 import {MetaMaskInpageProvider} from "@metamask/providers";
 
@@ -50,12 +48,8 @@ export class WalletDriver_Metamask extends WalletDriver_Ethereum {
     // WalletDriver_Ethereum
     //
 
-    public async makeProvider(): Promise<BrowserProvider|null> {
-        if (this.metamaskProvider === null) {
-            const options = { mustBeMetaMask: true }
-           this.metamaskProvider = (await detectEthereumProvider(options) ?? null)
-        }
-        const result = this.metamaskProvider !== null ?  new ethers.BrowserProvider(this.metamaskProvider) : null
+    public async isExpectedProvider(provider: object): Promise<boolean> {
+        const result = "isMetaMask" in provider && provider.isMetaMask == true
         return Promise.resolve(result)
     }
 


### PR DESCRIPTION
**Description**:

Changes below fix #774.

Root cause of the pb is a limitation in `@metamask/detect-provider` package.
This one breaks when both Metamask and Coinbase wallet extensions are enabled.

Coinbase has published a [note](https://docs.cloud.coinbase.com/wallet-sdk/docs/injected-provider-guidance) about the correct way to detect providers.
`WalletDriver_Ethereum.connect()` now implements behavior specified in this note.
Dependency on `@metamask/detect-provider` is removed

**Related issue(s)**:

Fixes #774

**Notes for reviewer**:

See #774 for reproduction scenario

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
