### PR TITLE
chore: bump copyright year in file headers 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/AppKeys.ts
+++ b/src/AppKeys.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/assets/styles/brand-theme.scss
+++ b/src/assets/styles/brand-theme.scss
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/assets/styles/explorer-bulma.sass
+++ b/src/assets/styles/explorer-bulma.sass
@@ -2,7 +2,7 @@
  /
  / Hedera Mirror Node Explorer
  /
- / Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ / Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  /
  / Licensed under the Apache License, Version 2.0 (the "License");
  / you may not use this file except in compliance with the License.

--- a/src/assets/styles/explorer-oruga.scss
+++ b/src/assets/styles/explorer-oruga.scss
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/ActionLink.vue
+++ b/src/components/ActionLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/AxiosStatus.vue
+++ b/src/components/AxiosStatus.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/CSVDownloadDialog.vue
+++ b/src/components/CSVDownloadDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/CSVDownloadProgressDialog.vue
+++ b/src/components/CSVDownloadProgressDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/CookiesDialog.vue
+++ b/src/components/CookiesDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/Copyable.vue
+++ b/src/components/Copyable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/DashboardCard.vue
+++ b/src/components/DashboardCard.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/EmptyTable.vue
+++ b/src/components/EmptyTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/ModalDialog.vue
+++ b/src/components/ModalDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/NotificationBanner.vue
+++ b/src/components/NotificationBanner.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/PlayPauseButton.vue
+++ b/src/components/PlayPauseButton.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/Property.vue
+++ b/src/components/Property.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/PropertyVertical.vue
+++ b/src/components/PropertyVertical.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/account/AccountTableController.ts
+++ b/src/components/account/AccountTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/account/BalanceTable.vue
+++ b/src/components/account/BalanceTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/account/TokenRelationshipsTableController.ts
+++ b/src/components/account/TokenRelationshipsTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/allowances/ApproveAllowanceSection.vue
+++ b/src/components/allowances/ApproveAllowanceSection.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/allowances/HbarAllowanceTableController.ts
+++ b/src/components/allowances/HbarAllowanceTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/allowances/TokenAllowanceTableController.ts
+++ b/src/components/allowances/TokenAllowanceTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/block/BlockTableController.ts
+++ b/src/components/block/BlockTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractActionsLoader.ts
+++ b/src/components/contract/ContractActionsLoader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractActionsTable.vue
+++ b/src/components/contract/ContractActionsTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultLogEntry.vue
+++ b/src/components/contract/ContractResultLogEntry.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultLogs.vue
+++ b/src/components/contract/ContractResultLogs.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultStateChangeEntry.vue
+++ b/src/components/contract/ContractResultStateChangeEntry.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultStates.vue
+++ b/src/components/contract/ContractResultStates.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultTableController.ts
+++ b/src/components/contract/ContractResultTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractResultTrace.vue
+++ b/src/components/contract/ContractResultTrace.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractTableController.ts
+++ b/src/components/contract/ContractTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/contract/ContractTransactionTable.vue
+++ b/src/components/contract/ContractTransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/contracts/ContractResultsSection.vue
+++ b/src/components/contracts/ContractResultsSection.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/dashboard/ContractCallTransactionTable.vue
+++ b/src/components/dashboard/ContractCallTransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/dashboard/CryptoTransactionTable.vue
+++ b/src/components/dashboard/CryptoTransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/dashboard/DashboardItem.vue
+++ b/src/components/dashboard/DashboardItem.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/dashboard/HbarMarketDashboard.vue
+++ b/src/components/dashboard/HbarMarketDashboard.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/dashboard/HbarPriceLoader.ts
+++ b/src/components/dashboard/HbarPriceLoader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/dashboard/HbarSupplyLoader.ts
+++ b/src/components/dashboard/HbarSupplyLoader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/dashboard/MarketDataCache.ts
+++ b/src/components/dashboard/MarketDataCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/dashboard/MessageTransactionTable.vue
+++ b/src/components/dashboard/MessageTransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/dashboard/Variation.vue
+++ b/src/components/dashboard/Variation.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/node/NetworkDashboardItem.vue
+++ b/src/components/node/NetworkDashboardItem.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/node/StakeRange.vue
+++ b/src/components/node/StakeRange.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/staking/OptOutDialog.vue
+++ b/src/components/staking/OptOutDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/staking/ProgressDialog.vue
+++ b/src/components/staking/ProgressDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/staking/StakingRewardsTableController.ts
+++ b/src/components/staking/StakingRewardsTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/staking/WalletChooser.vue
+++ b/src/components/staking/WalletChooser.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/FixedFeeTable.vue
+++ b/src/components/token/FixedFeeTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/FractionalFeeTable.vue
+++ b/src/components/token/FractionalFeeTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/MetaMaskImport.vue
+++ b/src/components/token/MetaMaskImport.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/NftHolderTableController.ts
+++ b/src/components/token/NftHolderTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/token/RoyaltyFeeTable.vue
+++ b/src/components/token/RoyaltyFeeTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/TokenBalanceTableController.ts
+++ b/src/components/token/TokenBalanceTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/token/TokenCustomFees.vue
+++ b/src/components/token/TokenCustomFees.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/TokenInfoAnalyzer.ts
+++ b/src/components/token/TokenInfoAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/token/TokenTableController.ts
+++ b/src/components/token/TokenTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/topic/TopicMessage.vue
+++ b/src/components/topic/TopicMessage.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/topic/TopicMessageTableController.ts
+++ b/src/components/topic/TopicMessageTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/NftTransactionAnalyzer.ts
+++ b/src/components/transaction/NftTransactionAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transaction/NftTransactionSummary.vue
+++ b/src/components/transaction/NftTransactionSummary.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/NftTransactionTableController.ts
+++ b/src/components/transaction/NftTransactionTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionAnalyzer.ts
+++ b/src/components/transaction/TransactionAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionFilterSelect.vue
+++ b/src/components/transaction/TransactionFilterSelect.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionGroupAnalyzer.ts
+++ b/src/components/transaction/TransactionGroupAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionTableController.ts
+++ b/src/components/transaction/TransactionTableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transaction/TransactionTableControllerXL.ts
+++ b/src/components/transaction/TransactionTableControllerXL.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/ArrowSegment.vue
+++ b/src/components/transfer_graphs/ArrowSegment.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/HbarTransferGraphC.vue
+++ b/src/components/transfer_graphs/HbarTransferGraphC.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/HbarTransferGraphF.vue
+++ b/src/components/transfer_graphs/HbarTransferGraphF.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/NftDetailsTransferGraph.vue
+++ b/src/components/transfer_graphs/NftDetailsTransferGraph.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/NftTransferGraph.vue
+++ b/src/components/transfer_graphs/NftTransferGraph.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/NftTransferGraphSection.vue
+++ b/src/components/transfer_graphs/NftTransferGraphSection.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/RewardTransferGraph.vue
+++ b/src/components/transfer_graphs/RewardTransferGraph.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/TokenTransferGraphC.vue
+++ b/src/components/transfer_graphs/TokenTransferGraphC.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/TokenTransferGraphF.vue
+++ b/src/components/transfer_graphs/TokenTransferGraphF.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/TransferGraphSection.vue
+++ b/src/components/transfer_graphs/TransferGraphSection.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/layout/HbarTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/HbarTransferLayout.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/layout/NFTTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/NFTTransferLayout.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/layout/RewardTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/RewardTransferLayout.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/transfer_graphs/layout/TokenTransferLayout.ts
+++ b/src/components/transfer_graphs/layout/TokenTransferLayout.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/values/AccountLink.vue
+++ b/src/components/values/AccountLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/AliasValue.vue
+++ b/src/components/values/AliasValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/BlockLink.vue
+++ b/src/components/values/BlockLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/ByteCodeValue.vue
+++ b/src/components/values/ByteCodeValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/ComplexKeyValue.vue
+++ b/src/components/values/ComplexKeyValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/ContractLink.vue
+++ b/src/components/values/ContractLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/DisassembledCodeValue.vue
+++ b/src/components/values/DisassembledCodeValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/DurationValue.vue
+++ b/src/components/values/DurationValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/Endpoints.vue
+++ b/src/components/values/Endpoints.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/EntityLink.vue
+++ b/src/components/values/EntityLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/FunctionValue.vue
+++ b/src/components/values/FunctionValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/HbarAmount.vue
+++ b/src/components/values/HbarAmount.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/HbarExtra.vue
+++ b/src/components/values/HbarExtra.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/HexaValue.vue
+++ b/src/components/values/HexaValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/InnerSenderEVMAddress.vue
+++ b/src/components/values/InnerSenderEVMAddress.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/KeyValue.vue
+++ b/src/components/values/KeyValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/OpcodeValue.vue
+++ b/src/components/values/OpcodeValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/PlainAmount.vue
+++ b/src/components/values/PlainAmount.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/SignatureValue.vue
+++ b/src/components/values/SignatureValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/StringValue.vue
+++ b/src/components/values/StringValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/TimestampValue.vue
+++ b/src/components/values/TimestampValue.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/TokenExtra.vue
+++ b/src/components/values/TokenExtra.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/TokenLink.vue
+++ b/src/components/values/TokenLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/TopicLink.vue
+++ b/src/components/values/TopicLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/values/TransactionLabel.vue
+++ b/src/components/values/TransactionLabel.vue
@@ -2,7 +2,7 @@
 -
 - Hedera Mirror Node Explorer
 -
-- Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+- Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
 -
 - Licensed under the Apache License, Version 2.0 (the "License");
 - you may not use this file except in compliance with the License.

--- a/src/components/values/TransactionLink.vue
+++ b/src/components/values/TransactionLink.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/verification/ContractVerificationDialog.vue
+++ b/src/components/verification/ContractVerificationDialog.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/verification/FileList.vue
+++ b/src/components/verification/FileList.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/components/wallet/WalletInfo.vue
+++ b/src/components/wallet/WalletInfo.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pages/AccountBalances.vue
+++ b/src/pages/AccountBalances.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Accounts.vue
+++ b/src/pages/Accounts.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/AccountsWithKey.vue
+++ b/src/pages/AccountsWithKey.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/AddressDetails.vue
+++ b/src/pages/AddressDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/AdminKeyDetails.vue
+++ b/src/pages/AdminKeyDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/BlockDetails.vue
+++ b/src/pages/BlockDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Blocks.vue
+++ b/src/pages/Blocks.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Contracts.vue
+++ b/src/pages/Contracts.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/MobileSearch.vue
+++ b/src/pages/MobileSearch.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/PageNotFound.vue
+++ b/src/pages/PageNotFound.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/RoutingSpec.vue
+++ b/src/pages/RoutingSpec.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Tokens.vue
+++ b/src/pages/Tokens.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Topics.vue
+++ b/src/pages/Topics.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/Transactions.vue
+++ b/src/pages/Transactions.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/pages/TransactionsById.vue
+++ b/src/pages/TransactionsById.vue
@@ -2,7 +2,7 @@
   -
   - Hedera Mirror Node Explorer
   -
-  - Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schemas/SignatureResponse.ts
+++ b/src/schemas/SignatureResponse.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schemas/SystemContractRegistry.ts
+++ b/src/schemas/SystemContractRegistry.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/AccountAlias.ts
+++ b/src/utils/AccountAlias.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/AxiosMonitor.ts
+++ b/src/utils/AxiosMonitor.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/CSVEncoder.ts
+++ b/src/utils/CSVEncoder.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/ComplexKeyLine.ts
+++ b/src/utils/ComplexKeyLine.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/Duration.ts
+++ b/src/utils/Duration.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/EthereumAddress.ts
+++ b/src/utils/EthereumAddress.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/EthereumHash.ts
+++ b/src/utils/EthereumHash.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/HMSF.ts
+++ b/src/utils/HMSF.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/NameService.ts
+++ b/src/utils/NameService.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/PathParam.ts
+++ b/src/utils/PathParam.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/SVGUtils.ts
+++ b/src/utils/SVGUtils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/StakingPeriod.ts
+++ b/src/utils/StakingPeriod.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/TimerUtils.ts
+++ b/src/utils/TimerUtils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/Timestamp.ts
+++ b/src/utils/Timestamp.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/TransactionHash.ts
+++ b/src/utils/TransactionHash.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/TransactionID.ts
+++ b/src/utils/TransactionID.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/BalanceAnalyzer.ts
+++ b/src/utils/analyzer/BalanceAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ByteCodeAnalyzer.ts
+++ b/src/utils/analyzer/ByteCodeAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ContractActionAnalyzer.ts
+++ b/src/utils/analyzer/ContractActionAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ContractAnalyzer.ts
+++ b/src/utils/analyzer/ContractAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ContractLogAnalyzer.ts
+++ b/src/utils/analyzer/ContractLogAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ContractResultAnalyzer.ts
+++ b/src/utils/analyzer/ContractResultAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ContractResultsLogsAnalyzer.ts
+++ b/src/utils/analyzer/ContractResultsLogsAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/ContractSourceAnalyzer.ts
+++ b/src/utils/analyzer/ContractSourceAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/FileImporter.ts
+++ b/src/utils/analyzer/FileImporter.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/NetworkAnalyzer.ts
+++ b/src/utils/analyzer/NetworkAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/analyzer/NodeAnalyzer.ts
+++ b/src/utils/analyzer/NodeAnalyzer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/bytecode_tools/disassembler/BytecodeDisassembler.ts
+++ b/src/utils/bytecode_tools/disassembler/BytecodeDisassembler.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/bytecode_tools/disassembler/utils/evm_opcodes.ts
+++ b/src/utils/bytecode_tools/disassembler/utils/evm_opcodes.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/bytecode_tools/disassembler/utils/helpers.ts
+++ b/src/utils/bytecode_tools/disassembler/utils/helpers.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/AccountByAddressCache.ts
+++ b/src/utils/cache/AccountByAddressCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/AccountByAliasCache.ts
+++ b/src/utils/cache/AccountByAliasCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/AccountByIdCache.ts
+++ b/src/utils/cache/AccountByIdCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/AssetCache.ts
+++ b/src/utils/cache/AssetCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/BalanceCache.ts
+++ b/src/utils/cache/BalanceCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/BlockByHashCache.ts
+++ b/src/utils/cache/BlockByHashCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/BlockByNbCache.ts
+++ b/src/utils/cache/BlockByNbCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/BlockByTsCache.ts
+++ b/src/utils/cache/BlockByTsCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/ContractByAddressCache.ts
+++ b/src/utils/cache/ContractByAddressCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/ContractByIdCache.ts
+++ b/src/utils/cache/ContractByIdCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/ContractResultByHashCache.ts
+++ b/src/utils/cache/ContractResultByHashCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/ContractResultByTransactionIdCache.ts
+++ b/src/utils/cache/ContractResultByTransactionIdCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/ContractResultByTsCache.ts
+++ b/src/utils/cache/ContractResultByTsCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/ContractResultsLogsByContractIdCache.ts
+++ b/src/utils/cache/ContractResultsLogsByContractIdCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/HbarPriceCache.ts
+++ b/src/utils/cache/HbarPriceCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/NetworkCache.ts
+++ b/src/utils/cache/NetworkCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/NftBySerialCache.ts
+++ b/src/utils/cache/NftBySerialCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/SourcifyCache.ts
+++ b/src/utils/cache/SourcifyCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/StakeCache.ts
+++ b/src/utils/cache/StakeCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TokenAssociationCache.ts
+++ b/src/utils/cache/TokenAssociationCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TokenInfoCache.ts
+++ b/src/utils/cache/TokenInfoCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TokenRelationshipCache.ts
+++ b/src/utils/cache/TokenRelationshipCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TopicMessageCache.ts
+++ b/src/utils/cache/TopicMessageCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TransactionByHashCache.ts
+++ b/src/utils/cache/TransactionByHashCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TransactionByIdCache.ts
+++ b/src/utils/cache/TransactionByIdCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TransactionByTsCache.ts
+++ b/src/utils/cache/TransactionByTsCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TransactionGroupByBlockCache.ts
+++ b/src/utils/cache/TransactionGroupByBlockCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/TransactionGroupCache.ts
+++ b/src/utils/cache/TransactionGroupCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/base/EntityCache.ts
+++ b/src/utils/cache/base/EntityCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/base/SerialCache.ts
+++ b/src/utils/cache/base/SerialCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/cache/base/SingletonCache.ts
+++ b/src/utils/cache/base/SingletonCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/downloader/EntityDownloader.ts
+++ b/src/utils/downloader/EntityDownloader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/downloader/RewardDownloader.ts
+++ b/src/utils/downloader/RewardDownloader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/loader/AutoRefreshLoader.ts
+++ b/src/utils/loader/AutoRefreshLoader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/loader/EntityLoader.ts
+++ b/src/utils/loader/EntityLoader.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/parser/AccountLocParser.ts
+++ b/src/utils/parser/AccountLocParser.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/parser/BlockLocParser.ts
+++ b/src/utils/parser/BlockLocParser.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/parser/ContractLocParser.ts
+++ b/src/utils/parser/ContractLocParser.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/parser/TransactionLocParser.ts
+++ b/src/utils/parser/TransactionLocParser.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/solc/SolcInput.ts
+++ b/src/utils/solc/SolcInput.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/solc/SolcMetadata.ts
+++ b/src/utils/solc/SolcMetadata.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/solc/SolcOutput.ts
+++ b/src/utils/solc/SolcOutput.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/solc/SolcUtils.ts
+++ b/src/utils/solc/SolcUtils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/sourcify/SourcifyUtils.ts
+++ b/src/utils/sourcify/SourcifyUtils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/table/RowBuffer.ts
+++ b/src/utils/table/RowBuffer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriver.ts
+++ b/src/utils/wallet/WalletDriver.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriverError.ts
+++ b/src/utils/wallet/WalletDriverError.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriver_Blade.ts
+++ b/src/utils/wallet/WalletDriver_Blade.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriver_Ethereum.ts
+++ b/src/utils/wallet/WalletDriver_Ethereum.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriver_Hashpack.ts
+++ b/src/utils/wallet/WalletDriver_Hashpack.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriver_Hedera.ts
+++ b/src/utils/wallet/WalletDriver_Hedera.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletDriver_Metamask.ts
+++ b/src/utils/wallet/WalletDriver_Metamask.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/wallet/WalletManager.ts
+++ b/src/utils/wallet/WalletManager.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/AccountNavigation.cy.ts
+++ b/tests/e2e/specs/AccountNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/AdminKeyDetailsNavigation.cy.ts
+++ b/tests/e2e/specs/AdminKeyDetailsNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/BlockNavigation.cy.ts
+++ b/tests/e2e/specs/BlockNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/BlocksResponseCollector.cy.ts
+++ b/tests/e2e/specs/BlocksResponseCollector.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/ContractNavigation.cy.ts
+++ b/tests/e2e/specs/ContractNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/ContractResultDetails.cy.ts
+++ b/tests/e2e/specs/ContractResultDetails.cy.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/CopyHexaToClipboard.cy.ts
+++ b/tests/e2e/specs/CopyHexaToClipboard.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/DashboardNavigation.cy.ts
+++ b/tests/e2e/specs/DashboardNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/HomePage.cy.ts
+++ b/tests/e2e/specs/HomePage.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/LegalNotices.cy.ts
+++ b/tests/e2e/specs/LegalNotices.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/MobileMenu.cy.ts
+++ b/tests/e2e/specs/MobileMenu.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/MobileSearch.cy.ts
+++ b/tests/e2e/specs/MobileSearch.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/NodeNavigation.cy.ts
+++ b/tests/e2e/specs/NodeNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/PageNotFound.cy.ts
+++ b/tests/e2e/specs/PageNotFound.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/SearchBar.cy.ts
+++ b/tests/e2e/specs/SearchBar.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/TokenInfoCollector.cy.ts
+++ b/tests/e2e/specs/TokenInfoCollector.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/TokenNavigation.cy.ts
+++ b/tests/e2e/specs/TokenNavigation.cy.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/TopNavigationBar.cy.ts
+++ b/tests/e2e/specs/TopNavigationBar.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/TopicNavigation.cy.ts
+++ b/tests/e2e/specs/TopicNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/TransactionNavigation.cy.ts
+++ b/tests/e2e/specs/TransactionNavigation.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/specs/TransferGraphs.cy.ts
+++ b/tests/e2e/specs/TransferGraphs.cy.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/account/AccountBalances.spec.ts
+++ b/tests/unit/account/AccountBalances.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/account/Accounts.spec.ts
+++ b/tests/unit/account/Accounts.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/account/AdminKeyDetails.spec.ts
+++ b/tests/unit/account/AdminKeyDetails.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/block/BlockDetails.spec.ts
+++ b/tests/unit/block/BlockDetails.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/block/Blocks.spec.ts
+++ b/tests/unit/block/Blocks.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/contract/Contracts.spec.ts
+++ b/tests/unit/contract/Contracts.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/dashboard/HbarMarketDashboard.spec.ts
+++ b/tests/unit/dashboard/HbarMarketDashboard.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/schema/NetworkRegistry.spec.ts
+++ b/tests/unit/schema/NetworkRegistry.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/staking/Staking.spec.ts
+++ b/tests/unit/staking/Staking.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/staking/StakingDialog.spec.ts
+++ b/tests/unit/staking/StakingDialog.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/staking/WalletDriver_Mock.ts
+++ b/tests/unit/staking/WalletDriver_Mock.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/token/Tokens.spec.ts
+++ b/tests/unit/token/Tokens.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/topic/TopicDetails.spec.ts
+++ b/tests/unit/topic/TopicDetails.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/topic/Topics.spec.ts
+++ b/tests/unit/topic/Topics.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transaction/TransactionTableControllerXL.spec.ts
+++ b/tests/unit/transaction/TransactionTableControllerXL.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transaction/Transactions.spec.ts
+++ b/tests/unit/transaction/Transactions.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/transfer_graphs/layout/TokenTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/TokenTransferLayout.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/AccountLocParser.spec.ts
+++ b/tests/unit/utils/AccountLocParser.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/B64Utils.spec.ts
+++ b/tests/unit/utils/B64Utils.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/BlockLocParser.spec.ts
+++ b/tests/unit/utils/BlockLocParser.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/ComplexKeyLine.spec.ts
+++ b/tests/unit/utils/ComplexKeyLine.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/ContractAnalyzer.spec.ts
+++ b/tests/unit/utils/ContractAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/ContractLocParser.spec.ts
+++ b/tests/unit/utils/ContractLocParser.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/Duration.spec.ts
+++ b/tests/unit/utils/Duration.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/EVMAddress.spec.ts
+++ b/tests/unit/utils/EVMAddress.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/EthereumAddress.spec.ts
+++ b/tests/unit/utils/EthereumAddress.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/PathParam.spec.ts
+++ b/tests/unit/utils/PathParam.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/TableController.spec.ts
+++ b/tests/unit/utils/TableController.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/TransactionID.spec.ts
+++ b/tests/unit/utils/TransactionID.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/TransactionLocParser.spec.ts
+++ b/tests/unit/utils/TransactionLocParser.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/analyzer/BalanceAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/BalanceAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/analyzer/ByteCodeAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ByteCodeAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/analyzer/ContractLogAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractLogAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/analyzer/TokenInfoAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/TokenInfoAnalyzer.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/bytecode_tools/bytecodeDisassembler.spec.ts
+++ b/tests/unit/utils/bytecode_tools/bytecodeDisassembler.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/bytecode_tools/bytecode_assets.ts
+++ b/tests/unit/utils/bytecode_tools/bytecode_assets.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/ContractByAddressCache.spec.ts
+++ b/tests/unit/utils/cache/ContractByAddressCache.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/ContractByIdCache.spec.ts
+++ b/tests/unit/utils/cache/ContractByIdCache.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/ContractResultByTransactionIdCache.spec.ts
+++ b/tests/unit/utils/cache/ContractResultByTransactionIdCache.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
+++ b/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/EntityCache.spec.ts
+++ b/tests/unit/utils/cache/EntityCache.spec.ts
@@ -4,7 +4,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/SerialCache.spec.ts
+++ b/tests/unit/utils/cache/SerialCache.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/utils/cache/TransactionGroupByBlockCache.spec.ts
+++ b/tests/unit/utils/cache/TransactionGroupByBlockCache.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/AccountLink.spec.ts
+++ b/tests/unit/values/AccountLink.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/AliasValue.spec.ts
+++ b/tests/unit/values/AliasValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/BlobValue.spec.ts
+++ b/tests/unit/values/BlobValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/BlockLink.spec.ts
+++ b/tests/unit/values/BlockLink.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/ComplexKeyValue.spec.ts
+++ b/tests/unit/values/ComplexKeyValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/ContractLink.spec.ts
+++ b/tests/unit/values/ContractLink.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/DashboardCard.spec.ts
+++ b/tests/unit/values/DashboardCard.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/DurationValue.spec.ts
+++ b/tests/unit/values/DurationValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/Endpoints.spec.ts
+++ b/tests/unit/values/Endpoints.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/EntityLink.spec.ts
+++ b/tests/unit/values/EntityLink.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/HbarAmount.spec.ts
+++ b/tests/unit/values/HbarAmount.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/HexaValue.spec.ts
+++ b/tests/unit/values/HexaValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/KeyValue.spec.ts
+++ b/tests/unit/values/KeyValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/OpcodeValue.spec.ts
+++ b/tests/unit/values/OpcodeValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/TimestampValue.spec.ts
+++ b/tests/unit/values/TimestampValue.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/TokenAmount.spec.ts
+++ b/tests/unit/values/TokenAmount.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/TokenExtra.spec.ts
+++ b/tests/unit/values/TokenExtra.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/TokenLink.spec.ts
+++ b/tests/unit/values/TokenLink.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/values/TopicLink.spec.ts
+++ b/tests/unit/values/TopicLink.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera Mirror Node Explorer
  *
- * Copyright (C) 2021 - 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description**:

Align all file headers to the following:

`Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC`

**Related issue(s)**:

Fixes #848 
