### PR TITLE
fix: account and contract inline token balances

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -443,8 +443,15 @@ export default defineComponent({
     const displayedBalances: ComputedRef<TokenBalance[]> = computed(() => {
         const result: TokenBalance[] = []
         const allBalances = balanceAnalyzer.tokenBalances.value
+        // Display in priority 'non-zero balances'
         for (let i = 0; i < allBalances.length && result.length < MAX_TOKEN_BALANCES; i++) {
             if (allBalances[i].balance > 0) {
+                result.push(allBalances[i])
+            }
+        }
+        // Complete with 'zero balances' if any room left
+        for (let i = 0; i < allBalances.length && result.length < MAX_TOKEN_BALANCES; i++) {
+            if (!result.includes(allBalances[i])) {
                 result.push(allBalances[i])
             }
         }

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -313,6 +313,7 @@ import ApproveAllowanceSection from "@/components/allowances/ApproveAllowanceSec
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import Copyable from "@/components/Copyable.vue";
 import {TokenBalance} from "@/schemas/HederaSchemas";
+import {NftCollectionCache} from "@/utils/cache/NftCollectionCache";
 
 const MAX_TOKEN_BALANCES = 10
 
@@ -406,12 +407,21 @@ export default defineComponent({
     })
 
     //
-    // balanceCache
+    // BalanceAnalyzer
     //
 
     const balanceAnalyzer = new BalanceAnalyzer(accountLocParser.accountId, 10000)
     onMounted(() => balanceAnalyzer.mount())
     onBeforeUnmount(() => balanceAnalyzer.unmount())
+
+    //
+    // NftCollectionCache
+    //
+
+    const nftCollectionLookup = NftCollectionCache.instance.makeLookup(accountId)
+    onMounted(() => nftCollectionLookup.mount())
+    onBeforeUnmount(() => nftCollectionLookup.unmount())
+
     const elapsed = computed(() => {
           let result: string | null
           if (balanceAnalyzer.balanceTimeStamp.value) {
@@ -441,8 +451,10 @@ export default defineComponent({
         return result
     })
 
-    const displayAllTokenLinks = computed(
-        () => displayedBalances.value.length < balanceAnalyzer.tokenBalances.value.length)
+    const displayAllTokenLinks = computed(() => {
+        return displayedBalances.value.length < balanceAnalyzer.tokenBalances.value.length
+            || (nftCollectionLookup.entity.value?.length ?? 0) > 0
+    })
 
     //
     // contract

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -329,8 +329,15 @@ export default defineComponent({
     const displayedBalances: ComputedRef<TokenBalance[]> = computed(() => {
       const result: TokenBalance[] = []
       const allBalances = balanceAnalyzer.tokenBalances.value
+      // Display in priority 'non-zero balances'
       for (let i = 0; i < allBalances.length && result.length < MAX_TOKEN_BALANCES; i++) {
         if (allBalances[i].balance > 0) {
+          result.push(allBalances[i])
+        }
+      }
+      // Complete with 'zero balances' if any room left
+      for (let i = 0; i < allBalances.length && result.length < MAX_TOKEN_BALANCES; i++) {
+        if (!result.includes(allBalances[i])) {
           result.push(allBalances[i])
         }
       }


### PR DESCRIPTION
**Description**:

- Include tokens with a balance=0 when there is enough room in the list of balance displayed inline in  ContractDetails and AccountDetails.
- Display the 'Show all tokens' link when the account/contract owns at least one serial #, such that we can get to the details of that collection.

**Notes for reviewer**:

Needs refactoring to share this code between account and contract. Will add more tests then.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
