### PR TITLE
feat: support HIP-15 address checksum in search field

### DIFF
--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -53,9 +53,12 @@
               <span style="display: inline-block">Make sure you enter one of the expressions below:</span>
               <br/><br/>
               <div>
-                &bull; an entity ID (0.0.x)<br/>
+                &bull; an entity ID with or without checksum (0.0.x or 0.0.x-abcde)<br/>
                 <div class="should-wrap h-help-item">
                   Example:&nbsp;0.0.1484550
+                </div>
+                <div class="should-wrap h-help-item">
+                  or:&nbsp;0.0.1484550-yapfr
                 </div>
               </div>
               <div>

--- a/src/utils/ComplexKeyLine.ts
+++ b/src/utils/ComplexKeyLine.ts
@@ -136,7 +136,7 @@ export class ComplexKeyLine {
         const shard = Number(iContractID.shardNum ?? 0)
         const realm = Number(iContractID.realmNum ?? 0)
         const num = Number(iContractID.contractNum ?? 0)
-        const entityId = new EntityID(shard, realm, num)
+        const entityId = new EntityID(shard, realm, num, null)
         return entityId.toString()
     }
 }

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -25,6 +25,7 @@ export class EntityID {
     public readonly shard: number
     public readonly realm: number
     public readonly num: number
+    public readonly checksum: string|null
 
 
 
@@ -33,10 +34,11 @@ export class EntityID {
     // Public
     //
 
-    public constructor(shard: number, realm: number, num: number) {
+    public constructor(shard: number, realm: number, num: number, checksum: string|null) {
         this.shard = shard
         this.realm = realm
         this.num = num
+        this.checksum = checksum
     }
 
     public static parse(s: string, autoComplete = false): EntityID|null {
@@ -55,18 +57,38 @@ export class EntityID {
             if (shard == null || realm == null || num == null) {
                 result = null
             } else {
-                result = new EntityID(shard, realm, num)
+                result = new EntityID(shard, realm, num, null)
             }
         } else if (i1 === -1 && i2 === -1 && autoComplete) {
             const num = EntityID.parsePositiveInt(s)
             if (num == null) {
                 result = null
             } else {
-                result = new EntityID(0, 0, num)
+                result = new EntityID(0, 0, num, null)
             }
         } else {
             result = null
         }
+        return result
+    }
+
+    public static parseWithChecksum(s: string, autoComplete = false): EntityID|null {
+        let result: EntityID|null
+
+        const i = s.indexOf("-")
+        if (i != -1) {
+            const id = s.substring(0, i)
+            const checksum = s.substring(i+1)
+            const entityId = EntityID.parse(id, autoComplete)
+            if (entityId !== null) {
+                result = new EntityID(entityId.shard, entityId.realm, entityId.num, checksum)
+            } else {
+                result = null
+            }
+        } else {
+            result = EntityID.parse(s, autoComplete)
+        }
+
         return result
     }
 
@@ -99,7 +121,7 @@ export class EntityID {
                 const view = new DataView(buffer.buffer)
                 const bigNum = view.getBigInt64(12)
                 const num = 0 <= bigNum && bigNum < EntityID.MAX_INT ? Number(bigNum) : null
-                result = num != null ? new EntityID(0, 0, num) : null
+                result = num != null ? new EntityID(0, 0, num, null) : null
             } else {
                 result = null
             }
@@ -112,6 +134,16 @@ export class EntityID {
 
     public isEthereumPrecompiledContract(): boolean {
         return this.shard == 0 && this.realm == 0 && 1 <= this.num && this.num < 256
+    }
+
+    public cloneWithoutChecksum(): EntityID {
+        let result: EntityID
+        if (this.checksum !== null) {
+            result = new EntityID(this.shard, this.realm, this.num, null)
+        } else {
+            result = this
+        }
+        return result
     }
 
     /*

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -80,7 +80,7 @@ export class EntityID {
             const id = s.substring(0, i)
             const checksum = s.substring(i+1)
             const entityId = EntityID.parse(id, autoComplete)
-            if (entityId !== null) {
+            if (entityId !== null && hasChecksumSyntax(checksum)) {
                 result = new EntityID(entityId.shard, entityId.realm, entityId.num, checksum)
             } else {
                 result = null
@@ -177,6 +177,7 @@ export class EntityID {
         const n = s.match(/^[0-9]+$/) !== null ? parseInt(s) : EntityID.MAX_INT
         return (isNaN(n) || n >= EntityID.MAX_INT) ? null : n
     }
+
 }
 
 
@@ -190,4 +191,9 @@ function compareNumber(n1: number, n2: number): number {
         result = 0
     }
     return result
+}
+
+function hasChecksumSyntax(s: string): boolean {
+    const re = /[a-z]+/
+    return s.length == 5 && re.test(s)
 }

--- a/src/utils/EthereumAddress.ts
+++ b/src/utils/EthereumAddress.ts
@@ -57,7 +57,7 @@ export class EthereumAddress {
             const view = new DataView(this.bytes.buffer)
             const bigNum = view.getBigInt64(12)
             const num = 0 <= bigNum && bigNum < EntityID.MAX_INT ? Number(bigNum) : null
-            result = num != null ? new EntityID(0, 0, num) : null
+            result = num != null ? new EntityID(0, 0, num, null) : null
         } else {
             result = null
         }

--- a/tests/unit/utils/EntityID.spec.ts
+++ b/tests/unit/utils/EntityID.spec.ts
@@ -20,7 +20,7 @@
  *
  */
 
-import {describe, test, expect} from 'vitest'
+import {describe, expect, test} from 'vitest'
 import {EntityID} from "@/utils/EntityID";
 
 describe("EntityID.ts", () => {
@@ -35,7 +35,17 @@ describe("EntityID.ts", () => {
         expect(obj?.shard).toBe(0)
         expect(obj?.realm).toBe(0)
         expect(obj?.num).toBe(0)
+        expect(obj?.checksum).toBeNull()
         expect(obj?.toString()).toBe(str)
+
+        const str2 = "0.0.0-abcde"
+        expect(EntityID.parse(str2)).toBeNull()
+        const obj2 = EntityID.parseWithChecksum(str2)
+        expect(obj2?.shard).toBe(0)
+        expect(obj2?.realm).toBe(0)
+        expect(obj2?.num).toBe(0)
+        expect(obj2?.checksum).toBe("abcde")
+        expect(obj2?.toString()).toBe(str)
     })
 
     test("1.1.1", () => {
@@ -44,7 +54,17 @@ describe("EntityID.ts", () => {
         expect(obj?.shard).toBe(1)
         expect(obj?.realm).toBe(1)
         expect(obj?.num).toBe(1)
+        expect(obj?.checksum).toBeNull()
         expect(obj?.toString()).toBe(str)
+
+        const str2 = "1.1.1-abcde"
+        expect(EntityID.parse(str2)).toBeNull()
+        const obj2 = EntityID.parseWithChecksum(str2)
+        expect(obj2?.shard).toBe(1)
+        expect(obj2?.realm).toBe(1)
+        expect(obj2?.num).toBe(1)
+        expect(obj2?.checksum).toBe("abcde")
+        expect(obj2?.toString()).toBe(str)
     })
 
     test("0.0.98", () => {
@@ -53,7 +73,17 @@ describe("EntityID.ts", () => {
         expect(obj?.shard).toBe(0)
         expect(obj?.realm).toBe(0)
         expect(obj?.num).toBe(98)
+        expect(obj?.checksum).toBeNull()
         expect(obj?.toString()).toBe(str)
+
+        const str2 = "0.0.98-abcde"
+        expect(EntityID.parse(str2)).toBeNull()
+        const obj2 = EntityID.parseWithChecksum(str2)
+        expect(obj2?.shard).toBe(0)
+        expect(obj2?.realm).toBe(0)
+        expect(obj2?.num).toBe(98)
+        expect(obj2?.checksum).toBe("abcde")
+        expect(obj2?.toString()).toBe(str)
     })
 
     test("0.0.721838", () => {
@@ -62,16 +92,38 @@ describe("EntityID.ts", () => {
         expect(obj?.shard).toBe(0)
         expect(obj?.realm).toBe(0)
         expect(obj?.num).toBe(721838)
+        expect(obj?.checksum).toBeNull()
         expect(obj?.toString()).toBe(str)
+
+        const str2 = "0.0.721838-abcde"
+        expect(EntityID.parse(str2)).toBeNull()
+        const obj2 = EntityID.parseWithChecksum(str2)
+        expect(obj2?.shard).toBe(0)
+        expect(obj2?.realm).toBe(0)
+        expect(obj2?.num).toBe(721838)
+        expect(obj2?.checksum).toBe("abcde")
+        expect(obj2?.toString()).toBe(str)
     })
 
     test("98", () => {
-        const obj = EntityID.parse("98")
-        expect(obj).toBeNull()
-        const obj2 = EntityID.parse("98", true)
+        const str = "98"
+        expect(EntityID.parse(str)).toBeNull()
+        const obj = EntityID.parse(str, true)
+        expect(obj?.shard).toBe(0)
+        expect(obj?.realm).toBe(0)
+        expect(obj?.num).toBe(98)
+        expect(obj?.checksum).toBeNull()
+        expect(obj?.toString()).toBe("0.0.98")
+
+        const str2 = "98-abcde"
+        expect(EntityID.parse(str2)).toBeNull()
+        expect(EntityID.parse(str2, true)).toBeNull()
+        expect(EntityID.parseWithChecksum(str2)).toBeNull()
+        const obj2 = EntityID.parseWithChecksum(str2, true, true)
         expect(obj2?.shard).toBe(0)
         expect(obj2?.realm).toBe(0)
         expect(obj2?.num).toBe(98)
+        expect(obj2?.checksum).toBe("abcde")
         expect(obj2?.toString()).toBe("0.0.98")
     })
 
@@ -83,6 +135,7 @@ describe("EntityID.ts", () => {
         expect(obj2?.shard).toBe(0)
         expect(obj2?.realm).toBe(0)
         expect(obj2?.num).toBe(veryBigNum)
+        expect(obj2?.checksum).toBeNull()
         expect(obj2?.toString()).toBe("0.0." + veryBigNum.toString())
     })
 


### PR DESCRIPTION
**Description**:

Changes below implements #861.

Explorer `Search Bar` now accepts an entity id with or without its checksum (`0.0.x` or `0.0.x-abcde`).
When specified, Explorer extracts and validates the checksum:
1) if checksum is invalid, explorer displays `No Result` page (and no request is made to mirror node)
2) if checksum is valid, Explorer proceeds to the usual search operation.


**Related issue(s)**:

Fixes #861 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
