### PR TITLE
fix: Expande/Collapse button makes rows disappear in `Call Trace` section

### DIFF
--- a/src/components/contract/ContractResultTrace.vue
+++ b/src/components/contract/ContractResultTrace.vue
@@ -92,10 +92,13 @@ export default defineComponent({
       return expandedActions.value.length == 0
     })
     const collapseAll = (): void => {
-      expandedActions.value = []
+      expandedActions.value.splice(0) // expandedActions must be muted for Oruga table to work properly
     }
     const expandAll = (): void => {
-      expandedActions.value = contractActionsLoader.actionsWithPath.value ?? []
+      collapseAll()
+      for (const a of contractActionsLoader.actionsWithPath.value ?? [])  {
+          expandedActions.value.push(a) // expandedActions must be muted for Oruga table to work properly
+      }
     }
 
     return {


### PR DESCRIPTION
**Description**:
With changes below, `ContractResultTrace` vue mutates `expandedActions` array in place of replacing its value.
This avoids to break row collapse/expand logic in Oruga table.

**Related issue(s)**:

Fixes #868

**Notes for reviewer**:

See #868 for test sequence.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
