### PR TITLE
fix: display verified contract name in call trace section

### DIFF
--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -34,17 +34,30 @@
       </Copyable>
       <span v-if="entityId && showId">
         <span class="ml-1">(</span>
-        <router-link v-if="entityLinkType === CONTRACT"
-                     :to="{name: 'ContractDetails', params: {contractId: entityId}}">{{ entityId }}</router-link>
-        <router-link v-else-if="entityLinkType === ACCOUNT"
-                     :to="{name: 'AccountDetails', params: {accountId: entityId}}">{{ entityId }}</router-link>
-        <router-link v-else-if="entityLinkType === TOKEN"
-                     :to="{name: 'TokenDetails', params: {tokenId: entityId}}">{{ entityId }}</router-link>
+        <router-link v-if="verified && !showType" :to="{name: 'ContractDetails', params: {contractId: entityId}}">
+            <span>{{ contractName }}</span>
+            <span class="icon is-small has-text-success ml-1"><i class="fas fa-check-circle"></i></span>
+        </router-link>
+        <router-link v-else-if="entityLinkType === CONTRACT" :to="{name: 'ContractDetails', params: {contractId: entityId}}">
+            {{ entityId }}
+        </router-link>
+        <router-link v-else-if="entityLinkType === ACCOUNT" :to="{name: 'AccountDetails', params: {accountId: entityId}}">
+            {{ entityId }}
+        </router-link>
+        <router-link v-else-if="entityLinkType === TOKEN" :to="{name: 'TokenDetails', params: {tokenId: entityId}}">
+            {{ entityId }}
+        </router-link>
         <span v-else>{{ entityId }}</span>
         <span>)</span>
       </span>
     </div>
-    <div v-if="showType" class="h-is-extra-text h-is-text-size-2">{{ entityType }}</div>
+    <div v-if="showType" class="h-is-text-size-2">
+      <span class="h-is-extra-text">{{ entityType }}</span>
+      <span v-if="verified" class="ml-1">{{ contractName }}</span>
+      <span v-if="verified" class="icon is-small has-text-success ml-1">
+        <i class="fas fa-check-circle"></i>
+      </span>
+    </div>
   </div>
   <div v-else-if="initialLoading"/>
   <div v-else-if="showNone" class="has-text-grey">None</div>
@@ -57,19 +70,21 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onMounted, PropType, ref, watch} from "vue";
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref, watch} from "vue";
 import {initialLoadingKey} from "@/AppKeys";
 import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {EthereumAddress} from "@/utils/EthereumAddress";
 import Copyable from "@/components/Copyable.vue";
 import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
+import ContractName from "@/components/values/ContractName.vue";
+import {ContractAnalyzer, GlobalState} from "@/utils/analyzer/ContractAnalyzer";
 
 export enum ExtendedEntityType { UNDEFINED, ACCOUNT, CONTRACT, TOKEN }
 
 export default defineComponent({
   name: "EVMAddress",
-  components: {Copyable},
+  components: {ContractName, Copyable},
   props: {
     address: {
       type: String as PropType<string|null>,
@@ -208,6 +223,13 @@ export default defineComponent({
       }
     }
 
+    const contractAnalyzer = new ContractAnalyzer(entityId)
+    onMounted(() => contractAnalyzer.mount())
+    onBeforeUnmount(() => contractAnalyzer.unmount())
+
+    const contractName = computed(() => contractAnalyzer.contractName.value)
+    const verified = computed(() => contractAnalyzer.globalState.value !== GlobalState.Unverified)
+
     return {
       isSmallScreen,
       ACCOUNT: ExtendedEntityType.ACCOUNT,
@@ -219,7 +241,9 @@ export default defineComponent({
       significantPart,
       entityId,
       evmAddress,
-      copyToClipboard
+      copyToClipboard,
+      contractName,
+      verified,
     }
   }
 })

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -39,15 +39,15 @@
             <span class="icon is-small has-text-success ml-1"><i class="fas fa-check-circle"></i></span>
         </router-link>
         <router-link v-else-if="entityLinkType === CONTRACT" :to="{name: 'ContractDetails', params: {contractId: entityId}}">
-            {{ entityId }}
+            {{ displayId }}
         </router-link>
         <router-link v-else-if="entityLinkType === ACCOUNT" :to="{name: 'AccountDetails', params: {accountId: entityId}}">
-            {{ entityId }}
+            {{ displayId }}
         </router-link>
         <router-link v-else-if="entityLinkType === TOKEN" :to="{name: 'TokenDetails', params: {tokenId: entityId}}">
-            {{ entityId }}
+            {{ displayId }}
         </router-link>
-        <span v-else>{{ entityId }}</span>
+        <span v-else>{{ displayId }}</span>
         <span>)</span>
       </span>
     </div>
@@ -72,7 +72,7 @@
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref, watch} from "vue";
 import {initialLoadingKey} from "@/AppKeys";
-import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
+import {SystemContractEntry, systemContractRegistry} from "@/schemas/SystemContractRegistry";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {EthereumAddress} from "@/utils/EthereumAddress";
 import Copyable from "@/components/Copyable.vue";
@@ -135,6 +135,7 @@ export default defineComponent({
     const entityLinkType = ref<ExtendedEntityType>(ExtendedEntityType.UNDEFINED)
     const evmAddress = ref<string|null>(null)
     const entityId = ref<string|null>(null)
+    const systemContract = ref<SystemContractEntry|null>(null)
     const ethereumAddress = computed( () => EthereumAddress.parse(evmAddress.value ?? ''))
     const derivedEntityId = computed( () => ethereumAddress.value?.toEntityID()?.toString() ?? null)
 
@@ -168,11 +169,8 @@ export default defineComponent({
     }
 
     const updateFromSystemContract = async (): Promise<boolean> => {
-      const systemContract = systemContractRegistry.lookup(derivedEntityId.value ?? "")
-      if (systemContract !== null) {
-        entityId.value = systemContract.description
-      }
-      return Promise.resolve(systemContract !== null)
+      systemContract.value = systemContractRegistry.lookup(derivedEntityId.value ?? "")
+      return Promise.resolve(systemContract.value !== null)
     }
 
     const updateFromAccount = async (): Promise<boolean> => {
@@ -194,6 +192,9 @@ export default defineComponent({
       }
       return Promise.resolve(contract !== null)
     }
+
+    const displayId = computed(
+        () => systemContract.value !== null ? systemContract.value.description : entityId.value)
 
     const displayAddress = computed(
         () => props.compact
@@ -240,6 +241,7 @@ export default defineComponent({
       nonSignificantPart,
       significantPart,
       entityId,
+      displayId,
       evmAddress,
       copyToClipboard,
       contractName,

--- a/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -69,7 +69,7 @@ describe("ContractResultLogEntry.vue", () => {
         expect(wrapper.get("#blockNumber").find("a").exists()).toBeTruthy
         expect(wrapper.get("#blockNumber").get("a").text()).toBe('9')
         expect(wrapper.get("#blockNumber").text()).toBe("Block9")
-        expect(wrapper.get("#address").text()).toBe("Address0x00000000000000000000000000000000000b70cfCopy(0.0.749775)")
+        expect(wrapper.get("#address").text()).toBe("Address0x00000000000000000000000000000000000b70cfCopy(TestEvent)")
         expect(wrapper.get("#Args").text()).toBe("LogsFlightEvent (string phase, int256 airspeed, int256 verticalSpeed)Topic 0  signature hash0x01f789d670afa3030578cc570ac4d43ace6f1575dd6c395a711e72a30051efd2string  phaseHolding pointint256  airspeed0int256  verticalSpeed0")
         expect(wrapper.get("#logArg_phase").text()).toBe("string  phaseHolding point")
         expect(wrapper.get("#logArg_airspeed").text()).toBe("int256  airspeed0")


### PR DESCRIPTION
**Description**:

EVMAddress is now able to display the name of the contract when the address is a verified contract.
This reflects on the `Call Trace` and `Contract States` sections.

**Related issue(s)**:

Fixes #873

**Notes for reviewer**:

Note this PR depends upon PR #871 which should be integrated first. 

<img width="1175" alt="Screenshot 2024-01-29 at 18 21 59" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/6a5fe546-ec13-4d43-b3b5-27d1a99e49d0">
<img width="1175" alt="Screenshot 2024-01-29 at 18 22 20" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/8d2f3615-2c79-4ed4-b75f-09a9cd0328bc">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
