### PR TITLE
fix: adjusted Metamask wallet discovery logic

### DIFF
--- a/src/utils/wallet/WalletDriver.ts
+++ b/src/utils/wallet/WalletDriver.ts
@@ -54,7 +54,7 @@ export abstract class WalletDriver {
 
     public extensionNotFound(): WalletDriverError {
         const message = this.name + " extension not found"
-        const extra = "Please install and activate " + this.name + " extension."
+        const extra = "Please install and/or activate " + this.name + " extension."
         return new WalletDriverError(message, extra)
     }
 

--- a/src/utils/wallet/WalletDriver_Metamask.ts
+++ b/src/utils/wallet/WalletDriver_Metamask.ts
@@ -49,7 +49,7 @@ export class WalletDriver_Metamask extends WalletDriver_Ethereum {
     //
 
     public async isExpectedProvider(provider: object): Promise<boolean> {
-        const result = "isMetaMask" in provider && provider.isMetaMask == true
+        const result = "isMetaMask" in provider && provider.isMetaMask == true && !("isBraveWallet" in provider)
         return Promise.resolve(result)
     }
 


### PR DESCRIPTION
**Description**:
In the context of the Brave Ethereum object, the addition of the .isMetamask = true attribute is necessary. Without this extra condition, clicking on the Metamask wallet could inadvertently trigger calls to the Brave wallet, leading to potential confusion. This modification ensures that Metamask functions seamlessly, preventing any unintended interactions with the Brave wallet. Specifically, it introduces a safeguard that triggers a 'Wallet not found' error if the wallet setting is configured to point to the Brave wallet. This enhancement enhances the overall user experience and maintains the expected behavior of Metamask.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
