### PR TITLE
chore: tentative fix for random break in unit tests

### DIFF
--- a/src/components/dashboard/MarketDataCache.ts
+++ b/src/components/dashboard/MarketDataCache.ts
@@ -95,9 +95,17 @@ export class MarketDataCache {
     }
 
     public clear(): void {
-        this.hbarPriceCache.requestLoad()
-        this.hbarPrice24hCache.requestLoad()
-        this.hbarSupplyCache.requestLoad()
-        this.hbarSupply24hCache.requestLoad()
+        if (this.hbarPriceCache.mounted.value) {
+            this.hbarPriceCache.requestLoad()
+        }
+        if (this.hbarPrice24hCache.mounted.value) {
+            this.hbarPrice24hCache.requestLoad()
+        }
+        if (this.hbarSupplyCache.mounted.value) {
+            this.hbarSupplyCache.requestLoad()
+        }
+        if (this.hbarSupply24hCache.mounted.value) {
+            this.hbarSupply24hCache.requestLoad()
+        }
     }
 }

--- a/src/utils/loader/AutoRefreshLoader.ts
+++ b/src/utils/loader/AutoRefreshLoader.ts
@@ -60,7 +60,7 @@ export abstract class AutoRefreshLoader<E> extends EntityLoader<E> {
 
     protected concludeLoad(): void {
         this.refreshCount.value += 1
-        if (this.refreshCount.value < this.maxRefreshCount && window /* to avoid unit test break in CI env */) {
+        if (this.refreshCount.value < this.maxRefreshCount) {
             this.timeoutID = window.setTimeout(() => {
                 this.requestLoad()
             }, this.refreshPeriod)


### PR DESCRIPTION
**Description**:

Changes below fix `MetadataCache.clear()` : this is suspected to be root cause of random breaks in unit tests.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
