### PR TITLE
fix: make Input and Output scrollable in Contract Result section

### DIFF
--- a/src/components/values/ByteCodeValue.vue
+++ b/src/components/values/ByteCodeValue.vue
@@ -26,7 +26,7 @@
 
     <div v-if="textValue" id="bytecode"
          class="h-code-box h-has-page-background pt-1 pl-3 pr-2 pb-2 mt-2 mr-1"
-         style="max-height: 400px;">
+         :style="{'max-height':heightInPixel+'px'}">
         <HexaValue :byte-string="textValue" :copyable="false"/>
     </div>
 
@@ -52,6 +52,10 @@ export default defineComponent({
 
     props: {
         byteCode: String,
+        heightInPixel: {
+            type: Number,
+            default: 400
+        }
     },
 
     setup(props) {

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -66,7 +66,7 @@
     <Property :custom-nb-col-class="customNbColClass" id="functionInput">
       <template v-slot:name>Input - Function & Args</template>
       <template v-slot:value>
-        <HexaValue :byte-string="input" :show-none="true"/>
+        <ByteCodeValue :byte-code="input" :heightInPixel="140"/>
         <div v-if="functionDecodingStatus" class="h-is-extra-text h-is-text-size-3">
             <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
             <span>{{ functionDecodingStatus }}</span>
@@ -90,10 +90,11 @@ import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";
 import SignatureValue from "@/components/values/SignatureValue.vue";
+import ByteCodeValue from "@/components/values/ByteCodeValue.vue";
 
 export default defineComponent({
   name: 'FunctionInput',
-  components: {SignatureValue, FunctionValue, Property, HexaValue},
+  components: {ByteCodeValue, SignatureValue, FunctionValue, Property, HexaValue},
   props: {
     analyzer: {
       type: Object as PropType<FunctionCallAnalyzer>,

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -51,7 +51,7 @@
       <Property :custom-nb-col-class="customNbColClass" id="functionInput">
           <template v-slot:name>Input Args</template>
           <template v-slot:value>
-            <HexaValue :byte-string="inputArgsOnly" :show-none="true"/>
+            <ByteCodeValue :byte-code="inputArgsOnly ?? undefined" :height-in-pixel="140"/>
             <div v-if="inputDecodingStatus" class="h-is-extra-text h-is-text-size-3">
               <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
               <span>{{ inputDecodingStatus }}</span>
@@ -85,7 +85,6 @@
 
 import {defineComponent, inject, PropType, ref} from 'vue';
 import {initialLoadingKey} from "@/AppKeys";
-import HexaValue from "@/components/values/HexaValue.vue";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";
@@ -94,7 +93,7 @@ import ByteCodeValue from "@/components/values/ByteCodeValue.vue";
 
 export default defineComponent({
   name: 'FunctionInput',
-  components: {ByteCodeValue, SignatureValue, FunctionValue, Property, HexaValue},
+  components: {ByteCodeValue, SignatureValue, FunctionValue, Property},
   props: {
     analyzer: {
       type: Object as PropType<FunctionCallAnalyzer>,

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -66,7 +66,7 @@
     <Property :custom-nb-col-class="customNbColClass" id="functionInput">
       <template v-slot:name>Input - Function & Args</template>
       <template v-slot:value>
-        <ByteCodeValue :byte-code="input" :heightInPixel="140"/>
+        <ByteCodeValue :byte-code="input ?? undefined" :heightInPixel="140"/>
         <div v-if="functionDecodingStatus" class="h-is-extra-text h-is-text-size-3">
             <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
             <span>{{ functionDecodingStatus }}</span>

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -43,7 +43,7 @@
         <Property :custom-nb-col-class="customNbColClass" id="functionOutput">
             <template v-slot:name>Output Result</template>
             <template v-slot:value>
-                <HexaValue :byte-string="output" :show-none="true"/>
+                <ByteCodeValue :byte-code="output" :heightInPixel="140"/>
                 <div v-if="outputDecodingStatus" class="h-is-extra-text h-is-text-size-3">
                     <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
                     <span>{{ outputDecodingStatus }}</span>
@@ -67,10 +67,11 @@ import HexaValue from "@/components/values/HexaValue.vue";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";
+import ByteCodeValue from "@/components/values/ByteCodeValue.vue";
 
 export default defineComponent({
   name: 'FunctionResult',
-  components: {FunctionValue, Property, HexaValue},
+  components: {ByteCodeValue, FunctionValue, Property, HexaValue},
   props: {
     analyzer: {
       type: Object as PropType<FunctionCallAnalyzer>,

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -43,7 +43,7 @@
         <Property :custom-nb-col-class="customNbColClass" id="functionOutput">
             <template v-slot:name>Output Result</template>
             <template v-slot:value>
-                <ByteCodeValue :byte-code="output ?? undefined" :heightInPixel="140"/>
+                <ByteCodeValue :byte-code="output ?? undefined" :height-in-pixel="140"/>
                 <div v-if="outputDecodingStatus" class="h-is-extra-text h-is-text-size-3">
                     <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
                     <span>{{ outputDecodingStatus }}</span>
@@ -63,7 +63,6 @@
 
 import {defineComponent, inject, PropType, ref} from 'vue';
 import {initialLoadingKey} from "@/AppKeys";
-import HexaValue from "@/components/values/HexaValue.vue";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";
@@ -71,7 +70,7 @@ import ByteCodeValue from "@/components/values/ByteCodeValue.vue";
 
 export default defineComponent({
   name: 'FunctionResult',
-  components: {ByteCodeValue, FunctionValue, Property, HexaValue},
+  components: {ByteCodeValue, FunctionValue, Property},
   props: {
     analyzer: {
       type: Object as PropType<FunctionCallAnalyzer>,

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -43,7 +43,7 @@
         <Property :custom-nb-col-class="customNbColClass" id="functionOutput">
             <template v-slot:name>Output Result</template>
             <template v-slot:value>
-                <ByteCodeValue :byte-code="output" :heightInPixel="140"/>
+                <ByteCodeValue :byte-code="output ?? undefined" :heightInPixel="140"/>
                 <div v-if="outputDecodingStatus" class="h-is-extra-text h-is-text-size-3">
                     <span class="icon fas fa-exclamation-circle has-text-grey is-small mt-1 mr-1"/>
                     <span>{{ outputDecodingStatus }}</span>


### PR DESCRIPTION
**Description**:

In Contract Result section, the properties Input - Function & Args and Output Result sometimes contain the whole contract bytecode or runtime bytecode which can make the section extremely long.
With this PR, we use ByteCodeValue instead of HexaValue for these properties to make them scrollable.

**Notes for reviewer**:

<img width="1477" alt="Screenshot 2024-02-01 at 19 09 17" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/fba8c772-4e47-4c51-a65c-4c6032fb05d3">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
