### PR TITLE
Fix: Better align contents of AccountTable and ContractTable.

### DIFF
--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -46,14 +46,14 @@
       aria-previous-label="Previous page"
       customRowKey="account"
   >
-    <o-table-column v-slot="props" field="account" label="Account">
+    <o-table-column v-slot="props" field="account" label="ID">
       <div class="is-numeric">
         {{ props.row.account }}
       </div>
     </o-table-column>
 
-    <o-table-column field="expiry" label="Expiry" v-slot="props">
-      <TimestampValue v-bind:timestamp="props.row?.expiration_timestamp" v-bind:show-none="true"/>
+    <o-table-column v-slot="props" field="created" label="Created">
+      <TimestampValue v-bind:timestamp="props.row.created_timestamp"/>
     </o-table-column>
 
     <o-table-column field="nb_tokens" label="Tokens" v-slot="props">
@@ -74,7 +74,7 @@
 
     <o-table-column v-slot="props" field="memo" label="Memo">
       <div class="w250">
-        <BlobValue v-bind:blob-value="props.row.memo_base64" v-bind:base64="true" v-bind:show-none="true"/>
+        <BlobValue v-bind:blob-value="props.row.memo" v-bind:base64="true" v-bind:show-none="true"/>
       </div>
     </o-table-column>
 

--- a/tests/unit/account/Accounts.spec.ts
+++ b/tests/unit/account/Accounts.spec.ts
@@ -70,10 +70,10 @@ describe("Accounts.vue", () => {
 
         const table = card.findComponent(AccountTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("Account Expiry Tokens Memo Balance")
+        expect(table.get('thead').text()).toBe("ID Created Tokens Memo Balance")
         expect(table.get('tbody').text()).toBe(
             "0.0.730631" +
-            "None" +
+            "5:12:31.6676 AMFeb 28, 2022, UTC" +
             "1023423" +
             "None" +
             "23.42647909"


### PR DESCRIPTION
**Description**:

- Column `Account` renamed `ID`
- Column `Expiry` replaced by column `Created`
- Fix the underlying API property name used to get the memo

**Notes for reviewer**:

<img width="1037" alt="Screenshot 2024-02-09 at 12 25 19" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/11943f2c-f2d7-4ec1-8ae9-2a42bf233374">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
