### PR TITLE
fix: provided a key attribute to force refresh prism component on re-renders (#894)

### DIFF
--- a/src/components/values/SourceCodeValue.vue
+++ b/src/components/values/SourceCodeValue.vue
@@ -28,7 +28,7 @@
           class="mt-2 h-code-box h-has-page-background" style="max-height: 400px;">
         <template  v-for="(file, index) in sourceFiles">
             <p v-if="isFiltered(file)" class="pt-2 mx-3 h-is-extra-text">{{ file.name }}</p>
-            <prism v-if="isFiltered(file)" language="solidity" style="background-color: #171920; font-size: 0.7rem">
+            <prism v-if="isFiltered(file)" :key="file.name" language="solidity" style="background-color: #171920; font-size: 0.7rem">
                 <pre>{{ file.content }}</pre>
             </prism>
             <hr v-if="filter==='' && index < sourceFiles.length - 1" class="has-background-grey-dark m-0" style="height: 0.5px"/>

--- a/src/components/values/SourceCodeValue.vue
+++ b/src/components/values/SourceCodeValue.vue
@@ -26,9 +26,9 @@
 <template>
     <div  v-if="sourceFiles.length > 0"  id="source-code"
           class="mt-2 h-code-box h-has-page-background" style="max-height: 400px;">
-        <template  v-for="(file, index) in sourceFiles">
+        <template  v-for="(file, index) in sourceFiles" :key="file.path">
             <p v-if="isFiltered(file)" class="pt-2 mx-3 h-is-extra-text">{{ file.name }}</p>
-            <prism v-if="isFiltered(file)" :key="file.name" language="solidity" style="background-color: #171920; font-size: 0.7rem">
+            <prism v-if="isFiltered(file)" language="solidity" style="background-color: #171920; font-size: 0.7rem">
                 <pre>{{ file.content }}</pre>
             </prism>
             <hr v-if="filter==='' && index < sourceFiles.length - 1" class="has-background-grey-dark m-0" style="height: 0.5px"/>


### PR DESCRIPTION
**Description**:
Currently on Hashscan, we utilize an external library `prismjs` to display the solidity smart contract. This `prismjs` component wraps around the source solidity file as its child component. However, the `prismjs` component does not update its child components on re-renders. Therefore, this PR pushes in a fix that forces the prism component to refresh by supplying it with a dynamic unique `key` attribute.

**Related issue(s)**:

Fixes #894 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
