### PR TITLE
feat: display contracts created by account in AccountDetails

### DIFF
--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -134,6 +134,21 @@ export class AppStorage {
     }
 
     //
+    // preferred tab in account operations
+    //
+
+    private static readonly ACCOUNT_OPERATION_TAB_KEY = 'accountOperationTab'
+
+    public static getAccountOperationTab(): number | null {
+        const tab = this.getLocalStorageItem(this.ACCOUNT_OPERATION_TAB_KEY)
+        return tab != null ? Number(tab) : null
+    }
+
+    public static setAccountOperationTab(newValue: number | null): void {
+        this.setLocalStorageItem(this.ACCOUNT_OPERATION_TAB_KEY, newValue?.toString() ?? null)
+    }
+
+    //
     // Private
     //
 

--- a/src/assets/styles/explorer-oruga.scss
+++ b/src/assets/styles/explorer-oruga.scss
@@ -45,7 +45,7 @@ $select-arrow-size: 0.75rem;
 $select-height: 26px;
 $select-line-height: 1;
 $select-padding: 0 8px;
-
+$switch-active-background-color: $h-background-color;
 // Import Oruga
 @import '../../../node_modules/@oruga-ui/oruga-next/src/scss/oruga-full-vars';
 

--- a/src/components/EmptyTable.vue
+++ b/src/components/EmptyTable.vue
@@ -24,8 +24,8 @@
 
 <template>
   <div class="has-text-centered h-is-tertiary-text-text has-text-grey mb-4">
-    <span v-if="initialLoading">Loading…</span>
-    <span v-else>No Data</span>
+    <span v-if="initialLoading || loading">Loading…</span>
+    <span v-else>{{ noDataMessage }}</span>
   </div>
 </template>
 
@@ -40,6 +40,17 @@ import {initialLoadingKey} from "@/AppKeys";
 
 export default defineComponent({
   name: "EmptyTable",
+
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    },
+    noDataMessage: {
+      type: String,
+      default: 'No data'
+    }
+  },
 
   setup() {
     const initialLoading = inject(initialLoadingKey, ref(false))

--- a/src/components/PlayPauseButton.vue
+++ b/src/components/PlayPauseButton.vue
@@ -63,14 +63,19 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, onMounted, PropType, ref} from "vue";
-import {TableController} from "@/utils/table/TableController";
+import {computed, ComputedRef, defineComponent, onMounted, PropType, ref} from "vue";
+
+export interface PlayPauseController {
+    startAutoRefresh(): void
+    stopAutoRefresh(): void
+    autoRefresh: ComputedRef<boolean>
+}
 
 export default defineComponent({
   name: "PlayPauseButton",
 
   props: {
-    controller: Object as PropType<TableController<unknown, unknown>>
+    controller: Object as PropType<PlayPauseController>
   },
 
   setup(props) {

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -23,8 +23,8 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-    <div  class="is-flex is-justify-content-space-between is-align-items-center mt-5 mb-4">
-        <div class="tabs is-toggle h-is-property-text mb-1" >
+    <div class="is-flex is-justify-content-space-between is-align-items-center mt-5 mb-4">
+        <div class="tabs is-toggle h-is-property-text mb-1">
             <ul>
                 <li v-for="(tab, i) in tabs" :key="i" :class="{'is-active':selectedTab===i}">
                     <a :id="cssId + '-' + i" :style="{ fontWeight: selectedTab===i?500:300 }"
@@ -46,39 +46,39 @@
 import {defineComponent, PropType, ref} from "vue";
 
 export default defineComponent({
-  name: "Tabs",
+    name: "Tabs",
 
-  props: {
-      selectedTab: {
-          type: Number,
-          required: true
-      },
-      tabs: {
-          type: Array as PropType<string[]>,
-          required: true
-      },
-      cssId: {
-          type: String,
-          default: 'tab'
-      }
-  },
+    props: {
+        selectedTab: {
+            type: Number,
+            required: true
+        },
+        tabs: {
+            type: Array as PropType<string[]>,
+            required: true
+        },
+        cssId: {
+            type: String,
+            default: 'tab'
+        }
+    },
 
-  emits: ["update:selectedTab"],
+    emits: ["update:selectedTab"],
 
-  setup(props, context) {
+    setup(props, context) {
 
-      const selection = ref(props.selectedTab)
+        const selection = ref(props.selectedTab)
 
-      const handleSelect = (tab: number) => {
-          selection.value = tab
-          context.emit('update:selectedTab', tab)
-      }
+        const handleSelect = (tab: number) => {
+            selection.value = tab
+            context.emit('update:selectedTab', tab)
+        }
 
-    return {
-        selection,
-        handleSelect,
+        return {
+            selection,
+            handleSelect,
+        }
     }
-  }
 });
 
 </script>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,0 +1,90 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                 -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+    <div  class="is-flex is-justify-content-space-between is-align-items-center mt-5 mb-4">
+        <div class="tabs is-toggle h-is-property-text mb-1" >
+            <ul>
+                <li v-for="(tab, i) in tabs" :key="i" :class="{'is-active':selectedTab===i}">
+                    <a :id="cssId + '-' + i" :style="{ fontWeight: selectedTab===i?500:300 }"
+                       @click="handleSelect(i)">
+                        <span>{{ tab }}</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, PropType, ref} from "vue";
+
+export default defineComponent({
+  name: "Tabs",
+
+  props: {
+      selectedTab: {
+          type: Number,
+          required: true
+      },
+      tabs: {
+          type: Array as PropType<string[]>,
+          required: true
+      },
+      cssId: {
+          type: String,
+          default: 'tab'
+      }
+  },
+
+  emits: ["update:selectedTab"],
+
+  setup(props, context) {
+
+      const selection = ref(props.selectedTab)
+
+      const handleSelect = (tab: number) => {
+          selection.value = tab
+          context.emit('update:selectedTab', tab)
+      }
+
+    return {
+        selection,
+        handleSelect,
+    }
+  }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -1,0 +1,131 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+    <o-table
+        v-model:current-page="currentPage"
+        :data="transactions"
+        :hoverable="true"
+        :loading="loading"
+        :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
+        :narrowed="true"
+        :paginated="paginated"
+        :per-page="perPage"
+        :striped="true"
+
+        :total="total"
+        aria-current-label="Current page"
+        aria-next-label="Next page"
+        aria-page-label="Page"
+
+        aria-previous-label="Previous page"
+        backend-pagination
+        customRowKey="consensus_timestamp"
+        default-sort="consensus_timestamp"
+        @page-change="onPageChange"
+        @cell-click="handleClick"
+    >
+
+        <o-table-column v-slot="props" field="contract_id" label="ID">
+            <div class="is-numeric">
+                {{ props.row.entity_id }}
+            </div>
+        </o-table-column>
+
+        <o-table-column v-slot="props" field="contract_name" label="Contract Name">
+            <ContractName :contract-id="props.row.entity_id"/>
+        </o-table-column>
+
+        <o-table-column v-slot="props" field="created" label="Created">
+            <TimestampValue v-bind:timestamp="props.row.consensus_timestamp"/>
+        </o-table-column>
+
+    </o-table>
+
+    <EmptyTable v-if="!transactions.length"/>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {ComputedRef, defineComponent, onBeforeUnmount, onMounted, PropType, Ref} from 'vue';
+import {Transaction} from "@/schemas/HederaSchemas";
+import TimestampValue from "@/components/values/TimestampValue.vue";
+import {routeManager} from "@/router";
+import BlobValue from "@/components/values/BlobValue.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import EmptyTable from "@/components/EmptyTable.vue";
+import {TransactionTableController} from "@/components/transaction/TransactionTableController";
+import ContractName from "@/components/values/ContractName.vue";
+
+export default defineComponent({
+    name: 'AccountCreatedContractsTable',
+
+    components: {ContractName, EmptyTable, TimestampValue, BlobValue},
+
+    props: {
+        controller: {
+            type: Object as PropType<TransactionTableController>,
+            required: true
+        }
+    },
+
+    setup(props) {
+
+        onMounted(() => props.controller.mount())
+        onBeforeUnmount(() => props.controller.unmount())
+
+        const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+            routeManager.routeToContract(t.entity_id!, event.ctrlKey || event.metaKey)
+        }
+
+        return {
+            transactions: props.controller.rows as ComputedRef<Transaction[]>,
+            loading: props.controller.loading as ComputedRef<boolean>,
+            total: props.controller.totalRowCount as ComputedRef<number>,
+            currentPage: props.controller.currentPage as Ref<number>,
+            onPageChange: props.controller.onPageChange,
+            perPage: props.controller.pageSize as Ref<number>,
+            paginated: props.controller.paginated as ComputedRef<boolean>,
+            handleClick,
+            // From App
+            ORUGA_MOBILE_BREAKPOINT,
+        }
+    }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+</style>

--- a/src/components/account/AccountVerifiedContractsTable.vue
+++ b/src/components/account/AccountVerifiedContractsTable.vue
@@ -1,0 +1,128 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+    <o-table
+        :data="contracts"
+        :paginated="contracts.length > perPage"
+        :per-page="perPage"
+        :narrowed="true"
+        @cell-click="handleClick"
+
+        :hoverable="true"
+        :striped="true"
+        :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
+
+        aria-current-label="Current page"
+        aria-next-label="Next page"
+        aria-page-label="Page"
+        aria-previous-label="Previous page"
+        customRowKey="contract_id"
+    >
+
+        <o-table-column v-slot="props" field="contract_id" label="ID">
+            <div class="is-numeric">
+                {{ props.row.contract_id }}
+            </div>
+        </o-table-column>
+
+        <o-table-column v-slot="props" field="contract_name" label="Contract Name">
+            <ContractName :contract-id="props.row.contract_id"/>
+        </o-table-column>
+
+        <o-table-column v-slot="props" field="created" label="Created">
+            <TimestampValue v-bind:timestamp="props.row.created_timestamp"/>
+        </o-table-column>
+
+    </o-table>
+
+    <EmptyTable v-if="!contracts.length" :no-data-message="noDataMessage" :loading="!loaded"/>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from 'vue';
+import {Transaction} from "@/schemas/HederaSchemas";
+import TimestampValue from "@/components/values/TimestampValue.vue";
+import {routeManager} from "@/router";
+import BlobValue from "@/components/values/BlobValue.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import EmptyTable from "@/components/EmptyTable.vue";
+import ContractName from "@/components/values/ContractName.vue";
+import {VerifiedContractsController} from "@/components/contract/VerifiedContractsController";
+
+export default defineComponent({
+    name: 'AccountVerifiedContractsTable',
+
+    components: {ContractName, EmptyTable, TimestampValue, BlobValue},
+
+    props: {
+        controller: {
+            type: Object as PropType<VerifiedContractsController>,
+            required: true
+        },
+        loaded: Boolean,
+        overflow: Boolean
+    },
+
+    setup(props) {
+        const perPage = 10
+        const noDataMessage = computed(() =>
+            props.overflow
+                ? 'No verified contract found in the last ' + props.controller.capacity + ' created contracts'
+                :  'No verified contract'
+        )
+
+        onMounted( () => props.controller.mount())
+        onBeforeUnmount(() => props.controller.unmount())
+
+        const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+            routeManager.routeToContract(t.entity_id!, event.ctrlKey || event.metaKey)
+        }
+
+        return {
+            perPage,
+            noDataMessage,
+            handleClick,
+            ORUGA_MOBILE_BREAKPOINT,
+            contracts:props.controller.contracts,
+        }
+    }
+});
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+</style>

--- a/src/components/account/AccountVerifiedContractsTable.vue
+++ b/src/components/account/AccountVerifiedContractsTable.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         const noDataMessage = computed(() =>
             props.overflow
                 ? 'No verified contract found in the last ' + props.controller.capacity + ' created contracts'
-                :  'No verified contract'
+                :  'No data'
         )
 
         onMounted( () => props.controller.mount())

--- a/src/components/account/AccountVerifiedContractsTable.vue
+++ b/src/components/account/AccountVerifiedContractsTable.vue
@@ -26,20 +26,20 @@
 
     <o-table
         :data="contracts"
-        :paginated="contracts.length > perPage"
-        :per-page="perPage"
-        :narrowed="true"
-        @cell-click="handleClick"
-
         :hoverable="true"
-        :striped="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
+        :narrowed="true"
+        :paginated="contracts.length > perPage"
 
+        :per-page="perPage"
+        :striped="true"
         aria-current-label="Current page"
+
         aria-next-label="Next page"
         aria-page-label="Page"
         aria-previous-label="Previous page"
         customRowKey="contract_id"
+        @cell-click="handleClick"
     >
 
         <o-table-column v-slot="props" field="contract_id" label="ID">
@@ -58,7 +58,7 @@
 
     </o-table>
 
-    <EmptyTable v-if="!contracts.length" :no-data-message="noDataMessage" :loading="!loaded"/>
+    <EmptyTable v-if="!contracts.length" :loading="!loaded" :no-data-message="noDataMessage"/>
 
 </template>
 
@@ -97,10 +97,10 @@ export default defineComponent({
         const noDataMessage = computed(() =>
             props.overflow
                 ? 'No verified contract found in the last ' + props.controller.capacity + ' created contracts'
-                :  'No data'
+                : 'No data'
         )
 
-        onMounted( () => props.controller.mount())
+        onMounted(() => props.controller.mount())
         onBeforeUnmount(() => props.controller.unmount())
 
         const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
@@ -112,7 +112,7 @@ export default defineComponent({
             noDataMessage,
             handleClick,
             ORUGA_MOBILE_BREAKPOINT,
-            contracts:props.controller.contracts,
+            contracts: props.controller.contracts,
         }
     }
 });

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -78,7 +78,7 @@
 
 <script lang="ts">
 
-import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
+import {ComputedRef, defineComponent, inject, onBeforeUnmount, onMounted, PropType, Ref} from 'vue';
 import {Contract} from "@/schemas/HederaSchemas";
 import {routeManager} from "@/router";
 import BlobValue from "@/components/values/BlobValue.vue";
@@ -112,6 +112,9 @@ export default defineComponent({
   setup(props) {
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
+
+    onMounted(() => props.controller.mount())
+    onBeforeUnmount(() => props.controller.unmount())
 
     const handleClick = (contract: Contract, c: unknown, i: number, ci: number, event: MouseEvent) => {
       if (contract.contract_id) {

--- a/src/components/contract/VerifiedContractsController.ts
+++ b/src/components/contract/VerifiedContractsController.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {computed, ComputedRef, ref, Ref, watch} from "vue";
+import {computed, ComputedRef, ref, Ref} from "vue";
 import {PlayPauseController} from "@/components/PlayPauseButton.vue";
 import {Contract} from "@/schemas/HederaSchemas";
 import {VerifiedContractsBuffer, VerifiedContractsByAccountCache} from "@/utils/cache/VerifiedContractsByAccountCache";
@@ -46,8 +46,6 @@ export class VerifiedContractsController implements PlayPauseController {
     public overflow = ref(false)
 
     public mount(): void {
-        watch(this.contracts, ()=>console.log(`contracts.length: ${this.contracts.value.length}`))
-        console.log(`VerifiedContractsController.mount`)
         this.contractsLookup.mount()
     }
 

--- a/src/components/contract/VerifiedContractsController.ts
+++ b/src/components/contract/VerifiedContractsController.ts
@@ -86,17 +86,12 @@ export class VerifiedContractsController implements PlayPauseController {
     private timeoutID = -1
     private maxRefreshCount = 10
     private refreshCount = 0
-    private autoRefreshRef: Ref<boolean> = ref(false)
+    private autoRefreshRef: Ref<boolean> = ref(true)
 
     private async refresh(): Promise<void> {
-        this.autoRefreshRef.value = true
         if (this.contractsLookup.entity.value != null) {
-            this.contractsLookup.entity.value.update().catch(this.errorHandler)
-            this.contractsLookup.entity.value.contracts.forEach((c) => {
-                if (!this.contracts.value.includes(c)) {
-                    this.contracts.value.unshift(c)
-                }
-            })
+            await this.contractsLookup.entity.value.update().catch(this.errorHandler)
+            this.contracts.value = this.contractsLookup.entity.value.contracts
         }
         this.refreshCount += 1
         if (this.refreshCount < this.maxRefreshCount) {

--- a/src/components/contract/VerifiedContractsController.ts
+++ b/src/components/contract/VerifiedContractsController.ts
@@ -47,9 +47,9 @@ export class VerifiedContractsController implements PlayPauseController {
     }
 
 
-    public mount(): void {
+    public async mount(): Promise<void> {
         this.contractsLookup.mount()
-        this.refresh()
+        await this.refresh()
     }
 
     public unmount(): void {
@@ -63,11 +63,11 @@ export class VerifiedContractsController implements PlayPauseController {
 
     public readonly autoRefresh: ComputedRef<boolean> = computed(() => this.autoRefreshRef.value)
 
-    public startAutoRefresh(): void {
+    public async startAutoRefresh(): Promise<void> {
         if (!this.autoRefreshRef.value) {
             this.autoRefreshRef.value = true
             this.refreshCount = 0
-            this.refresh()
+            await this.refresh()
         }
     }
 
@@ -102,11 +102,8 @@ export class VerifiedContractsController implements PlayPauseController {
         return Promise.resolve()
     }
 
-    private scheduleNextRefresh(): void  {
-        this.timeoutID = window.setTimeout(
-            () => this.refresh(),
-            this.updatePeriod
-        )
+    private scheduleNextRefresh(): void {
+        this.timeoutID = window.setTimeout(() => this.refresh(), this.updatePeriod)
     }
 
     private cancelNextRefresh(): void {

--- a/src/components/contract/VerifiedContractsController.ts
+++ b/src/components/contract/VerifiedContractsController.ts
@@ -40,10 +40,9 @@ export class VerifiedContractsController implements PlayPauseController {
         return this.contractsLookup.entity.value?.contracts ?? []
     })
 
-    public capacity = 250
-
-    public loaded = ref(false)
-    public overflow = ref(false)
+    public capacity = VerifiedContractsBuffer.MAX_CANDIDATES
+    public overflow = computed(() => this.contractsLookup.entity.value?.overflow ?? false)
+    public loaded = computed(() => this.contractsLookup.entity.value != null)
 
     public mount(): void {
         this.contractsLookup.mount()

--- a/src/components/contract/VerifiedContractsController.ts
+++ b/src/components/contract/VerifiedContractsController.ts
@@ -21,7 +21,7 @@
 import {computed, ComputedRef, ref, Ref, watch} from "vue";
 import {PlayPauseController} from "@/components/PlayPauseButton.vue";
 import {Contract} from "@/schemas/HederaSchemas";
-import {VerifiedContractsBuffer, VerifiedContractsByAccountCache} from "@/utils/cache/VerifiedContractsByAccountCache";
+import {VerifiedContractsBuffer, VerifiedContractsByAccountIdCache} from "@/utils/cache/VerifiedContractsByAccountIdCache";
 import {Lookup} from "@/utils/cache/base/EntityCache";
 import axios, {AxiosError} from "axios";
 
@@ -39,7 +39,7 @@ export class VerifiedContractsController implements PlayPauseController {
     public loaded = computed(() => this.contractsLookup.entity.value != null)
 
     public constructor(accountId: Ref<string | null>) {
-        this.contractsLookup = VerifiedContractsByAccountCache.instance.makeLookup(accountId)
+        this.contractsLookup = VerifiedContractsByAccountIdCache.instance.makeLookup(accountId)
         watch(
             this.contractsLookup.entity,
             () => this.contracts.value = this.contractsLookup.entity.value?.contracts ?? []

--- a/src/components/contract/VerifiedContractsController.ts
+++ b/src/components/contract/VerifiedContractsController.ts
@@ -1,0 +1,85 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, ComputedRef, ref, Ref, watch} from "vue";
+import {PlayPauseController} from "@/components/PlayPauseButton.vue";
+import {Contract} from "@/schemas/HederaSchemas";
+import {VerifiedContractsBuffer, VerifiedContractsByAccountCache} from "@/utils/cache/VerifiedContractsByAccountCache";
+import {Lookup} from "@/utils/cache/base/EntityCache";
+
+export class VerifiedContractsController implements PlayPauseController {
+
+    private contractsLookup: Lookup<string, VerifiedContractsBuffer | null>
+
+    //
+    // Public
+    //
+
+    public constructor(accountId: Ref<string | null>) {
+        this.contractsLookup = VerifiedContractsByAccountCache.instance.makeLookup(accountId)
+    }
+
+    public readonly contracts: ComputedRef<Contract[]> = computed(() => {
+        return this.contractsLookup.entity.value?.contracts ?? []
+    })
+
+    public capacity = 250
+
+    public loaded = ref(false)
+    public overflow = ref(false)
+
+    public mount(): void {
+        watch(this.contracts, ()=>console.log(`contracts.length: ${this.contracts.value.length}`))
+        console.log(`VerifiedContractsController.mount`)
+        this.contractsLookup.mount()
+    }
+
+    public unmount(): void {
+        this.contractsLookup.unmount()
+    }
+
+    //
+    // PlayPauseController
+    //
+
+    public autoRefresh: ComputedRef<boolean> = computed(() => this.autoRefreshRef.value)
+
+    public startAutoRefresh(): void {
+
+    }
+
+    public stopAutoRefresh(): void  {
+
+    }
+
+    //
+    // Private
+    //
+
+    private readonly autoRefreshRef: Ref<boolean> = ref(false)
+
+    // private readonly errorHandler = (reason: unknown): void => {
+    //     console.log("reason=" + reason)
+    //     if (axios.isAxiosError(reason)) {
+    //         const axiosError = reason as AxiosError
+    //         console.log("url=" + axiosError.config?.url)
+    //     }
+    // }
+}

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -67,7 +67,7 @@
 
 <script lang="ts">
 
-import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
+import {ComputedRef, defineComponent, inject, onBeforeUnmount, onMounted, PropType, Ref} from 'vue';
 import {StakingReward} from '@/schemas/HederaSchemas';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
@@ -93,6 +93,9 @@ export default defineComponent({
   setup(props) {
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
+
+    onMounted(() => props.controller.mount())
+    onBeforeUnmount(() => props.controller.unmount())
 
     const handleClick = (t: StakingReward, c: unknown, i: number, ci: number, event: MouseEvent) => {
       if (t.timestamp) {

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -80,7 +80,7 @@
 
 <script lang="ts">
 
-import {computed, ComputedRef, defineComponent, inject, PropType, Ref} from "vue";
+import {computed, ComputedRef, defineComponent, inject, onBeforeUnmount, onMounted, PropType, Ref} from "vue";
 import {Transaction, TransactionType} from "@/schemas/HederaSchemas";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -108,6 +108,9 @@ export default defineComponent({
   setup(props) {
     const isTouchDevice = inject('isTouchDevice', false)
     const isMediumScreen = inject('isMediumScreen', true)
+
+    onMounted(() => props.controller.mount())
+    onBeforeUnmount(() => props.controller.unmount())
 
     const showingEthereumTransactions = computed(() => {
       return props.controller.transactionType.value === TransactionType.ETHEREUMTRANSACTION

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -28,7 +28,7 @@
   <o-table
       :data="transactions"
       :loading="loading"
-      paginated
+      :paginated="paginated"
       backend-pagination
       :total="total"
       v-model:current-page="currentPage"
@@ -129,6 +129,7 @@ export default defineComponent({
       currentPage: props.controller.currentPage as Ref<number>,
       onPageChange: props.controller.onPageChange,
       perPage: props.controller.pageSize as Ref<number>,
+      paginated: props.controller.paginated as ComputedRef<boolean>,
       showingEthereumTransactions,
       handleClick,
       makeTypeLabel,

--- a/src/components/transaction/TransactionTableController.ts
+++ b/src/components/transaction/TransactionTableController.ts
@@ -20,13 +20,14 @@
 
 import {KeyOperator, SortOrder, TableController} from "@/utils/table/TableController";
 import {Transaction, TransactionResponse} from "@/schemas/HederaSchemas";
-import {ComputedRef} from "vue";
+import {ComputedRef, ref, Ref} from "vue";
 import axios, {AxiosResponse} from "axios";
 import {Router} from "vue-router";
 
 
 export class TransactionTableController extends TableController<Transaction, string> {
 
+    private readonly accountId: Ref<string | null>
     private readonly transactionType: string
     private readonly transactionResult: string
 
@@ -37,11 +38,15 @@ export class TransactionTableController extends TableController<Transaction, str
     public constructor(router: Router, pageSize: ComputedRef<number>,
                        transactionType = "",
                        transactionResult= "",
-                       pageParamName = "p", keyParamName= "k") {
+                       pageParamName = "p",
+                       keyParamName= "k",
+                       accountId: Ref<string | null> = ref(null)) {
         super(router, pageSize, 10 * pageSize.value, 5000, 10, 100,
             pageParamName, keyParamName);
         this.transactionType = transactionType
         this.transactionResult = transactionResult
+        this.accountId = accountId
+        this.watchAndReload([this.accountId])
     }
 
     //
@@ -57,6 +62,7 @@ export class TransactionTableController extends TableController<Transaction, str
             transactiontype: string | undefined
             result: string | undefined
             timestamp: string | undefined
+            "account.id": string | undefined
         }
         params.limit = limit
         params.order = order
@@ -65,6 +71,9 @@ export class TransactionTableController extends TableController<Transaction, str
         }
         if (this.transactionResult != "") {
             params.result = this.transactionResult
+        }
+        if (this.accountId.value !== null) {
+            params["account.id"] = this.accountId.value
         }
         if (consensusTimestamp !== null) {
             params.timestamp = operator + ":" + consensusTimestamp

--- a/src/components/values/ContractName.vue
+++ b/src/components/values/ContractName.vue
@@ -33,8 +33,8 @@
                 {{ name }}
             </span>
         </div>
-        <span v-else-if="true" class="h-has-pill h-has-page-background has-text-grey has-text-weight-normal">
-            not verified
+        <span v-else-if="true" class="h-has-pill h-has-page-background has-text-grey has-text-weight-normal h-is-text-size-1">
+            NOT VERIFIED
         </span>
     </template>
 </template>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -223,7 +223,12 @@
               <TransactionFilterSelect :controller="transactionTableController"/>
           </div>
           <div v-else-if="selectedTab===1" class="is-flex is-justify-content-end is-align-items-center">
-              <PlayPauseButton :controller="contractCreateTableController"/>
+              <PlayPauseButton v-if="!filterVerified" :controller="contractCreateTableController"/>
+              <PlayPauseButton v-else :controller="verifiedContractsController"/>
+              <span class="ml-5 mr-2">All</span>
+              <o-field>
+                  <o-switch v-model="filterVerified">Verified</o-switch>
+              </o-field>
           </div>
       </template>
       <template v-slot:content>
@@ -239,7 +244,12 @@
           </div>
 
           <div v-else-if="selectedTab===1" id="recentContractsTable">
-              <AccountCreatedContractsTable v-if="account" :controller="contractCreateTableController"/>
+              <AccountCreatedContractsTable v-if="account && !filterVerified" :controller="contractCreateTableController"/>
+              <AccountVerifiedContractsTable
+                  v-else-if="account"
+                  :controller="verifiedContractsController"
+                  :loaded="loaded"
+                  :overflow="overflow"/>
               <EmptyTable v-else/>
           </div>
 
@@ -297,12 +307,14 @@ import InfoTooltip from "@/components/InfoTooltip.vue";
 import Copyable from "@/components/Copyable.vue";
 import InlineBalancesValue from "@/components/values/InlineBalancesValue.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
-import EmptyTable from "@/components/EmptyTable.vue";
-import AccountCreatedContractsTable from "@/components/account/AccountCreatedContractsTable.vue";
 import {TransactionType} from "@/schemas/HederaSchemas";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
+import EmptyTable from "@/components/EmptyTable.vue";
+import AccountVerifiedContractsTable from "@/components/account/AccountVerifiedContractsTable.vue";
 import {AppStorage} from "@/AppStorage";
 import Tabs from "@/components/Tabs.vue";
+import {VerifiedContractsController} from "@/components/contract/VerifiedContractsController";
+import AccountCreatedContractsTable from "@/components/account/AccountCreatedContractsTable.vue";
 
 export default defineComponent({
 
@@ -310,6 +322,7 @@ export default defineComponent({
 
   components: {
     AccountCreatedContractsTable,
+    AccountVerifiedContractsTable,
     EmptyTable,
     Tabs,
     MirrorLink,
@@ -411,6 +424,7 @@ export default defineComponent({
       selectedTab.value = tab
       AppStorage.setAccountOperationTab(tab)
     }
+    const filterVerified = ref(false)
 
     //
     // Table controllers and cache for Recent Account Operations
@@ -425,6 +439,8 @@ export default defineComponent({
     const contractCreateTableController = new TransactionTableController(
         router, perPage, TransactionType.CONTRACTCREATEINSTANCE, "success", "p3", "k3", accountId)
 
+    const verifiedContractsController = new VerifiedContractsController(accountId)
+
     const rewardsTableController = new StakingRewardsTableController(
         router, accountLocParser.accountId, perPage, "p2", "k2")
 
@@ -434,6 +450,9 @@ export default defineComponent({
       isTouchDevice,
       transactionTableController,
       contractCreateTableController,
+      verifiedContractsController,
+      loaded: verifiedContractsController.loaded,
+      overflow: verifiedContractsController.overflow,
       notification: accountLocParser.errorNotification,
       isInactiveEvmAddress: accountLocParser.isInactiveEvmAddress,
       account: accountLocParser.accountInfo,
@@ -457,6 +476,7 @@ export default defineComponent({
       selectedTab,
       tabLabels,
       handleTabUpdate,
+      filterVerified,
     }
   }
 });

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -218,11 +218,11 @@
         <p id="recentTransactions" class="h-is-secondary-title">Recent Account Operations</p>
       </template>
       <template v-slot:control>
-          <div v-if="selectedTab===0" class="is-flex is-align-items-flex-end">
+          <div v-if="selectedTab === 0" class="is-flex is-align-items-flex-end">
               <PlayPauseButton :controller="transactionTableController"/>
               <TransactionFilterSelect :controller="transactionTableController"/>
           </div>
-          <div v-else-if="selectedTab===1" class="is-flex is-justify-content-end is-align-items-center">
+          <div v-else-if="selectedTab === 1" class="is-flex is-justify-content-end is-align-items-center">
               <PlayPauseButton v-if="!filterVerified" :controller="contractCreateTableController"/>
               <PlayPauseButton v-else :controller="verifiedContractsController"/>
               <span class="ml-5 mr-2">All</span>
@@ -239,11 +239,11 @@
               css-id="operations-tab"
           />
 
-          <div v-if="selectedTab===0" id="recentTransactionsTable">
+          <div v-if="selectedTab === 0" id="recentTransactionsTable">
               <TransactionTable v-if="account" :controller="transactionTableController" :narrowed="true"/>
           </div>
 
-          <div v-else-if="selectedTab===1" id="recentContractsTable">
+          <div v-else-if="selectedTab === 1" id="recentContractsTable">
               <AccountCreatedContractsTable v-if="account && !filterVerified" :controller="contractCreateTableController"/>
               <AccountVerifiedContractsTable
                   v-else-if="account"

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -222,6 +222,9 @@
               <PlayPauseButton :controller="transactionTableController"/>
               <TransactionFilterSelect :controller="transactionTableController"/>
           </div>
+          <div v-else-if="selectedTab===1" class="is-flex is-justify-content-end is-align-items-center">
+              <PlayPauseButton :controller="contractCreateTableController"/>
+          </div>
       </template>
       <template v-slot:content>
           <Tabs
@@ -236,6 +239,8 @@
           </div>
 
           <div v-else-if="selectedTab===1" id="recentContractsTable">
+              <AccountCreatedContractsTable v-if="account" :controller="contractCreateTableController"/>
+              <EmptyTable v-else/>
           </div>
 
           <div v-else id="recentRewardsTable">
@@ -293,6 +298,9 @@ import Copyable from "@/components/Copyable.vue";
 import InlineBalancesValue from "@/components/values/InlineBalancesValue.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
+import AccountCreatedContractsTable from "@/components/account/AccountCreatedContractsTable.vue";
+import {TransactionType} from "@/schemas/HederaSchemas";
+import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import {AppStorage} from "@/AppStorage";
 import Tabs from "@/components/Tabs.vue";
 
@@ -301,8 +309,9 @@ export default defineComponent({
   name: 'AccountDetails',
 
   components: {
-    Tabs,
+    AccountCreatedContractsTable,
     EmptyTable,
+    Tabs,
     MirrorLink,
     InlineBalancesValue,
     Copyable,
@@ -413,6 +422,9 @@ export default defineComponent({
     const transactionTableController = new TransactionTableControllerXL(
         router, accountId, perPage, true, "p1", "k1")
 
+    const contractCreateTableController = new TransactionTableController(
+        router, perPage, TransactionType.CONTRACTCREATEINSTANCE, "success", "p3", "k3", accountId)
+
     const rewardsTableController = new StakingRewardsTableController(
         router, accountLocParser.accountId, perPage, "p2", "k2")
 
@@ -421,6 +433,7 @@ export default defineComponent({
       isMediumScreen,
       isTouchDevice,
       transactionTableController,
+      contractCreateTableController,
       notification: accountLocParser.errorNotification,
       isInactiveEvmAddress: accountLocParser.isInactiveEvmAddress,
       account: accountLocParser.accountInfo,

--- a/src/pages/Contracts.vue
+++ b/src/pages/Contracts.vue
@@ -50,7 +50,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
+import {computed, defineComponent, inject} from 'vue';
 import ContractTable from "@/components/contract/ContractTable.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
 import Footer from "@/components/Footer.vue";
@@ -82,8 +82,6 @@ export default defineComponent({
     //
     const perPage = computed(() => isMediumScreen ? 15 : 10)
     const contractTableController = new ContractTableController(useRouter(), perPage)
-    onMounted(() => contractTableController.mount())
-    onBeforeUnmount(() => contractTableController.unmount())
 
     return {
       isSmallScreen,

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -137,6 +137,10 @@ export class SourcifySetup {
         return this.repoURL + matchPrefix + this.chainID + "/" + normalizedAddress
     }
 
+    makeCheckAllByAddressURL(): string {
+        return this.serverURL + "check-all-by-addresses"
+    }
+
     makeContractLookupURL(contractAddress: string): string {
         const normalizedAddress = EthereumAddress.normalizeEIP55(contractAddress)
         return this.verifierURL + "lookup/" + normalizedAddress

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -48,6 +48,7 @@ import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache";
 import {MarketDataCache} from "@/components/dashboard/MarketDataCache";
 import { ContractResultsLogsByContractIdCache } from "@/utils/cache/ContractResultsLogsByContractIdCache"
 import {NftCollectionCache} from "@/utils/cache/NftCollectionCache";
+import {VerifiedContractsByAccountCache} from "@/utils/cache/VerifiedContractsByAccountCache";
 
 export class CacheUtils {
 
@@ -65,6 +66,7 @@ export class CacheUtils {
         ContractResultByHashCache.instance.clear()
         ContractResultByTransactionIdCache.instance.clear()
         ContractResultByTsCache.instance.clear()
+        ContractResultsLogsByContractIdCache.instance.clear()
         MarketDataCache.instance.clear()
         HbarPriceCache.instance.clear()
         // IPFSCache.instance => no clear: we preserve it because IPFS content is valid for all networks
@@ -82,6 +84,6 @@ export class CacheUtils {
         TransactionGroupCache.instance.clear()
         TransactionGroupByBlockCache.instance.clear()
         TopicMessageCache.instance.clear()
-        ContractResultsLogsByContractIdCache.instance.clear()
+        VerifiedContractsByAccountCache.instance.clear()
     }
 }

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -48,7 +48,7 @@ import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache";
 import {MarketDataCache} from "@/components/dashboard/MarketDataCache";
 import { ContractResultsLogsByContractIdCache } from "@/utils/cache/ContractResultsLogsByContractIdCache"
 import {NftCollectionCache} from "@/utils/cache/NftCollectionCache";
-import {VerifiedContractsByAccountCache} from "@/utils/cache/VerifiedContractsByAccountCache";
+import {VerifiedContractsByAccountIdCache} from "@/utils/cache/VerifiedContractsByAccountIdCache";
 
 export class CacheUtils {
 
@@ -84,6 +84,6 @@ export class CacheUtils {
         TransactionGroupCache.instance.clear()
         TransactionGroupByBlockCache.instance.clear()
         TopicMessageCache.instance.clear()
-        VerifiedContractsByAccountCache.instance.clear()
+        VerifiedContractsByAccountIdCache.instance.clear()
     }
 }

--- a/src/utils/cache/VerifiedContractsByAccountCache.ts
+++ b/src/utils/cache/VerifiedContractsByAccountCache.ts
@@ -18,28 +18,97 @@
  *
  */
 
-import {Contract, ContractsResponse} from "@/schemas/HederaSchemas";
+import {Contract, ContractsResponse, TransactionResponse} from "@/schemas/HederaSchemas";
 import {EntityCache} from "@/utils/cache/base/EntityCache";
-import axios from "axios";
+import axios, {AxiosResponse} from "axios";
+import {routeManager} from "@/router";
+import {SourcifyCache} from "@/utils/cache/SourcifyCache";
 
 export class VerifiedContractsBuffer {
 
-    private accountId: string
+    private static MAX_ITERATIONS = 10
+    private static ITERATION_LIMIT = 25
+    private candidates: Contract[] = []
+    private verifiedAddresses: string[] = []
+    private readonly accountId: string
 
+    public static MAX_CANDIDATES = VerifiedContractsBuffer.ITERATION_LIMIT * VerifiedContractsBuffer.MAX_ITERATIONS
     public contracts: Contract[] = []
+    public overflow = false
 
     public constructor(accountId: string) {
         this.accountId = accountId
     }
 
     public async update(): Promise<void> {
-        const params = {
-            limit: 5,
-            order: 'desc',
+
+        this.contracts = []
+        const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup!
+
+        if (sourcifySetup !== null && sourcifySetup.activate) {
+            const isRefresh = this.candidates.length > 0
+            let loadedContracts: Contract[] = []
+            let nextURL: string | null = "api/v1/transactions"
+            let iteration = 0
+
+            while (nextURL !== null && iteration < VerifiedContractsBuffer.MAX_ITERATIONS) {
+                const params = {
+                    limit: VerifiedContractsBuffer.ITERATION_LIMIT,
+                    order: 'desc',
+                    'account.id': this.accountId,
+                    transactiontype: 'CONTRACTCREATEINSTANCE',
+                    result: 'success',
+                    'timestamp': isRefresh ? `gt:${this.candidates[0].created_timestamp}` : undefined
+                }
+                const response: AxiosResponse<TransactionResponse> =
+                    await axios.get<TransactionResponse>(nextURL, {params: iteration === 0 ? params : undefined})
+                const loadedTransactions = response.data.transactions ?? []
+
+                if (loadedTransactions.length > 0) {
+                    let requestURL = "api/v1/contracts?"
+                    for (let i = 0; i < loadedTransactions.length; i++) {
+                        if (i > 0) {
+                            requestURL += '&'
+                        }
+                        if (loadedTransactions[i].entity_id != null) {
+                            requestURL += 'contract.id=' + loadedTransactions[i].entity_id
+                        }
+                    }
+                    const response: AxiosResponse<ContractsResponse> = await axios.get<ContractsResponse>(requestURL)
+                    loadedContracts = loadedContracts.concat(response.data.contracts ?? [])
+                }
+
+                nextURL = response.data.links?.next ?? null
+                iteration += 1
+            }
+
+            if (loadedContracts.length > 0) {
+                this.candidates = loadedContracts.concat(this.candidates)
+                this.overflow = (this.candidates.length >= VerifiedContractsBuffer.MAX_CANDIDATES)
+                this.candidates = this.candidates.slice(0, VerifiedContractsBuffer.MAX_CANDIDATES)
+
+                // Only check the verification status of the newly loaded contracts
+                // to avoid unduly loading Sourcify server at each refresh
+                const addressesToCheck: string[] = []
+                for (const c of loadedContracts ?? []) {
+                    addressesToCheck.push(c.evm_address)
+                }
+
+                const newlyVerifiedAddresses = await SourcifyCache.checkAllContracts(addressesToCheck)
+                this.verifiedAddresses = this.verifiedAddresses.concat(newlyVerifiedAddresses)
+            }
+
+            for (const c of this.candidates) {
+                if (c.contract_id != null && this.verifiedAddresses.includes(c.evm_address)) {
+                    this.contracts.push(c)
+                    const record = await SourcifyCache.instance.lookup(c.contract_id)
+                    if (record === null) {
+                        SourcifyCache.instance.forget(c.contract_id)
+                    }
+                }
+            }
         }
-        const response = await axios.get<ContractsResponse>("api/v1/contracts", {params: params})
-        this.contracts = response.data.contracts ?? []
-        console.log(`VerifiedContractsBuffer.update - this.buffer.value: ${this.contracts}`)
+        return Promise.resolve()
     }
 }
 

--- a/src/utils/cache/VerifiedContractsByAccountCache.ts
+++ b/src/utils/cache/VerifiedContractsByAccountCache.ts
@@ -1,0 +1,55 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {Contract, ContractsResponse} from "@/schemas/HederaSchemas";
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import axios from "axios";
+
+export class VerifiedContractsBuffer {
+
+    private accountId: string
+
+    public contracts: Contract[] = []
+
+    public constructor(accountId: string) {
+        this.accountId = accountId
+    }
+
+    public async update(): Promise<void> {
+        const params = {
+            limit: 5,
+            order: 'desc',
+        }
+        const response = await axios.get<ContractsResponse>("api/v1/contracts", {params: params})
+        this.contracts = response.data.contracts ?? []
+        console.log(`VerifiedContractsBuffer.update - this.buffer.value: ${this.contracts}`)
+    }
+}
+
+export class VerifiedContractsByAccountCache extends EntityCache<string, VerifiedContractsBuffer | null> {
+
+    public static readonly instance = new VerifiedContractsByAccountCache()
+
+    protected async load(key: string): Promise<VerifiedContractsBuffer | null> {
+        const buffer = new VerifiedContractsBuffer(key)
+        await buffer.update()
+        return Promise.resolve(buffer)
+    }
+}

--- a/src/utils/cache/VerifiedContractsByAccountCache.ts
+++ b/src/utils/cache/VerifiedContractsByAccountCache.ts
@@ -20,7 +20,7 @@
 
 import {Contract, ContractsResponse, TransactionResponse} from "@/schemas/HederaSchemas";
 import {EntityCache} from "@/utils/cache/base/EntityCache";
-import axios, {AxiosResponse} from "axios";
+import axios, {AxiosError, AxiosResponse} from "axios";
 import {routeManager} from "@/router";
 import {SourcifyCache} from "@/utils/cache/SourcifyCache";
 
@@ -118,7 +118,15 @@ export class VerifiedContractsByAccountCache extends EntityCache<string, Verifie
 
     protected async load(key: string): Promise<VerifiedContractsBuffer | null> {
         const buffer = new VerifiedContractsBuffer(key)
-        await buffer.update()
+        await buffer.update().catch(this.errorHandler)
         return Promise.resolve(buffer)
+    }
+
+    private readonly errorHandler = (reason: unknown): void => {
+        console.log("reason=" + reason)
+        if (axios.isAxiosError(reason)) {
+            const axiosError = reason as AxiosError
+            console.log("url=" + axiosError.config?.url)
+        }
     }
 }

--- a/src/utils/cache/VerifiedContractsByAccountIdCache.ts
+++ b/src/utils/cache/VerifiedContractsByAccountIdCache.ts
@@ -86,17 +86,12 @@ export class VerifiedContractsBuffer {
                 this.candidates = loadedContracts.concat(this.candidates)
                 this.overflow = (this.candidates.length >= VerifiedContractsBuffer.MAX_CANDIDATES)
                 this.candidates = this.candidates.slice(0, VerifiedContractsBuffer.MAX_CANDIDATES)
-
-                // Only check the verification status of the newly loaded contracts
-                // to avoid unduly loading Sourcify server at each refresh
-                const addressesToCheck: string[] = []
-                for (const c of loadedContracts ?? []) {
-                    addressesToCheck.push(c.evm_address)
-                }
-
-                const newlyVerifiedAddresses = await SourcifyCache.checkAllContracts(addressesToCheck)
-                this.verifiedAddresses = this.verifiedAddresses.concat(newlyVerifiedAddresses)
             }
+
+            const addressesToCheck: string[] = []
+            this.candidates.forEach((c) => addressesToCheck.push(c.evm_address))
+            const newlyVerifiedAddresses = await SourcifyCache.checkAllContracts(addressesToCheck)
+            this.verifiedAddresses = this.verifiedAddresses.concat(newlyVerifiedAddresses)
 
             for (const c of this.candidates) {
                 if (c.contract_id != null && this.verifiedAddresses.includes(c.evm_address)) {

--- a/src/utils/cache/VerifiedContractsByAccountIdCache.ts
+++ b/src/utils/cache/VerifiedContractsByAccountIdCache.ts
@@ -112,9 +112,9 @@ export class VerifiedContractsBuffer {
     }
 }
 
-export class VerifiedContractsByAccountCache extends EntityCache<string, VerifiedContractsBuffer | null> {
+export class VerifiedContractsByAccountIdCache extends EntityCache<string, VerifiedContractsBuffer | null> {
 
-    public static readonly instance = new VerifiedContractsByAccountCache()
+    public static readonly instance = new VerifiedContractsByAccountIdCache()
 
     protected async load(key: string): Promise<VerifiedContractsBuffer | null> {
         const buffer = new VerifiedContractsBuffer(key)

--- a/tests/e2e/specs/AccountNavigation.cy.ts
+++ b/tests/e2e/specs/AccountNavigation.cy.ts
@@ -164,6 +164,29 @@ describe('Account Navigation', () => {
         cy.contains('0.0.800')
     })
 
+    it ('should follow link to recent created contract', () => {
+        const accountID = "0.0.902"
+        cy.visit('testnet/account/' + accountID)
+        cy.url().should('include', '/testnet/account/' + accountID)
+        cy.contains('Account ID:' + accountID)
+
+        cy.get('#operations-tab-1')
+            .click()
+
+        cy.get('#recentContractsTable')
+            .find('tbody tr')
+            .should('be.visible')
+            .should('have.length.at.least', 2)
+            .eq(0)
+            .find('td')
+            .eq(0)
+            .click()
+
+        cy.url().should('include', '/testnet/contract/')
+        cy.contains('Contract')
+        cy.contains(accountID)
+    })
+
     it ('should display account details using account ID', () => {
         const accountID = "0.0.592746"
         cy.visit('mainnet/account/' + accountID)

--- a/tests/e2e/specs/AccountNavigation.cy.ts
+++ b/tests/e2e/specs/AccountNavigation.cy.ts
@@ -147,6 +147,9 @@ describe('Account Navigation', () => {
         cy.url().should('include', '/mainnet/account/' + accountID)
         cy.contains('Account ID:' + accountID)
 
+        cy.get('#operations-tab-2')
+            .click()
+
         cy.get('#recentRewardsTable')
             .find('tbody tr')
             .should('be.visible')

--- a/tests/unit/contract/Contracts.spec.ts
+++ b/tests/unit/contract/Contracts.spec.ts
@@ -72,7 +72,7 @@ describe("Contracts.vue", () => {
         expect(table.get('thead').text()).toBe("ID Contract Name Created Memo")
         expect(table.get('tbody').text()).toBe(
             "0.0.749775" +
-            " not verified " +
+            " NOT VERIFIED " +
             "3:09:15.9474 PMMar 7, 2022, UTC" +
             "Mirror Node acceptance test: 2022-03-07T15:09:15.228564328Z Create contract"
         )

--- a/tests/unit/contract/Contracts.spec.ts
+++ b/tests/unit/contract/Contracts.spec.ts
@@ -81,7 +81,8 @@ describe("Contracts.vue", () => {
         wrapper.unmount()
         await flushPromises()
 
-        expect(wrapper.vm.contractTableController.mounted.value).toBe(false)
+        // we now expect the controller to be still mounted since it is mounted by the ContractTable component
+        expect(wrapper.vm.contractTableController.mounted.value).toBe(true)
     });
 
 });


### PR DESCRIPTION
**Description**:

This PR add a table of contracts recently created by an account on its AccountDetails page. A toggle allows to choose to display only the verified contracts.

To avoid cluttering the AccountDetails page, the following sections are now regrouped as tabs in a single section named 'Recent Account Operations':
- Transactions
- Created Contracts
- Staking Rewards

**Related issue(s)**:

Fixes #901

**Notes for reviewer**:

Deployed on the staging server.

<img width="1113" alt="Screenshot 2024-02-20 at 16 14 30" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/f7c4a1ef-f42a-48af-bfef-ecba2a154fac">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
