### PR TITLE
fix: removed UTF-8 decoding from hex error message string processing (#904)

### DIFF
--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -23,11 +23,8 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-
     <template v-if="errorSignature">
-
         <div v-if="error">
-
             <div class="h-is-tertiary-text my-2">Error</div>
 
             <Property :custom-nb-col-class="customNbColClass" id="errorFunction">
@@ -46,20 +43,19 @@
                     </template>
                 </Property>
             </template>
-
-        </div><template v-else>
-
+        </div>
+        
+        <template v-else>
             <Property :custom-nb-col-class="customNbColClass" id="functionInput">
                 <template v-slot:name>Error Message</template>
                 <template v-slot:value>
                     <HexaValue :show-none="true"/>
                 </template>
             </Property>
-
         </template>
-
-    </template><template v-else>
-
+    </template>
+    
+    <template v-else>
         <Property :custom-nb-col-class="customNbColClass" id="errorMessage">
             <template v-slot:name>Error Message</template>
             <template v-slot:value>
@@ -73,7 +69,6 @@
                 </template>
             </template>
         </Property>
-
     </template>
 
 </template>
@@ -109,7 +104,6 @@ export default defineComponent({
     },
 
     setup(props) {
-
         const initialLoading = inject(initialLoadingKey, ref(false))
         const decodedError = computed( () =>
             props.analyzer.normalizedError.value != null ? decodeSolidityErrorMessage(props.analyzer.normalizedError.value) : null)

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -127,7 +127,7 @@ const errorStringSelector = '0x08c379a0'
 const panicUint256Selector = '0x4e487b71'
 
 export function decodeSolidityErrorMessage(message: string | null): string | null {
-    let result: string|null = null
+    let result: string|null
 
     // https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/
     // Section "Revert on assertion failures and similar conditions instead of using the invalid opcode"
@@ -147,7 +147,9 @@ export function decodeSolidityErrorMessage(message: string | null): string | nul
                 ethers.dataSlice(message ?? "", 4)
             )
             result = 'Panic(0x' + parseInt(code.toString()).toString(16) + ')'
-        } 
+        }  else {
+            result = null;
+        }
     } catch(reason) {
         result = null
     }

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -127,7 +127,7 @@ const errorStringSelector = '0x08c379a0'
 const panicUint256Selector = '0x4e487b71'
 
 export function decodeSolidityErrorMessage(message: string | null): string | null {
-    let result: string|null
+    let result: string|null = null
 
     // https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/
     // Section "Revert on assertion failures and similar conditions instead of using the invalid opcode"
@@ -147,11 +147,7 @@ export function decodeSolidityErrorMessage(message: string | null): string | nul
                 ethers.dataSlice(message ?? "", 4)
             )
             result = 'Panic(0x' + parseInt(code.toString()).toString(16) + ')'
-        } else {
-            const textDecoder = new TextDecoder()
-            const bytes = hexToByte(message)
-            result = bytes !== null ? textDecoder.decode(bytes) : null
-        }
+        } 
     } catch(reason) {
         result = null
     }


### PR DESCRIPTION
**Description**:
This PR removes UTF-8 decoding from the hex error message string to allow Hashscan to display the original hex value of the error message, rather than a non-human-readable string.

**Related issue(s)**:

Fixes #904

**UI update:
Fix from 
![image](https://github.com/hashgraph/hedera-mirror-node-explorer/assets/66233296/05b48faa-e123-42be-bb10-a79185c635e9)

to
![image](https://github.com/hashgraph/hedera-mirror-node-explorer/assets/66233296/9440d56a-aab2-4a09-a8a3-e5205d00e814)


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
