### PR TITLE
fix: set min-height for ByteCodeValue.

### DIFF
--- a/src/components/values/ByteCodeValue.vue
+++ b/src/components/values/ByteCodeValue.vue
@@ -26,6 +26,7 @@
 
     <div v-if="nonNullValue" id="bytecode"
          class="h-code-box h-has-page-background pt-1 pl-3 pr-2 pb-2 mt-2 mr-1"
+         style="min-height:20px"
          :style="{'max-height':heightInPixel+'px'}">
         <HexaValue :byte-string="textValue" :copyable="false"/>
     </div>


### PR DESCRIPTION
**Description**:

One-line change.

**Notes for reviewer**:

Before:
<img width="1424" alt="Screenshot 2024-03-01 at 16 14 23" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/bf84dd3f-4996-4d9c-8b2f-813b2151bb02">

After:
<img width="1424" alt="Screenshot 2024-03-01 at 16 17 13" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/1dc600af-3f17-462c-a555-3a84f73ed87a">
