### PR TITLE
feat: show token symbol with child transactions

### DIFF
--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -201,21 +201,19 @@
         <Property v-if="childTransactions.length" id="childTransactions">
           <template v-slot:name>Child Transactions</template>
           <template v-slot:value>
-            <router-link v-if="displayAllChildrenLinks"
-                         :to="routeManager.makeRouteToTransactionsById(transactionId ?? '')">
-              {{ 'Show all ' + childTransactions.length + ' transactions' }}
-            </router-link>
-            <div v-else>
-              <div v-for="tx in childTransactions" :key="tx.nonce">
-                <router-link :to="routeManager.makeRouteToTransactionObj(tx)">
-                  <span class="is-numeric">{{ '#' + tx.nonce }}</span>
-                  <span class="ml-2">{{ makeTypeLabel(tx.name) }}</span>
-                </router-link>
-                <span v-for="id in getTargetedTokens(tx, 5)" :key="id" class="ml-2">
-                  <TokenExtra :token-id="id" :use-anchor="true"/>
-                </span>
-              </div>
+            <div v-for="tx in childTransactions.slice(0, MAX_INLINE_CHILDREN)" :key="tx.nonce">
+              <router-link :to="routeManager.makeRouteToTransactionObj(tx)">
+                <span class="is-numeric">{{ '#' + tx.nonce }}</span>
+                <span class="ml-2">{{ makeTypeLabel(tx.name) }}</span>
+              </router-link>
+              <span v-for="id in getTargetedTokens(tx, 5)" :key="id" class="ml-2">
+                <TokenExtra :token-id="id" :use-anchor="true"/>
+              </span>
             </div>
+            <router-link v-if="displayAllChildrenLinks" class="has-text-grey"
+                         :to="routeManager.makeRouteToTransactionsById(transactionId ?? '')">
+              {{ 'Show all ' + childTransactions.length + ' child transactions' }}
+            </router-link>
           </template>
         </Property>
       </template>
@@ -283,7 +281,7 @@ import InfoTooltip from "@/components/InfoTooltip.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
 import TokenExtra from "@/components/values/TokenExtra.vue";
 
-const MAX_INLINE_CHILDREN = 9
+const MAX_INLINE_CHILDREN = 10
 
 export default defineComponent({
 
@@ -468,6 +466,7 @@ export default defineComponent({
       isTokenAssociation: transactionAnalyzer.isTokenAssociation,
       associatedTokens: transactionAnalyzer.tokens,
       getTargetedTokens,
+      MAX_INLINE_CHILDREN
     }
   },
 })

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -206,11 +206,15 @@
               {{ 'Show all ' + childTransactions.length + ' transactions' }}
             </router-link>
             <div v-else>
-              <router-link v-for="tx in childTransactions" :key="tx.nonce"
-                           :to="routeManager.makeRouteToTransactionObj(tx)">
-                <span class="mr-2 is-numeric">{{ '#' + tx.nonce }}</span>
-                <span>{{ makeTypeLabel(tx.name) }}</span>
-                <br/></router-link>
+              <div v-for="tx in childTransactions" :key="tx.nonce">
+                <router-link :to="routeManager.makeRouteToTransactionObj(tx)">
+                  <span class="is-numeric">{{ '#' + tx.nonce }}</span>
+                  <span class="ml-2">{{ makeTypeLabel(tx.name) }}</span>
+                </router-link>
+                <span v-for="id in getTargetedTokens(tx, 5)" :key="id" class="ml-2">
+                  <TokenExtra :token-id="id" :use-anchor="true"/>
+                </span>
+              </div>
             </div>
           </template>
         </Property>
@@ -250,7 +254,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
-import {makeOperatorAccountLabel, makeTypeLabel} from "@/utils/TransactionTools";
+import {getTargetedTokens, makeOperatorAccountLabel, makeTypeLabel} from "@/utils/TransactionTools";
 import AccountLink from "@/components/values/AccountLink.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -277,6 +281,7 @@ import {TransactionAnalyzer} from "@/components/transaction/TransactionAnalyzer"
 import {TransactionGroupCache} from "@/utils/cache/TransactionGroupCache";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
+import TokenExtra from "@/components/values/TokenExtra.vue";
 
 const MAX_INLINE_CHILDREN = 9
 
@@ -285,6 +290,7 @@ export default defineComponent({
   name: 'TransactionDetails',
 
   components: {
+    TokenExtra,
     MirrorLink,
     InfoTooltip,
     TokenLink,
@@ -460,7 +466,8 @@ export default defineComponent({
       displayResult,
       topicMessage: topicMessageLookup.entity,
       isTokenAssociation: transactionAnalyzer.isTokenAssociation,
-      associatedTokens: transactionAnalyzer.tokens
+      associatedTokens: transactionAnalyzer.tokens,
+      getTargetedTokens,
     }
   },
 })

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -379,3 +379,30 @@ export function makeNetOfRewards(transfers: Transfer[] | undefined, rewards: Sta
 
     return result
 }
+
+export function getTargetedTokens(transaction: Transaction, nbItems: number|null = null): string[]  {
+    let result: string[]
+    const type = transaction.name
+    if (makeTypeLabel(type).toUpperCase().includes("TOKEN")) {
+        result = transaction.entity_id ? [transaction.entity_id] : []
+    } else if (type === TransactionType.CRYPTOTRANSFER) {
+        result = []
+        transaction.nft_transfers.forEach((nft) => {
+            if (nft.token_id && !result.includes(nft.token_id)) {
+                result.push(nft.token_id)
+            }
+        })
+        transaction.token_transfers.forEach((token) => {
+            if (token.token_id && !result.includes(token.token_id)) {
+                result.push(token.token_id)
+            }
+        })
+    } else {
+        result = []
+    }
+    if (nbItems != null) {
+        result = result.slice(0, nbItems)
+    }
+    return result
+}
+

--- a/tests/e2e/specs/TransactionNavigation.cy.ts
+++ b/tests/e2e/specs/TransactionNavigation.cy.ts
@@ -136,7 +136,7 @@ describe('Transaction Navigation', () => {
 
         cy.get('#childTransactionsValue')
             .find('a')
-            .should('have.length', 4)
+            .should('have.length', 6)
             .eq(0)
             .click()
             .then(() => {
@@ -213,7 +213,7 @@ describe('Transaction Navigation', () => {
 
         cy.get('#childTransactionsValue')
             .find('a')
-            .should('have.length', 2)
+            .should('have.length', 4)
             .eq(0)
             .click()
             .then(() => {

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -1799,6 +1799,7 @@ export const SAMPLE_PARENT_CHILD_TRANSACTIONS = {
             "parent_consensus_timestamp": "1662470957.014478705",
             "result": "SUCCESS",
             "scheduled": false,
+            "token_transfers": [],
             "transaction_hash": "Gqep6H2B3iE4id1qPG92q51LP20WXW7r53ujWlKekk8RBhYTfpFiD4iJBkK8UnGc",
             "transaction_id": "0.0.48113503-1662470948-432078184",
             "transfers": [],

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -45,7 +45,7 @@ import {
     SAMPLE_FAILED_TRANSACTIONS,
     SAMPLE_FILE_UPDATE_TRANSACTION,
     SAMPLE_NETWORK_EXCHANGERATE,
-    SAMPLE_NETWORK_NODES,
+    SAMPLE_NETWORK_NODES, SAMPLE_NONFUNGIBLE,
     SAMPLE_PARENT_CHILD_TRANSACTIONS,
     SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS,
     SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
@@ -672,6 +672,7 @@ describe("TransactionDetails.vue", () => {
         const PARENT = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[0]
         const CHILD1 = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[1]
         const CHILD2 = SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions[2]
+        const TARGETED_TOKEN = CHILD1.entity_id
 
         const mock = new MockAdapter(axios)
         const matcher1 = "/api/v1/transactions"
@@ -684,6 +685,8 @@ describe("TransactionDetails.vue", () => {
         });
         const matcher11 = "/api/v1/transactions/" + PARENT.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_PARENT_CHILD_TRANSACTIONS);
+        const matcher2 = "/api/v1/tokens/" + TARGETED_TOKEN
+        mock.onGet(matcher2).reply(200, SAMPLE_NONFUNGIBLE);
 
         const wrapper = mount(TransactionDetails, {
             global: {
@@ -701,14 +704,22 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("^Transaction " + normalizeTransactionId(PARENT.transaction_id, true)))
 
         const children = wrapper.get("#childTransactionsValue")
-        expect(children.text()).toBe("#1TOKEN MINT#2CRYPTO TRANSFER")
+        expect(children.text()).toBe("" +
+            "#1TOKEN MINTĦFRENSKINGDOM" +
+            "#2CRYPTO TRANSFERĦFRENSKINGDOM")
 
         const links = children.findAll('a')
         expect(links[0].attributes("href")).toBe(
             "/mainnet/transaction/" + CHILD1.consensus_timestamp
         )
         expect(links[1].attributes("href")).toBe(
+            "/mainnet/token/" + TARGETED_TOKEN
+        )
+        expect(links[2].attributes("href")).toBe(
             "/mainnet/transaction/" + CHILD2.consensus_timestamp
+        )
+        expect(links[3].attributes("href")).toBe(
+            "/mainnet/token/" + TARGETED_TOKEN
         )
 
         wrapper.unmount()


### PR DESCRIPTION
**Description**:

This PR brings 2 changes:
 - add token symbol(s) to any child transaction listed in the TransactionDetails, when relevant (i.e. for a `CRYPTO TRANSFER` including token/nft transfer, or any other token-related transaction type like `TOKEN MINT`)
 - always list the first 10 child transactions, followed when necessary by the link `Show all N child transactions`.
 - 
**Related issue(s)**:

Fixes #540

**Notes for reviewer**:

Deploying on staging server.

<img width="1172" alt="Screenshot 2024-03-04 at 14 22 32" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/df9319f2-0e71-4f66-b614-2d7a65f83210">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
