### PR TITLE
fix: InlineBalanceValue unit test break

### DIFF
--- a/src/components/values/InlineBalancesValue.vue
+++ b/src/components/values/InlineBalancesValue.vue
@@ -97,7 +97,9 @@ export default defineComponent({
             let result: string|null
             const duration = props.balanceAnalyzer.balanceAge.value
             if (duration !== null) {
-                if (duration.days > 0) {
+                if (duration.years > 0) {
+                    result = "> " + (duration.years > 1 ? duration.years + " years" : "1 year") + " ago"
+                } else if (duration.days > 0) {
                     result = "> " + (duration.days > 1 ? duration.days + " days" : "1 day") + " ago"
                 } else if (duration.hours > 0) {
                     result = "> " + (duration.hours > 1 ? duration.hours + " hours" : "1 hour") + " ago"

--- a/src/utils/Timestamp.ts
+++ b/src/utils/Timestamp.ts
@@ -52,6 +52,11 @@ export class Timestamp {
         return this.seconds + "." + this.nanoseconds.toString().padStart(9, "0")
     }
 
+    public toDate(): Date {
+        const seconds = this.seconds + (this.nanoseconds / 1_000_000_000)
+        return new Date(seconds * 1000)
+    }
+
     //
     // Private
     //

--- a/src/utils/Timestamp.ts
+++ b/src/utils/Timestamp.ts
@@ -52,11 +52,6 @@ export class Timestamp {
         return this.seconds + "." + this.nanoseconds.toString().padStart(9, "0")
     }
 
-    public toDate(): Date {
-        const seconds = this.seconds + (this.nanoseconds / 1_000_000_000)
-        return new Date(seconds * 1000)
-    }
-
     //
     // Private
     //

--- a/src/utils/analyzer/BalanceAnalyzer.ts
+++ b/src/utils/analyzer/BalanceAnalyzer.ts
@@ -22,7 +22,6 @@ import {computed, ComputedRef, Ref, ref, watch, WatchStopHandle} from "vue";
 import {BalancesResponse, TokenBalance} from "@/schemas/HederaSchemas";
 import {BalanceCache} from "@/utils/cache/BalanceCache";
 import {Duration} from "@/utils/Duration";
-import {Timestamp} from "@/utils/Timestamp";
 
 export class BalanceAnalyzer {
 

--- a/src/utils/analyzer/BalanceAnalyzer.ts
+++ b/src/utils/analyzer/BalanceAnalyzer.ts
@@ -22,6 +22,7 @@ import {computed, ComputedRef, Ref, ref, watch, WatchStopHandle} from "vue";
 import {BalancesResponse, TokenBalance} from "@/schemas/HederaSchemas";
 import {BalanceCache} from "@/utils/cache/BalanceCache";
 import {Duration} from "@/utils/Duration";
+import {Timestamp} from "@/utils/Timestamp";
 
 export class BalanceAnalyzer {
 
@@ -50,6 +51,7 @@ export class BalanceAnalyzer {
             this.watchHandle.value = null
         }
         this.response.value = null
+        this.balanceAge.value = null
         if (this.timeoutID != -1) {
             window.clearTimeout(this.timeoutID)
             this.timeoutID = -1
@@ -88,11 +90,14 @@ export class BalanceAnalyzer {
             } catch {
                 this.response.value = null
             } finally {
-                this.balanceAge.value = Duration.decompose(new Date().getTime() / 1000 - Number.parseFloat(this.balanceTimeStamp.value ?? ''))
+                this.balanceAge.value = this.balanceTimeStamp.value !== null
+                    ? Duration.decompose(new Date().getTime() / 1000 - Number.parseFloat(this.balanceTimeStamp.value))
+                    : null
                 this.scheduleNextLookup()
             }
         } else {
             this.response.value = null
+            this.balanceAge.value = null
         }
     }
 

--- a/tests/unit/utils/analyzer/BalanceAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/BalanceAnalyzer.spec.ts
@@ -26,7 +26,6 @@ import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {BalanceAnalyzer} from "@/utils/analyzer/BalanceAnalyzer";
-import {Timestamp} from "@/utils/Timestamp";
 import {SAMPLE_ACCOUNT, SAMPLE_ACCOUNT_BALANCES} from "../../Mocks";
 
 describe("BalanceAnalyzer.spec.ts", () => {
@@ -81,10 +80,6 @@ describe("BalanceAnalyzer.spec.ts", () => {
     })
 
     test("set account between mount() and unmount() ", async () => {
-
-        const t = "1646728200.821070000"
-        const tt = Timestamp.parse(t)
-        const date = tt.toDate()
 
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/balances"

--- a/tests/unit/utils/analyzer/BalanceAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/BalanceAnalyzer.spec.ts
@@ -26,6 +26,7 @@ import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {BalanceAnalyzer} from "@/utils/analyzer/BalanceAnalyzer";
+import {Timestamp} from "@/utils/Timestamp";
 import {SAMPLE_ACCOUNT, SAMPLE_ACCOUNT_BALANCES} from "../../Mocks";
 
 describe("BalanceAnalyzer.spec.ts", () => {
@@ -42,6 +43,7 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
 
         // sets contract id before mount
         contractId.value = SAMPLE_ACCOUNT.account
@@ -49,11 +51,13 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
         await flushPromises()
         expect(balanceAnalyzer.accountId.value).toBe(SAMPLE_ACCOUNT.account)
         expect(balanceAnalyzer.hbarBalance.value).toBeNull() // because it's not mounted ;)
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
 
         // mount
         balanceAnalyzer.mount()
@@ -62,6 +66,7 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBe(SAMPLE_ACCOUNT_BALANCES.balances[0].balance)
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual(SAMPLE_ACCOUNT_BALANCES.balances[0].tokens)
         expect(balanceAnalyzer.balanceTimeStamp.value).toBe(SAMPLE_ACCOUNT_BALANCES.timestamp)
+        expect(balanceAnalyzer.balanceAge.value?.years).toBeGreaterThan(1)
 
         // unmount
         balanceAnalyzer.unmount()
@@ -70,11 +75,16 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
 
         mock.restore()
     })
 
     test("set account between mount() and unmount() ", async () => {
+
+        const t = "1646728200.821070000"
+        const tt = Timestamp.parse(t)
+        const date = tt.toDate()
 
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/balances"
@@ -86,6 +96,7 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
 
         // mount
         balanceAnalyzer.mount()
@@ -94,6 +105,7 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
 
         // sets contract id between mount and unmount
         contractId.value = SAMPLE_ACCOUNT.account
@@ -101,11 +113,13 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
         await flushPromises()
         expect(balanceAnalyzer.accountId.value).toBe(SAMPLE_ACCOUNT.account)
         expect(balanceAnalyzer.hbarBalance.value).toBe(SAMPLE_ACCOUNT_BALANCES.balances[0].balance)
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual(SAMPLE_ACCOUNT_BALANCES.balances[0].tokens)
         expect(balanceAnalyzer.balanceTimeStamp.value).toBe(SAMPLE_ACCOUNT_BALANCES.timestamp)
+        expect(balanceAnalyzer.balanceAge.value?.years).toBeGreaterThan(1)
 
         // unmount
         balanceAnalyzer.unmount()
@@ -114,6 +128,7 @@ describe("BalanceAnalyzer.spec.ts", () => {
         expect(balanceAnalyzer.hbarBalance.value).toBeNull()
         expect(balanceAnalyzer.tokenBalances.value).toStrictEqual([])
         expect(balanceAnalyzer.balanceTimeStamp.value).toBeNull()
+        expect(balanceAnalyzer.balanceAge.value).toBeNull()
 
         mock.restore()
     })

--- a/tests/unit/values/InlineBalancesValue.spec.ts
+++ b/tests/unit/values/InlineBalancesValue.spec.ts
@@ -171,7 +171,7 @@ describe("InlineBalancesValue.vue", () => {
         await flushPromises()
 
         expect(wrapper.text()).toContain("100.00000000" + ">")
-        expect(wrapper.text()).toContain("days ago" +
+        expect(wrapper.text()).toContain("years ago" +
             "1" + "Token-1" +
             "2" + "Token-2" +
             "3" + "Token-3" +
@@ -233,7 +233,7 @@ describe("InlineBalancesValue.vue", () => {
         // console.log(wrapper.html())
 
         expect(wrapper.text()).toContain("100.00000000" + ">")
-        expect(wrapper.text()).toContain("days ago" +
+        expect(wrapper.text()).toContain("years ago" +
             "1" + "Token-1" +
             "2" + "Token-2" +
             "3" + "Token-3" +
@@ -296,7 +296,7 @@ describe("InlineBalancesValue.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toContain("100.00000000" + ">")
-        expect(wrapper.text()).toContain("days ago" +
+        expect(wrapper.text()).toContain("years ago" +
             "2" + "Token-2" +
             "3" + "Token-3" +
             "5" + "Token-5" +
@@ -359,7 +359,7 @@ describe("InlineBalancesValue.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toContain("100.00000000" + ">")
-        expect(wrapper.text()).toContain("days ago" +
+        expect(wrapper.text()).toContain("years ago" +
             "1" + "NFT-1")
         expect(wrapper.get('#show-all-link').text()).toBe("Show all tokens")
 


### PR DESCRIPTION
**Description**:

Fix test breaking when balance was exactly 2 year old, which should not happen outside of the context of the test...
InlineBalanceValue now processes years separately from days.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
