### PR TITLE
chore: remove use of 'app' query parameter in AccountDetails

### DIFF
--- a/src/components/allowances/ApproveAllowanceSection.vue
+++ b/src/components/allowances/ApproveAllowanceSection.vue
@@ -91,7 +91,6 @@ export default defineComponent({
 
   props: {
     accountId: String,
-    showApproveDialog: String
   },
 
   setup: function (props) {
@@ -104,17 +103,6 @@ export default defineComponent({
         () => walletManager.connected.value && walletManager.accountId.value === props.accountId)
     // const isWalletConnected = computed(() => false)
     const showApproveAllowanceDialog = ref(false)
-
-    onMounted(() => {
-      if (props.showApproveDialog === 'true' && isWalletConnected.value) {
-        handleApproveButton()
-      }
-    })
-    watch(isWalletConnected, (newValue) => {
-      if (newValue && props.showApproveDialog === 'true') {
-        handleApproveButton()
-      }
-    })
 
     watch(showApproveAllowanceDialog, (newValue) => {
       if (!newValue) {

--- a/src/components/wallet/WalletInfo.vue
+++ b/src/components/wallet/WalletInfo.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 
         const accountRoute = computed(() => {
           return walletManager.accountId.value !== null
-              ? routeManager.makeRouteToAccount(walletManager.accountId.value, false)
+              ? routeManager.makeRouteToAccount(walletManager.accountId.value)
               : null
          })
         

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -259,7 +259,7 @@
       </template>
     </DashboardCard>
 
-    <ApproveAllowanceSection :account-id="normalizedAccountId ?? undefined" :showApproveDialog="showApproveDialog"/>
+    <ApproveAllowanceSection :account-id="normalizedAccountId ?? undefined"/>
 
     <MirrorLink :network="network" entityUrl="accounts" :loc="accountId"/>
 
@@ -354,7 +354,6 @@ export default defineComponent({
 
   props: {
     accountId: String,
-    showApproveDialog: String,
     network: String,
   },
 

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -343,7 +343,7 @@ export default defineComponent({
 
     const accountRoute = computed(() => {
       return walletManager.accountId.value !== null
-          ? routeManager.makeRouteToAccount(walletManager.accountId.value, false)
+          ? routeManager.makeRouteToAccount(walletManager.accountId.value)
           : null
     })
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -116,11 +116,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/:network/account/:accountId',
     name: 'AccountDetails',
     component: AccountDetails,
-    props: route => ({
-      network: route.params.network as string|undefined,
-      accountId: route.params.accountId as string|undefined,
-      showApproveDialog: route.query.app as string|undefined
-    })
+    props: true
   },
   {
     path: '/:network/adminKey/:accountId',

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -208,11 +208,10 @@ export class RouteManager {
     // Account
     //
 
-    public makeRouteToAccount(accountId: string, showApproveDialog = false): RouteLocationRaw {
+    public makeRouteToAccount(accountId: string): RouteLocationRaw {
         return {
             name: 'AccountDetails',
-            params: {accountId: accountId, network: this.currentNetwork.value},
-            query: {app: showApproveDialog ? 'true' : 'false'}
+            params: {accountId: accountId, network: this.currentNetwork.value}
         }
     }
 


### PR DESCRIPTION
**Description**:

Remove dead code (this was once used to open the ApproveAllowanceDialog directly from the Staking page).
