### PR TITLE
00856 add hip 859 support for gasconsumed

### DIFF
--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -84,7 +84,7 @@
             <PlainAmount :amount="contractResult?.gas_used" none-label="None"/>
           </template>
         </Property>
-        <Property id="gasUsed">
+        <Property id="gasConsumed">
           <template v-slot:name>Gas Consumed</template>
           <template v-slot:value>
             <PlainAmount :amount="contractResult?.gas_consumed" none-label="None"/>

--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -84,6 +84,12 @@
             <PlainAmount :amount="contractResult?.gas_used" none-label="None"/>
           </template>
         </Property>
+        <Property id="gasUsed">
+          <template v-slot:name>Gas Consumed</template>
+          <template v-slot:value>
+            <PlainAmount :amount="contractResult?.gas_consumed" none-label="None"/>
+          </template>
+        </Property>
         <Property id="maxFeePerGas">
           <template v-slot:name>Max Fee Per Gas</template>
           <template v-slot:value>

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -522,6 +522,7 @@ export interface ContractResult {
     gas_limit: number
     gas_price: string | null
     gas_used: number | null
+    gas_consumed: number | null
     hash: string | null
     max_fee_per_gas: string | null
     max_priority_fee_per_gas: string | null


### PR DESCRIPTION
**Description**:
This PR adds a new field `Gas Consumed` under contract result information section to introduce the support for [HIP-859](https://hips.hedera.com/hip/hip-859)

<img width="1514" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/66233296/d41278f6-f8a2-474e-b21f-daa437b9343d">

Fixes #856 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
