### PR TITLE
fix: prevent editing allowance when token is not associated

### DIFF
--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -27,8 +27,8 @@
              :delay="delay"
              multiline="multiline"
              :position="position ?? 'auto'"
-             class="h-tooltip ml-1">
-    <span class="icon is-small h-is-extra-text"><i class="fas fa-info-circle"></i></span>
+             class="h-tooltip">
+    <span class="icon is-small h-is-property-text h-is-extra-text"><i class="fas fa-info-circle"></i></span>
   </o-tooltip>
 </template>
 

--- a/src/components/Property.vue
+++ b/src/components/Property.vue
@@ -28,6 +28,8 @@
     <div class="column is-flex is-justify-content-space-between">
       <div class="has-text-weight-light" :id="nameId">
         <slot name="name"/>
+        <span v-if="tooltip" class="ml-2"/>
+        <InfoTooltip v-if="tooltip" :label="tooltip"/>
       </div>
       <div :id="valueId" class="ml-4 has-text-right">
         <slot name="value"/>
@@ -38,6 +40,8 @@
   <div v-else class="columns" :id="id" style="margin-bottom: -0.75rem;">
     <div :class="nbColClass" class="column has-text-weight-light" :id="nameId">
       <slot name="name"/>
+      <span v-if="tooltip" class="ml-2"/>
+      <InfoTooltip v-if="tooltip" :label="tooltip"/>
     </div>
     <div class="column has-text-left" :id="valueId">
       <slot name="value"/>
@@ -53,9 +57,11 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject} from "vue";
+import InfoTooltip from "@/components/InfoTooltip.vue";
 
 export default defineComponent({
   name: "Property",
+  components: {InfoTooltip},
   props: {
     id: String,
     fullWidth: {
@@ -66,7 +72,8 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    customNbColClass: String
+    customNbColClass: String,
+    tooltip: String
   },
   setup(props){
     const nameId = props.id + 'Name'

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -282,6 +282,7 @@ export default defineComponent({
     onMounted(() => tokenInfoLookup.mount())
     onBeforeUnmount(() => tokenInfoLookup.unmount())
     const tokenInfo = computed(() => tokenInfoLookup.entity.value)
+    const tokenSymbol = computed(() => makeTokenSymbol(tokenInfo.value, 8))
     const initialTokenAmount = computed(
         () => props.currentTokenAllowance?.amount_granted
             ? formatTokenAmount(
@@ -356,7 +357,7 @@ export default defineComponent({
         result = "Previous allowance was to "
             + props.currentTokenAllowance.spender + " for "
             + initialTokenAmount.value
-            + " tokens (" + props.currentTokenAllowance.token_id + ")"
+            + " " + tokenSymbol.value + " tokens (" + props.currentTokenAllowance.token_id + ")"
       } else {
         result = null
       }
@@ -497,9 +498,8 @@ export default defineComponent({
             + " for " + (selectedHbarAmount.value??0/100000000) + " hbars?"
       } else if (allowanceChoice.value === 'token') {
         const token = normalizedToken.value
-        const symbol = makeTokenSymbol(tokenInfo.value, 8)
         result = "Do you want to approve an allowance to account " + toAccount
-            + " for " + selectedTokenAmount.value + " fungible tokens " + symbol + " (" + token + ")?"
+            + " for " + selectedTokenAmount.value + " " + tokenSymbol.value + " tokens (" + token + ")?"
       } else {  // 'nft'
         const nFT = normalizedNFT.value
         result = "Do you want to approve an allowance to account " + toAccount

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -489,6 +489,7 @@ export default defineComponent({
         nftSerialsFeedback)
 
     const showConfirmDialog = ref(false)
+
     const confirmMessage = computed(() => {
       let result: string
       const toAccount = normalizedSpender.value
@@ -558,17 +559,17 @@ export default defineComponent({
           let tid = null
 
           if (allowanceChoice.value === 'hbar') {
-            if (selectedHbarAmount.value) {
+            if (selectedHbarAmount.value != null) {
               tid = normalizeTransactionId(await walletManager.approveHbarAllowance(
                   normalizedSpender.value, parseFloat(selectedHbarAmount.value)))
             }
           } else if (allowanceChoice.value === 'token') {
-              if (normalizedToken.value && rawTokenAmount.value) {
+              if (normalizedToken.value != null && rawTokenAmount.value != null) {
               tid = normalizeTransactionId(await walletManager.approveTokenAllowance(
                   normalizedToken.value, normalizedSpender.value, rawTokenAmount.value))
             }
           } else { // 'nft'
-            if (normalizedNFT.value) {
+            if (normalizedNFT.value != null) {
               tid = normalizeTransactionId(await walletManager.approveNFTAllowance(
                   normalizedNFT.value, normalizedSpender.value, nftSerials.value))
             }

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -495,12 +495,21 @@ export default defineComponent({
       const toAccount = normalizedSpender.value
 
       if (allowanceChoice.value === 'hbar') {
-        result = "Do you want to approve an allowance to account " + toAccount
-            + " for " + (selectedHbarAmount.value??0/100000000) + " hbars?"
+        if (Number(selectedHbarAmount.value) === 0) {
+            result = "Do you want to remove the hbar allowance for account " + toAccount + "?"
+        } else {
+            result = "Do you want to approve an allowance to account " + toAccount
+                + " for " + (selectedHbarAmount.value??0/100000000) + " hbars?"
+        }
       } else if (allowanceChoice.value === 'token') {
         const token = normalizedToken.value
-        result = "Do you want to approve an allowance to account " + toAccount
-            + " for " + selectedTokenAmount.value + " " + tokenSymbol.value + " tokens (" + token + ")?"
+        if (rawTokenAmount.value === 0) {
+          result = "Do you want to remove the allowance to account " + toAccount
+              + " for " + tokenSymbol.value + " token (" + token + ")?"
+        } else {
+          result = "Do you want to approve an allowance to account " + toAccount
+              + " for " + selectedTokenAmount.value + " " + tokenSymbol.value + " tokens (" + token + ")?"
+        }
       } else {  // 'nft'
         const nFT = normalizedNFT.value
         result = "Do you want to approve an allowance to account " + toAccount

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -211,7 +211,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, PropType, Ref, ref, watch} from "vue";
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType, Ref, ref, watch} from "vue";
 import router, {walletManager} from "@/router";
 import {EntityID} from "@/utils/EntityID";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
@@ -221,7 +221,6 @@ import {
   CryptoAllowance,
   Nfts,
   TokenAllowance,
-  TokenInfo,
   TokenRelationshipResponse,
   Transaction,
   TransactionByIdResponse
@@ -233,6 +232,8 @@ import {WalletDriverCancelError, WalletDriverError} from "@/utils/wallet/WalletD
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
+import {formatTokenAmount} from "@/components/values/TokenAmount.vue";
+import {makeTokenSymbol} from "@/schemas/HederaUtils";
 
 const VALID_ACCOUNT_MESSAGE = "Account found"
 const VALID_CONTRACT_MESSAGE = "Contract found"
@@ -277,7 +278,24 @@ export default defineComponent({
     const selectedHbarAmount = ref<string | null>(null)
     const selectedToken = ref<string | null>(null)
     const normalizedToken = computed(() => EntityID.normalize(nr.stripChecksum(selectedToken.value ?? "")))
+    const tokenInfoLookup = TokenInfoCache.instance.makeLookup(normalizedToken)
+    onMounted(() => tokenInfoLookup.mount())
+    onBeforeUnmount(() => tokenInfoLookup.unmount())
+    const tokenInfo = computed(() => tokenInfoLookup.entity.value)
+    const initialTokenAmount = computed(
+        () => props.currentTokenAllowance?.amount_granted
+            ? formatTokenAmount(
+                BigInt(props.currentTokenAllowance.amount_granted),
+                Number(tokenInfo.value?.decimals ?? 0)
+            )
+            : null
+    )
     const selectedTokenAmount = ref<string | null>(null)
+    const rawTokenAmount = computed(
+        () => selectedTokenAmount.value != null
+            ? Number.parseFloat(selectedTokenAmount.value) * Math.pow(10, Number(tokenInfo.value?.decimals))
+            : null
+    )
     const selectedNft = ref<string | null>(null)
     const normalizedNFT = computed(() => EntityID.normalize(nr.stripChecksum(selectedNft.value ?? "")))
     const selectedNftSerials = ref<string | null>(null)
@@ -321,7 +339,7 @@ export default defineComponent({
         result ||= allowanceChoice.value !== "token"
         result ||= selectedSpender.value !== props.currentTokenAllowance?.spender
         result ||= selectedToken.value !== props.currentTokenAllowance.token_id
-        result ||= selectedTokenAmount.value !== (props.currentTokenAllowance?.amount_granted.toString() ?? null)
+        result ||= rawTokenAmount.value !== (props.currentTokenAllowance?.amount_granted ?? null)
       } else {
         result = true
       }
@@ -337,7 +355,7 @@ export default defineComponent({
       } else if (props.currentTokenAllowance) {
         result = "Previous allowance was to "
             + props.currentTokenAllowance.spender + " for "
-            + props.currentTokenAllowance.amount_granted
+            + initialTokenAmount.value
             + " tokens (" + props.currentTokenAllowance.token_id + ")"
       } else {
         result = null
@@ -353,8 +371,8 @@ export default defineComponent({
       ) && edited.value
     })
 
-    watch(() => props.showDialog, (newValue) => {
-      if (newValue) {
+    watch([() => props.showDialog, tokenInfo], () => {
+      if (props.showDialog) {
         if (props.currentHbarAllowance) {
           isEditing.value = true
           allowanceChoice.value = "hbar"
@@ -371,7 +389,12 @@ export default defineComponent({
           selectedSpender.value = props.currentTokenAllowance?.spender ?? null
           selectedHbarAmount.value = null
           selectedToken.value = props.currentTokenAllowance.token_id
-          selectedTokenAmount.value = props.currentTokenAllowance?.amount_granted.toString() ?? null
+          selectedTokenAmount.value = props.currentTokenAllowance.amount_granted
+              ? formatTokenAmount(
+                  BigInt(props.currentTokenAllowance.amount_granted),
+                  Number(tokenInfo.value?.decimals ?? 0)
+              )
+              : null
           selectedNft.value = null
           selectedNftSerials.value = null
         } else {
@@ -474,8 +497,9 @@ export default defineComponent({
             + " for " + (selectedHbarAmount.value??0/100000000) + " hbars?"
       } else if (allowanceChoice.value === 'token') {
         const token = normalizedToken.value
+        const symbol = makeTokenSymbol(tokenInfo.value, 8)
         result = "Do you want to approve an allowance to account " + toAccount
-            + " for " + selectedTokenAmount.value + " fungible tokens (" + token + ")?"
+            + " for " + selectedTokenAmount.value + " fungible tokens " + symbol + " (" + token + ")?"
       } else {  // 'nft'
         const nFT = normalizedNFT.value
         result = "Do you want to approve an allowance to account " + toAccount
@@ -539,9 +563,9 @@ export default defineComponent({
                   normalizedSpender.value, parseFloat(selectedHbarAmount.value)))
             }
           } else if (allowanceChoice.value === 'token') {
-            if (normalizedToken.value && selectedTokenAmount.value) {
+              if (normalizedToken.value && rawTokenAmount.value) {
               tid = normalizeTransactionId(await walletManager.approveTokenAllowance(
-                  normalizedToken.value, normalizedSpender.value, parseFloat(selectedTokenAmount.value)))
+                  normalizedToken.value, normalizedSpender.value, rawTokenAmount.value))
             }
           } else { // 'nft'
             if (normalizedNFT.value) {
@@ -736,15 +760,15 @@ export default defineComponent({
                 const tokens = response.data.tokens
                 if (tokens && tokens.length > 0) {
                   if (type !== null) {
-                    TokenInfoCache.instance.lookup(entity)
-                        .then((t: TokenInfo | null) => {
-                          if (t?.type === type) {
-                            isValid.value = true
+                      if (tokenInfo.value != null) {
+                          if (tokenInfo.value.type === type) {
+                              isValid.value = true
                           } else {
-                            message.value = (type === 'FUNGIBLE_COMMON') ? TOKEN_NOT_FUNGIBLE_MESSAGE : TOKEN_NOT_NFT_MESSAGE
+                              message.value = (type === 'FUNGIBLE_COMMON') ? TOKEN_NOT_FUNGIBLE_MESSAGE : TOKEN_NOT_NFT_MESSAGE
                           }
-                        })
-                        .catch(() => message.value = TOKEN_NOT_FOUND_MESSAGE)
+                      } else {
+                          message.value = TOKEN_NOT_FOUND_MESSAGE
+                      }
                   } else {
                     isValid.value = true
                   }

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -117,14 +117,17 @@ export default defineComponent({
     const isMediumScreen = inject('isMediumScreen', true)
 
     const isWalletConnected = computed(
-        () => walletManager.connected.value && walletManager.accountId.value === props.controller.accountId.value)
+        () => walletManager.isHederaWallet.value
+            && walletManager.connected.value
+            && walletManager.accountId.value === props.controller.accountId.value
+    )
     // const isWalletConnected = computed(() => false)
 
     const allowances = computed<DisplayedTokenAllowance[]>(() => {
         const result = []
         for (const a of props.controller.rows.value) {
             let allowance: DisplayedTokenAllowance = a as DisplayedTokenAllowance
-            isTokenAllowanceEditable(a).then((result) => allowance.isEditable = result)
+            isTokenAllowanceEditable(a).then((r) => allowance.isEditable = r)
             result.push(allowance)
         }
         return result

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -52,10 +52,8 @@
                 <template v-slot:name>Verification Status</template>
                 <template v-slot:value>
                     <div class="is-flex is-align-items-center">
-                        <span>
-                            {{ isFullMatch ? "Full Match" : "Partial Match" }}
-                            <InfoTooltip :label="tooltipText"/>
-                        </span>
+                        <p class="mr-2">{{ isFullMatch ? "Full Match" : "Partial Match" }}</p>
+                        <InfoTooltip :label="tooltipText"/>
                         <button v-if="!isFullMatch" id="verify-button"
                                 class="button is-white h-is-smaller ml-3"
                                 @click="showVerifyDialog = true">

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -28,7 +28,7 @@
   <span v-if="showExtra && tokenId != null">
     <TokenExtra v-bind:token-id="tokenId" v-bind:use-anchor="useAnchor"/>
   </span>
-  <InfoTooltip v-if="decimalOverflow"
+  <InfoTooltip v-if="decimalOverflow" class="ml-2"
                :label="`This token amount cannot be displayed because the number of decimals (${decimalCount}) of the token is too large`"/>
 </template>
 

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -149,7 +149,7 @@ export default defineComponent({
   }
 });
 
-function formatTokenAmount(rawAmount: bigint, decimalCount: number): string {
+export function formatTokenAmount(rawAmount: bigint, decimalCount: number): string {
   let result: string
 
   const amountFormatter = new Intl.NumberFormat('en-US', {

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -156,19 +156,17 @@
           </template>
         </Property>
 
-        <Property id="expiresAt">
+        <Property id="expiresAt" tooltip="Account expiry is not turned on yet. Value in this field is not relevant.">
           <template v-slot:name>
             <span>Expires at</span>
-            <InfoTooltip label="Account expiry is not turned on yet. Value in this field is not relevant."/>
           </template>
           <template v-slot:value>
             <TimestampValue v-bind:show-none="true" v-bind:timestamp="account?.expiry_timestamp"/>
           </template>
         </Property>
-        <Property id="autoRenewPeriod">
+        <Property id="autoRenewPeriod" tooltip="Account auto-renew is not turned on yet. Value in this field is not relevant.">
           <template v-slot:name>
             <span>Auto Renew Period</span>
-            <InfoTooltip label="Account auto-renew is not turned on yet. Value in this field is not relevant."/>
           </template>
           <template v-slot:value>
             <DurationValue v-bind:number-value="account?.auto_renew_period ?? undefined"/>
@@ -310,7 +308,6 @@ import AliasValue from "@/components/values/AliasValue.vue";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import ApproveAllowanceSection from "@/components/allowances/ApproveAllowanceSection.vue";
-import InfoTooltip from "@/components/InfoTooltip.vue";
 import Copyable from "@/components/Copyable.vue";
 import InlineBalancesValue from "@/components/values/InlineBalancesValue.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
@@ -338,7 +335,6 @@ export default defineComponent({
     MirrorLink,
     InlineBalancesValue,
     Copyable,
-    InfoTooltip,
     ApproveAllowanceSection,
     EVMAddress,
     AliasValue,

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -94,28 +94,25 @@
                 <TransactionLink :transactionLoc="contract?.created_timestamp ?? undefined"/>
               </template>
             </Property>
-            <Property id="expiresAt">
+            <Property id="expiresAt" tooltip="Contract expiry is not turned on yet. Value in this field is not relevant.">
               <template v-slot:name>
                 <span>Expires at</span>
-                <InfoTooltip label="Contract expiry is not turned on yet. Value in this field is not relevant."/>
               </template>
               <template v-slot:value>
                 <TimestampValue v-bind:timestamp="contract?.expiration_timestamp" v-bind:show-none="true"/>
               </template>
             </Property>
-            <Property id="autoRenewPeriod">
+            <Property id="autoRenewPeriod" tooltip="Contract auto-renew is not turned on yet. Value in this field is not relevant.">
               <template v-slot:name>
                 <span>Auto Renew Period</span>
-                <InfoTooltip label="Contract auto-renew is not turned on yet. Value in this field is not relevant."/>
               </template>
               <template v-slot:value>
                 <DurationValue v-bind:number-value="contract?.auto_renew_period ?? undefined"/>
               </template>
             </Property>
-            <Property id="autoRenewAccount">
+            <Property id="autoRenewAccount" tooltip="Contract auto-renew is not turned on yet. Value in this field is not relevant.">
               <template v-slot:name>
                 <span>Auto Renew Account</span>
-                <InfoTooltip label="Contract auto-renew is not turned on yet. Value in this field is not relevant."/>
               </template>
               <template v-slot:value>
                 <AccountLink :account-id="autoRenewAccount" :show-none="true" null-label="None"/>
@@ -211,7 +208,6 @@ import TransactionLink from "@/components/values/TransactionLink.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import ContractByteCodeSection from "@/components/contract/ContractByteCodeSection.vue";
 import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
-import InfoTooltip from "@/components/InfoTooltip.vue";
 import Copyable from "@/components/Copyable.vue";
 import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer";
 import ContractResultLogs from "@/components/contract/ContractResultLogs.vue";
@@ -229,7 +225,6 @@ export default defineComponent({
     MirrorLink,
     Copyable,
     ContractByteCodeSection,
-    InfoTooltip,
     ContractResultsSection,
     EVMAddress,
     TransactionLink,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -88,28 +88,25 @@
             <BlobValue :blob-value="tokenInfo?.memo" :show-none="true"/>
           </template>
         </Property>
-        <Property id="expiresAt">
+        <Property id="expiresAt" tooltip="Token expiry is not turned on yet. Value in this field is not relevant.">
           <template v-slot:name>
             <span>Expires at</span>
-            <InfoTooltip label="Token expiry is not turned on yet. Value in this field is not relevant."/>
           </template>
           <template v-slot:value>
             <TimestampValue :nano="true" :show-none="true" :timestamp="tokenInfo?.expiry_timestamp?.toString()"/>
           </template>
         </Property>
-        <Property id="autoRenewPeriod">
+        <Property id="autoRenewPeriod" tooltip="Token auto-renew is not turned on yet. Value in this field is not relevant.">
           <template v-slot:name>
             <span>Auto Renew Period</span>
-            <InfoTooltip label="Token auto-renew is not turned on yet. Value in this field is not relevant."/>
           </template>
           <template v-slot:value>
             <DurationValue v-bind:number-value="tokenInfo?.auto_renew_period ?? undefined"/>
           </template>
         </Property>
-        <Property id="autoRenewAccount">
+        <Property id="autoRenewAccount" tooltip="Token auto-renew is not turned on yet. Value in this field is not relevant.">
           <template v-slot:name>
             <span>Auto Renew Account</span>
-            <InfoTooltip label="Token auto-renew is not turned on yet. Value in this field is not relevant."/>
           </template>
           <template v-slot:value>
             <AccountLink :account-id="tokenInfo?.auto_renew_account" :show-none="true"/>
@@ -328,7 +325,6 @@ import {makeTokenSymbol} from "@/schemas/HederaUtils";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";
 import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
-import InfoTooltip from "@/components/InfoTooltip.vue";
 import Copyable from "@/components/Copyable.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
 
@@ -339,7 +335,6 @@ export default defineComponent({
   components: {
     MirrorLink,
     Copyable,
-    InfoTooltip,
     ContractResultsSection,
     EVMAddress,
     TokenCustomFees,

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -143,11 +143,12 @@
                         :show-extra="true" :timestamp="transaction.consensus_timestamp"/>
           </template>
         </Property>
-        <Property id="maxFee">
+        <Property id="maxFee"
+                  :tooltip="showMaxFeeTooltip
+                  ? 'Max Fee limit does not include the hbar cost of gas consumed by transactions executed on the EVM.'
+                  : undefined">
           <template v-slot:name>
             <span>Max Fee</span>
-            <InfoTooltip v-if="showMaxFeeTooltip"
-                         label="Max Fee limit does not include the hbar cost of gas consumed by transactions executed on the EVM."/>
           </template>
           <template v-slot:value>
             <HbarAmount v-if="transaction" :amount="maxFee" :show-extra="true"
@@ -277,7 +278,6 @@ import {TransactionLocParser} from "@/utils/parser/TransactionLocParser";
 import {TransactionGroupAnalyzer} from "@/components/transaction/TransactionGroupAnalyzer";
 import {TransactionAnalyzer} from "@/components/transaction/TransactionAnalyzer";
 import {TransactionGroupCache} from "@/utils/cache/TransactionGroupCache";
-import InfoTooltip from "@/components/InfoTooltip.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
 import TokenExtra from "@/components/values/TokenExtra.vue";
 
@@ -290,7 +290,6 @@ export default defineComponent({
   components: {
     TokenExtra,
     MirrorLink,
-    InfoTooltip,
     TokenLink,
     TopicMessage,
     ContractResult,

--- a/src/schemas/HederaSchemas.ts
+++ b/src/schemas/HederaSchemas.ts
@@ -24,6 +24,7 @@
 
 import {EntityID} from "@/utils/EntityID";
 import {makeDefaultNodeDescription} from "@/schemas/HederaUtils";
+import {BalanceCache} from "@/utils/cache/BalanceCache";
 
 export interface AccountsResponse {
     accounts: AccountInfo[] | undefined
@@ -105,6 +106,22 @@ export interface TokenAllowancesResponse {
 
 export interface TokenAllowance extends CryptoAllowance {
     token_id: string | null,    // Network entity ID in the format of shard.realm.num
+}
+
+export async function isTokenAllowanceEditable(allowance: TokenAllowance): Promise<boolean> {
+    let result = false
+    if (allowance.owner != null) {
+        const r = await BalanceCache.instance.lookup(allowance.owner, true)
+        if (r && r.balances && r.balances.length >= 1) {
+            for (const balance of r.balances[0].tokens) {
+                if (balance.token_id === allowance.token_id) {
+                    result = true
+                    break
+                }
+            }
+        }
+    }
+    return result
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**:

- Display (i) icon and tooltip instead of edit icon in the `Token Allowances` table when the token is not associated (any more) with the account.
- Fix display of token amount in the `ApproveAllowanceDialog` when the token has decimals.
- Display token symbol in dialog confirmation messages
- Clarify confirmation messages when the edit is in fact a suppression (amount set to 0)

**Related issue(s)**:

Fixes #584

**Notes for reviewer**:

See screen captures in associated issue #584
