### PR TITLE
feat: action for downloading ABI of a verified contract

### DIFF
--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -103,7 +103,7 @@
                         <input type="checkbox" v-model="showHexaOpcode">
                     </label>
                 </div>
-                <div v-else-if="selectedOption==='abi'" class="is-flex is-justify-content-end"><DownloadButton @click="handleDownloadABI"/></div>
+                <div v-else-if="selectedOption==='abi' && showDownloadABI" class="is-flex is-justify-content-end"><DownloadButton @click="handleDownloadABI"/></div>
             </div>
             <SourceCodeValue  v-if="isVerified && selectedOption==='source'" class="mt-3"
                               :source-files="solidityFiles ?? undefined"
@@ -296,6 +296,10 @@ export default defineComponent({
         }
     }
 
+    const showDownloadABI = computed(() => {
+        return routeManager.currentNetworkEntry.value.name == "previewnet"
+    })
+
     return {
       isTouchDevice,
       isSmallScreen,
@@ -324,7 +328,8 @@ export default defineComponent({
       isImportFile,
       relevantPath,
       handleDownload,
-      handleDownloadABI
+      handleDownloadABI,
+      showDownloadABI,
     }
   }
 });

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -103,6 +103,7 @@
                         <input type="checkbox" v-model="showHexaOpcode">
                     </label>
                 </div>
+                <div v-else-if="selectedOption==='abi'" class="is-flex is-justify-content-end"><DownloadButton @click="handleDownloadABI"/></div>
             </div>
             <SourceCodeValue  v-if="isVerified && selectedOption==='source'" class="mt-3"
                               :source-files="solidityFiles ?? undefined"
@@ -273,6 +274,28 @@ export default defineComponent({
         }
     }
 
+    const abiBlob  = computed(() => {
+      let result: Blob|null
+      const itf = props.contractAnalyzer.interface.value
+      if (itf !== null) {
+        result = new Blob([itf.formatJson()], { type: "text/json" })
+      } else {
+        result = null
+      }
+      return result
+    })
+
+    const handleDownloadABI = () => {
+        if (abiBlob.value !== null) {
+            const url = window.URL.createObjectURL(abiBlob.value)
+            const outputName = props.contractAnalyzer.contractName.value + ".json"
+            const a = document.createElement('a')
+            a.setAttribute('href', url)
+            a.setAttribute('download', outputName);
+            a.click()
+        }
+    }
+
     return {
       isTouchDevice,
       isSmallScreen,
@@ -301,6 +324,7 @@ export default defineComponent({
       isImportFile,
       relevantPath,
       handleDownload,
+      handleDownloadABI
     }
   }
 });


### PR DESCRIPTION
**Description**:
Changes below add an action for downloading ABI to `Contract Details` page (in ABI tab).
This button is currently visible on `previewnet` only.
It will be enabled on `testnet` and `mainnet` later.

**Related issue(s)**:

Fixes #934 

**Notes for reviewer**:

![image](https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/88ec251a-d736-46dd-9160-b8e3a1cea0fe)
