### PR TITLE
chore: replaced `web3-utils.toChecksumAddress()` by `ethers.getAddress()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,7 @@
         "prismjs": "^1.29.0",
         "vue": "^3.3.4",
         "vue-prism-component": "^2.0.0",
-        "vue-router": "^4.3.0",
-        "web3-utils": "1.10.0"
+        "vue-router": "^4.3.0"
       },
       "devDependencies": {
         "@cypress/code-coverage": "^3.12.30",
@@ -4750,14 +4749,6 @@
       "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
       "dev": true
     },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
-      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -4834,22 +4825,6 @@
       "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/secp256k1": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
-      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -6712,11 +6687,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
-    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -6777,6 +6747,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -6952,32 +6923,6 @@
         "base-x": "^4.0.0"
       }
     },
-    "node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/bs58check/node_modules/base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bs58check/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -7019,7 +6964,8 @@
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
@@ -7282,6 +7228,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -7721,6 +7668,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -7733,6 +7681,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -9144,14 +9093,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dependencies": {
-        "js-sha3": "^0.8.0"
-      }
-    },
     "node_modules/ethereum-cryptography": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
@@ -9172,43 +9113,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/ethers": {
@@ -9290,24 +9194,6 @@
         }
       }
     },
-    "node_modules/ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-unit/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-    },
     "node_modules/event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -9353,6 +9239,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -10100,6 +9987,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -10671,15 +10559,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
       }
     },
     "node_modules/is-inside-container": {
@@ -12059,6 +11938,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -12652,24 +12532,6 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
-    },
-    "node_modules/number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/number-to-bn/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -13351,6 +13213,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -14141,6 +14004,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -14506,20 +14370,10 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/rlp": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      },
-      "bin": {
-        "rlp": "bin/rlp"
       }
     },
     "node_modules/rollup": {
@@ -14754,25 +14608,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/scrypt-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
-    "node_modules/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -14842,6 +14677,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -15426,18 +15262,6 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
-      "dependencies": {
-        "is-hex-prefixed": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
       }
     },
     "node_modules/strip-json-comments": {
@@ -17346,22 +17170,6 @@
         "web3-providers-ipc": "^4.0.7"
       }
     },
-    "node_modules/web3-core/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
     "node_modules/web3-errors": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web3-errors/-/web3-errors-1.1.4.tgz",
@@ -17412,22 +17220,6 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/web3-eth-abi/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
     "node_modules/web3-eth-accounts": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-4.1.1.tgz",
@@ -17446,22 +17238,6 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/web3-eth-accounts/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
     "node_modules/web3-eth-contract": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-4.2.0.tgz",
@@ -17473,22 +17249,6 @@
         "web3-eth-abi": "^4.2.0",
         "web3-types": "^1.3.1",
         "web3-utils": "^4.1.1",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3-eth-contract/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
         "web3-validator": "^2.0.4"
       },
       "engines": {
@@ -17516,22 +17276,6 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/web3-eth-ens/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
     "node_modules/web3-eth-iban": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-4.0.7.tgz",
@@ -17541,22 +17285,6 @@
         "web3-types": "^1.3.0",
         "web3-utils": "^4.0.7",
         "web3-validator": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3-eth-iban/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
       },
       "engines": {
         "node": ">=14",
@@ -17580,38 +17308,6 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/web3-eth-personal/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3-eth/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
     "node_modules/web3-net": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-4.0.7.tgz",
@@ -17621,22 +17317,6 @@
         "web3-rpc-methods": "^1.1.3",
         "web3-types": "^1.3.0",
         "web3-utils": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3-net/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
       },
       "engines": {
         "node": ">=14",
@@ -17658,22 +17338,6 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/web3-providers-http/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
     "node_modules/web3-providers-ipc": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-4.0.7.tgz",
@@ -17683,23 +17347,6 @@
         "web3-errors": "^1.1.3",
         "web3-types": "^1.3.0",
         "web3-utils": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3-providers-ipc/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "optional": true,
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
       },
       "engines": {
         "node": ">=14",
@@ -17717,22 +17364,6 @@
         "web3-types": "^1.3.0",
         "web3-utils": "^4.0.7",
         "ws": "^8.8.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3-providers-ws/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
       },
       "engines": {
         "node": ">=14",
@@ -17783,20 +17414,19 @@
       }
     },
     "node_modules/web3-utils": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.0.tgz",
-      "integrity": "sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
+      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
       "dependencies": {
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
+        "ethereum-cryptography": "^2.0.0",
+        "eventemitter3": "^5.0.1",
+        "web3-errors": "^1.1.4",
+        "web3-types": "^1.5.0",
+        "web3-validator": "^2.0.4"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14",
+        "npm": ">=6.12.0"
       }
     },
     "node_modules/web3-validator": {
@@ -17809,22 +17439,6 @@
         "web3-errors": "^1.1.4",
         "web3-types": "^1.3.1",
         "zod": "^3.21.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/web3/node_modules/web3-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.2.1.tgz",
-      "integrity": "sha512-Fk29BlEqD9Q9Cnw4pBkKw7czcXiRpsSco/BzEUl4ye0ZTSHANQFfjsfQmNm4t7uY11u6Ah+8F3tNjBeU4CA80A==",
-      "dependencies": {
-        "ethereum-cryptography": "^2.0.0",
-        "eventemitter3": "^5.0.1",
-        "web3-errors": "^1.1.4",
-        "web3-types": "^1.5.0",
-        "web3-validator": "^2.0.4"
       },
       "engines": {
         "node": ">=14",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "prismjs": "^1.29.0",
     "vue": "^3.3.4",
     "vue-prism-component": "^2.0.0",
-    "vue-router": "^4.3.0",
-    "web3-utils": "1.10.0"
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.12.30",

--- a/src/utils/EthereumAddress.ts
+++ b/src/utils/EthereumAddress.ts
@@ -20,7 +20,7 @@
 
 import {byteToHex, hexToByte} from "@/utils/B64Utils";
 import {EntityID} from "@/utils/EntityID";
-import web3Utils  from "web3-utils";
+import {ethers} from "ethers";
 
 export class EthereumAddress {
 
@@ -37,8 +37,8 @@ export class EthereumAddress {
 
     public static normalizeEIP55(byteString: string): string {
         // https://eips.ethereum.org/EIPS/eip-55
-        // https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#tochecksumaddress
-        return web3Utils.toChecksumAddress(byteString)
+        // https://docs.ethers.org/v6/api/address/#getAddress
+        return ethers.getAddress(byteString)
     }
 
     public toString(): string {


### PR DESCRIPTION
**Description**:

Changes below
- replace call to `web3-utils.toChecksumAddress()` by `ethers.getAddress()`
- remove (direct) dependency to `web3-utils` package

Note that Explorer still depends on `web3-utils` package indirectly (through  `@hedera-name-service/hns-resolution-sdk`)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
