### PR TITLE
fix: prevent dissociate token from treasury account

### DIFF
--- a/src/components/AlertDialog.vue
+++ b/src/components/AlertDialog.vue
@@ -1,0 +1,75 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+    <Dialog :controller="controller">
+
+        <template v-slot:dialogInput>
+            <div class="is-flex is-justify-content-center h-is-tertiary-text">
+            <span class="icon has-text-warning h-is-secondary-title mr-3">
+                <i class="fas fa-exclamation-triangle"></i>
+            </span>
+                <slot name="alertMessage"/>
+            </div>
+        </template>
+
+        <template v-slot:dialogInputButtons>
+            <DialogButton :controller="controller">CLOSE</DialogButton>
+        </template>
+
+    </Dialog>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {defineComponent, PropType} from "vue";
+import Dialog from "@/components/dialog/Dialog.vue";
+import CommitButton from "@/components/dialog/CommitButton.vue";
+import DialogButton from "@/components/dialog/DialogButton.vue";
+import DialogTitle from "@/components/dialog/DialogTitle.vue";
+import {DialogController} from "@/components/dialog/DialogController";
+
+export default defineComponent({
+    name: "AlertDialog",
+    components: {DialogTitle, DialogButton, CommitButton, Dialog},
+    props: {
+        controller: {
+            type: Object as PropType<DialogController>,
+            required: true
+        },
+    },
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped/>

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -33,7 +33,7 @@
                         <slot name="dialogTitle"/>
                     </div>
 
-                    <hr class="h-card-separator"/>
+                    <hr v-if="slots.dialogTitle" class="h-card-separator"/>
 
                     <div class="dialog-stack mb-4">
                         <div :class="{'is-invisible': !dialogInputVisible}">
@@ -89,7 +89,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, PropType, watch} from "vue";
+import {computed, defineComponent, PropType, useSlots, watch} from "vue";
 import DialogButton from "@/components/dialog/DialogButton.vue";
 import {DialogController, DialogMode} from "@/components/dialog/DialogController";
 
@@ -103,7 +103,7 @@ export default defineComponent({
         },
     },
     setup(props) {
-
+        const slots = useSlots()
         const dialogInputVisible = computed(() => props.controller.mode.value === DialogMode.Input)
         const dialogBusyVisible = computed(() => props.controller.mode.value === DialogMode.Busy)
         const dialogSuccessVisible = computed(() => props.controller.mode.value === DialogMode.Success)
@@ -116,6 +116,7 @@ export default defineComponent({
         })
 
         return {
+            slots,
             dialogInputVisible,
             dialogBusyVisible,
             dialogSuccessVisible,

--- a/src/components/token/TokenInfoAnalyzer.ts
+++ b/src/components/token/TokenInfoAnalyzer.ts
@@ -90,6 +90,7 @@ export class TokenInfoAnalyzer {
 
     public readonly customFees = computed(() => this.tokenInfo.value?.custom_fees)
 
+    public readonly treasuryAccount = computed(() => this.tokenInfo.value?.treasury_account_id)
 
     public readonly tokenChecksum = computed(() =>
         this.tokenInfo.value?.token_id ? networkRegistry.computeChecksum(


### PR DESCRIPTION
**Description**:

Clicking on the DISSOCIATE action when the connected account is treasury for the token will now bring up an alert dialog explaining why it is not possible.

**Related issue(s)**:

Fixes #942 

**Notes for reviewer**:

<img width="839" alt="Screenshot 2024-03-25 at 17 50 50" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/31ba9254-619d-4e02-9733-d705f089f90d">

