### PR TITLE
feat: ABI tab now displays function selectors

### DIFF
--- a/src/components/values/abi/ContractAbiEntry.vue
+++ b/src/components/values/abi/ContractAbiEntry.vue
@@ -129,9 +129,9 @@ export default defineComponent({
 
         const signature = computed(() => props.contractCallBuilder.fragment.format("full"))
 
-        const mutability = computed(() => (props.contractCallBuilder.fragment.stateMutability as string).toUpperCase())
+        const mutability = computed(() => props.contractCallBuilder.fragment.stateMutability.toUpperCase())
 
-        const selector = computed(() => (props.contractCallBuilder.fragment.selector as string))
+        const selector = computed(() => props.contractCallBuilder.fragment.selector)
 
         const hasResult = computed(() => props.contractCallBuilder.hasResult())
 

--- a/src/components/values/abi/ContractAbiEntry.vue
+++ b/src/components/values/abi/ContractAbiEntry.vue
@@ -35,6 +35,7 @@
         <div class="is-flex is-align-items-baseline">
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ signature }}</prism>
             <div class="h-has-pill h-is-text-size-1 has-background-black has-text-grey has-text-weight-normal">{{ mutability }}</div>
+            <div class="h-has-pill h-is-text-size-1 has-background-black has-text-grey has-text-weight-normal">{{ selector }}</div>
         </div>
 
         <!-- Row 1 -->
@@ -130,6 +131,8 @@ export default defineComponent({
 
         const mutability = computed(() => (props.contractCallBuilder.fragment.stateMutability as string).toUpperCase())
 
+        const selector = computed(() => props.contractCallBuilder.fragment.selector)
+
         const hasResult = computed(() => props.contractCallBuilder.hasResult())
 
         const dialogDidUpdateContractState = () => {
@@ -140,6 +143,7 @@ export default defineComponent({
             running,
             signature,
             mutability,
+            selector,
             isGetter,
             hasResult,
             callOutput: props.contractCallBuilder.callOutput,

--- a/src/components/values/abi/ContractAbiEntry.vue
+++ b/src/components/values/abi/ContractAbiEntry.vue
@@ -35,7 +35,7 @@
         <div class="is-flex is-align-items-baseline">
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ signature }}</prism>
             <div class="h-has-pill h-is-text-size-1 has-background-black has-text-grey has-text-weight-normal">{{ mutability }}</div>
-            <div class="h-has-pill h-is-text-size-1 has-background-black has-text-grey has-text-weight-normal">{{ selector }}</div>
+            <div style="color:#f08d49" class="h-has-pill h-is-text-size-1 has-background-black has-text-weight-normal ml-1">{{ selector }}</div>
         </div>
 
         <!-- Row 1 -->
@@ -131,7 +131,7 @@ export default defineComponent({
 
         const mutability = computed(() => (props.contractCallBuilder.fragment.stateMutability as string).toUpperCase())
 
-        const selector = computed(() => props.contractCallBuilder.fragment.selector)
+        const selector = computed(() => (props.contractCallBuilder.fragment.selector as string))
 
         const hasResult = computed(() => props.contractCallBuilder.hasResult())
 


### PR DESCRIPTION
**Description**:

With changes below, `ABI` tab (in `Contract Details` page) now displays function selectors:

<img width="1178" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/35d10f70-ac86-44fd-959d-d471ff99ed06">

**Related issue(s)**:

Fixes #943

**Notes for reviewer**:

Have a look to contract `testnet/0.0.3580249`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
