### PR TITLE
feat: ABI tab should display index for each function

### DIFF
--- a/src/components/values/abi/ContractAbiEntry.vue
+++ b/src/components/values/abi/ContractAbiEntry.vue
@@ -33,7 +33,7 @@
             <i :class="{ 'fa-play': !isGetter, 'fa-redo': isGetter}" class="fas fa-xs" style="background-color: #202532"/>
         </button>
         <div class="is-flex is-align-items-baseline ml-3">
-            <div class="h-is-text-size-3 has-text-grey has-text-weight-normal">{{ index }}.</div>
+            <div class="h-is-text-size-3 has-text-grey has-text-weight-medium">{{ index }}.</div>
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ signature }}</prism>
             <div class="h-has-pill h-is-text-size-1 has-background-black has-text-grey has-text-weight-normal">{{ mutability }}</div>
             <div style="color:#f08d49" class="h-has-pill h-is-text-size-1 has-background-black has-text-weight-normal ml-1">{{ selector }}</div>

--- a/src/components/values/abi/ContractAbiEntry.vue
+++ b/src/components/values/abi/ContractAbiEntry.vue
@@ -32,7 +32,8 @@
                 v-on:click="handleClick()">
             <i :class="{ 'fa-play': !isGetter, 'fa-redo': isGetter}" class="fas fa-xs" style="background-color: #202532"/>
         </button>
-        <div class="is-flex is-align-items-baseline">
+        <div class="is-flex is-align-items-baseline ml-3">
+            <div class="h-is-text-size-3 has-text-grey has-text-weight-normal">{{ index }}.</div>
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ signature }}</prism>
             <div class="h-has-pill h-is-text-size-1 has-background-black has-text-grey has-text-weight-normal">{{ mutability }}</div>
             <div style="color:#f08d49" class="h-has-pill h-is-text-size-1 has-background-black has-text-weight-normal ml-1">{{ selector }}</div>
@@ -88,6 +89,10 @@ export default defineComponent({
     props: {
         contractCallBuilder: {
             type: Object as PropType<ContractCallBuilder>,
+            required: true
+        },
+        index: {
+            type: Number,
             required: true
         }
     },

--- a/src/components/values/abi/ContractAbiValue.vue
+++ b/src/components/values/abi/ContractAbiValue.vue
@@ -32,9 +32,9 @@
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
                 {{ "//\n// Functions\n//"}}
             </prism>
-            <div v-for="b of contractCallBuilders" :key="b.fragment.selector">
+            <div v-for="(b,i) in contractCallBuilders" :key="b.fragment.selector">
                 <div class="mb-2" style="margin-left: 0.6rem">
-                    <ContractAbiEntry :contract-call-builder="b"
+                    <ContractAbiEntry :contract-call-builder="b" :index="i"
                                       @did-update-contract-state="entryDidUpdateContractState"/>
                 </div>
             </div>


### PR DESCRIPTION
**Description**:

With changes below, `ABI` tab now displays an index before each function of the ABI:

<img width="1178" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/4870b2fc-b7e4-4c00-a556-035fe022508e">


**Related issue(s)**:

Fixes #946

**Notes for reviewer**:

Have a look to contract `testnet/0.0.3580249`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
