### PR TITLE
fix: display hint when wallet is silent

### DIFF
--- a/src/components/TopNavBar.vue
+++ b/src/components/TopNavBar.vue
@@ -165,7 +165,6 @@ import {networkRegistry} from "@/schemas/NetworkRegistry";
 import WalletChooser from "@/components/staking/WalletChooser.vue";
 import { WalletDriver } from '@/utils/wallet/WalletDriver';
 import {WalletDriverCancelError} from '@/utils/wallet/WalletDriverError';
-import ProgressDialog from './staking/ProgressDialog.vue';
 import {defineComponent, inject, ref} from "vue";
 import WalletInfo from '@/components/wallet/WalletInfo.vue'
 import {DialogController} from "@/components/dialog/DialogController";
@@ -173,7 +172,7 @@ import ConnectWalletDialog from "@/components/wallet/ConnectWalletDialog.vue";
 
 export default defineComponent({
   name: "TopNavBar",
-  components: {ConnectWalletDialog, AxiosStatus, SearchBar, WalletChooser, ProgressDialog, WalletInfo},
+  components: {ConnectWalletDialog, AxiosStatus, SearchBar, WalletChooser, WalletInfo},
 
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)

--- a/src/components/dialog/DialogStatus.vue
+++ b/src/components/dialog/DialogStatus.vue
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-    <div class="is-flex is-align-items-baseline my-4">
+    <div class="h-is-property-text my-4">
         <slot name="extraMessage"/>
     </div>
 
@@ -52,7 +52,7 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, PropType, watch} from "vue";
+import {computed, defineComponent, PropType} from "vue";
 import {DialogController, DialogMode} from "@/components/dialog/DialogController";
 
 export default defineComponent({
@@ -63,11 +63,18 @@ export default defineComponent({
             type: Object as PropType<DialogController>,
             required: true
         },
+        isSuccess: Boolean as PropType<boolean|undefined>,
     },
     setup(props) {
 
-        const dialogSuccessVisible = computed(() => props.controller.mode.value === DialogMode.Success)
-        const dialogErrorVisible = computed(() => props.controller.mode.value === DialogMode.Error)
+        const dialogSuccessVisible = computed(
+            () => props.isSuccess !== undefined
+                ? props.isSuccess
+                : props.controller.mode.value === DialogMode.Success)
+        const dialogErrorVisible = computed(
+            () => props.isSuccess !== undefined
+                ? !props.isSuccess
+                : props.controller.mode.value === DialogMode.Error)
 
         return {
             dialogSuccessVisible,

--- a/src/components/wallet/ConnectWalletDialog.vue
+++ b/src/components/wallet/ConnectWalletDialog.vue
@@ -1,0 +1,103 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+    <Dialog :controller="controller">
+
+        <template v-slot:dialogTitle>
+            <DialogTitle>{{ title }}</DialogTitle>
+        </template>
+
+        <template v-slot:dialogInput>
+            <DialogStatus :controller="controller" :is-success="false">
+                <template v-slot:mainMessage>{{ mainMessage }}</template>
+                <template v-slot:extraMessage>{{ extraMessage }}</template>
+            </DialogStatus>
+        </template>
+
+        <template v-slot:dialogInputButtons>
+            <DialogButton :controller="controller">CLOSE</DialogButton>
+        </template>
+
+    </Dialog>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, PropType} from "vue";
+import Dialog from "@/components/dialog/Dialog.vue";
+import DialogButton from "@/components/dialog/DialogButton.vue";
+import DialogTitle from "@/components/dialog/DialogTitle.vue";
+import {DialogController} from "@/components/dialog/DialogController";
+import DialogStatus from "@/components/dialog/DialogStatus.vue";
+import {WalletDriverError} from "@/utils/wallet/WalletDriverError";
+
+export default defineComponent({
+    name: "ConnectWalletDialog",
+
+    components: {DialogStatus, DialogTitle, DialogButton, Dialog},
+
+    props: {
+        controller: {
+            type: Object as PropType<DialogController>,
+            required: true
+        },
+        error: {
+            type: Object as PropType<unknown>,
+            required: false
+        }
+    },
+
+    setup(props) {
+        const title = "Could not connect wallet"
+        const mainMessage = computed(
+            () => props.error instanceof WalletDriverError
+                ? props.error.message
+                : "Unexpected error"
+        )
+        const extraMessage = computed(
+            () => props.error instanceof WalletDriverError
+                ? props.error.extra
+                : JSON.stringify(props.error)
+        )
+        return {
+            title,
+            mainMessage,
+            extraMessage,
+        }
+    },
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped/>

--- a/src/utils/wallet/WalletDriver.ts
+++ b/src/utils/wallet/WalletDriver.ts
@@ -89,7 +89,10 @@ export abstract class WalletDriver {
     }
 
     public silentMessage(): string {
-        return this.name + " is silent";
+        return this.name + " is silent. " +
+            "Try to deactivate and re-activate the extension, " +
+            "then to restart Chrome, " +
+            "and then to re-install the extension."
     }
 
     //

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -93,8 +93,9 @@ describe("App.vue", () => {
 
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
+        console.log(navBar.text())
         expect(navBar.text()).toBe(
-            "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEFillerFillerCLOSEDashboardTransactionsTokensTopicsContractsAccountsNodesBlocksCUSTOMNET1CUSTOMNET2CUSTOMNET3CONNECT WALLET...")
+            "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEDashboardTransactionsTokensTopicsContractsAccountsNodesBlocksCUSTOMNET1CUSTOMNET2CUSTOMNET3CONNECT WALLET...")
 
         expect(wrapper.findComponent(HbarMarketDashboard).exists()).toBe(true)
 

--- a/tests/unit/TopNavBar.spec.ts
+++ b/tests/unit/TopNavBar.spec.ts
@@ -54,7 +54,7 @@ describe("TopNavBar.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe(
-            "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEFillerFillerCLOSEDashboardTransactionsTokensTopicsContractsAccountsNodesStakingBlocksMAINNETTESTNETPREVIEWNETCONNECT WALLET...")
+            "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEDashboardTransactionsTokensTopicsContractsAccountsNodesStakingBlocksMAINNETTESTNETPREVIEWNETCONNECT WALLET...")
 
         const links = wrapper.findAll("a")
         expect(links.length).toBe(18)
@@ -80,7 +80,7 @@ describe("TopNavBar.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe(
-            "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEFillerFillerCLOSEDashboardTransactionsTokensTopicsContractsAccountsNodesStakingBlocksMAINNETTESTNETPREVIEWNETCONNECT WALLET...")
+            "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEDashboardTransactionsTokensTopicsContractsAccountsNodesStakingBlocksMAINNETTESTNETPREVIEWNETCONNECT WALLET...")
 
         const links = wrapper.findAll("a")
         expect(links.length).toBe(18)


### PR DESCRIPTION
**Description**:

- Adresses the issue by adding a couple hints for the user, to the existing error message.
- Also refactors the dialog implementation to use the new dialog components.

**Related issue(s)**:

Fixes #895

**Notes for reviewer**:

- See related issue for reproducing the issue.
- New dialog with hints:

<img width="810" alt="Screenshot 2024-03-27 at 11 47 34" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/605f94a4-b136-47d3-9f7c-a820869c49a3">
