### PR TITLE
fix: too many nested calls break call trace depth path.

### DIFF
--- a/src/components/contract/ContractActionsLoader.ts
+++ b/src/components/contract/ContractActionsLoader.ts
@@ -23,6 +23,8 @@ import axios, {AxiosResponse} from "axios";
 import {computed, ref, Ref, watch} from "vue";
 import {EntityLoader} from "@/utils/loader/EntityLoader";
 
+const MAX_DEPTH_LEVEL = 20
+
 export interface ContractActionWithPath {
     action: ContractAction,
     depthPath: string
@@ -101,8 +103,12 @@ export class ContractActionsLoader extends EntityLoader<ContractActionsResponse>
             depthVector.push(1)
         }
 
-        for (let i = 0; i < depthVector.length; i++) {
-            result += (i === 0) ? depthVector[i] : "_" + depthVector[i]
+        for (let i = 0; i < depthVector.length && i < MAX_DEPTH_LEVEL; i++) {
+            if (i < MAX_DEPTH_LEVEL - 1) {
+                result += (i === 0) ? depthVector[i] : "_" + depthVector[i]
+            } else {
+                result +='(…)'
+            }
         }
 
         return result


### PR DESCRIPTION
**Description**:

Truncate the call trace depth path when nesting level > 20.

**Related issue(s)**:

Fixes #916 

**Notes for reviewer**:

<img width="1424" alt="Screenshot 2024-03-27 at 19 59 13" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/862f4ddf-124e-473a-8308-6875f96f314f">
