### PR TITLE
feat: flag call signature decoded with 4byte.directory

### DIFF
--- a/src/components/values/SignatureValue.vue
+++ b/src/components/values/SignatureValue.vue
@@ -27,7 +27,12 @@
     <HexaValue :byte-string="functionHash" show-none/>
     <div class="h-is-extra-text h-is-text-size-3 should-wrap">{{ signature }}</div>
     <div v-if="is4byteSignature" class="mt-1">
-        <span class="h-has-pill h-is-text-size-1 has-background-grey">4byte.directory</span>
+        <o-tooltip label="Decoding of the signature provided by the 4byte.directory Signature Database"
+                   :delay="200"
+                   multiline="multiline"
+                   class="h-tooltip">
+            <span class="h-has-pill h-is-text-size-1 has-background-grey" style="cursor:default;">4byte</span>
+        </o-tooltip>
     </div>
   </div>
   <div v-else-if="initialLoading"/>

--- a/src/components/values/SignatureValue.vue
+++ b/src/components/values/SignatureValue.vue
@@ -26,6 +26,9 @@
   <div v-if="functionHash">
     <HexaValue :byte-string="functionHash" show-none/>
     <div class="h-is-extra-text h-is-text-size-3 should-wrap">{{ signature }}</div>
+    <div v-if="is4byteSignature" class="mt-1">
+        <span class="h-has-pill h-is-text-size-1 has-background-grey">4byte.directory</span>
+    </div>
   </div>
   <div v-else-if="initialLoading"/>
   <div v-else class="has-text-grey">None</div>
@@ -58,6 +61,7 @@ export default defineComponent({
     return {
       functionHash: props.analyzer.functionHash,
       signature: props.analyzer.signature,
+      is4byteSignature: props.analyzer.is4byteSignature,
       initialLoading
     }
   }

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -357,8 +357,7 @@ export class FunctionCallAnalyzer {
             && paramType.name == "responseCode"
             && typeof value == "bigint") {
             // It's a responseCode from a system contract
-            const message = labelForResponseCode(value)
-            return message
+            return labelForResponseCode(value)
         } else {
             return null
         }

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -32,6 +32,7 @@ export class FunctionCallAnalyzer {
     private readonly contractAnalyzer: ContractAnalyzer
     private readonly signatureResponse = shallowRef<SignatureResponse|null>(null)
     private readonly functionFragment = shallowRef<ethers.FunctionFragment|null>(null)
+    private readonly is4byteFunctionFragment = ref<boolean>(false)
     private readonly functionDecodingFailure = shallowRef<unknown>(null)
     private readonly inputResult = shallowRef<ethers.Result|null>(null)
     private readonly inputDecodingFailure = shallowRef<unknown>(null)
@@ -99,6 +100,10 @@ export class FunctionCallAnalyzer {
 
     public readonly signature: ComputedRef<string|null> = computed(() => {
         return this.functionFragment.value?.format() ?? null
+    })
+
+    public readonly is4byteSignature: ComputedRef<boolean> = computed(() => {
+        return this.is4byteFunctionFragment.value
     })
 
     public readonly errorSignature: ComputedRef<string|null> = computed(() => {
@@ -236,9 +241,11 @@ export class FunctionCallAnalyzer {
                 try {
                     this.functionFragment.value = i.getFunction(functionHash)
                     this.functionDecodingFailure.value = null
+                    this.is4byteFunctionFragment.value = false
                 } catch(failure) {
                     this.functionFragment.value = null
                     this.functionDecodingFailure.value = failure
+                    this.is4byteFunctionFragment.value = false
                 }
             } else if (r !== null && r.results.length >= 1) {
                 let r0: SignatureRecord|null
@@ -256,17 +263,21 @@ export class FunctionCallAnalyzer {
                 if (r0 !== null) {
                     this.functionFragment.value = ethers.FunctionFragment.from(r0.text_signature)
                     this.functionDecodingFailure.value = null
+                    this.is4byteFunctionFragment.value = true
                 } else {
                     this.functionFragment.value = null
                     this.functionDecodingFailure.value = null
+                    this.is4byteFunctionFragment.value = false
                 }
             } else {
                 this.functionFragment.value = null
                 this.functionDecodingFailure.value = null
+                this.is4byteFunctionFragment.value = false
             }
         } else {
             this.functionFragment.value = null
             this.functionDecodingFailure.value = null
+            this.is4byteFunctionFragment.value = false
         }
     }
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -93,7 +93,6 @@ describe("App.vue", () => {
 
         const navBar = wrapper.findComponent(TopNavBar)
         expect(navBar.exists()).toBe(true)
-        console.log(navBar.text())
         expect(navBar.text()).toBe(
             "Connect WalletCANCELCONNECT DisclaimerPlease don't show me this next timeCANCELAGREEDashboardTransactionsTokensTopicsContractsAccountsNodesBlocksCUSTOMNET1CUSTOMNET2CUSTOMNET3CONNECT WALLET...")
 


### PR DESCRIPTION
**Description**:

Changes below add a "4byte" pills in `Call Result` and `Call Trace` sections when a signature has been resolved using `4byte.directory` database.


**Notes for reviewer**:

<img width="1156" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/5a1c758b-74d3-410d-8f9c-6f3813039055">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
