### PR TITLE
feat: separate readonly functions from readwrite and add selection of fragment type displayed

### DIFF
--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -191,6 +191,19 @@ export class AppStorage {
         return this.INPUT_PARAMS + "/" + functionHash + "/" + paramName
     }
 
+    //
+    // selected fragment type in ABI tab
+    //
+
+    private static readonly FRAGMENT_TYPE_KEY = 'fragmentType'
+
+    public static getFragmentType(): string | null {
+        return this.getLocalStorageItem(this.FRAGMENT_TYPE_KEY)
+    }
+
+    public static setFragmentType(newValue: string | null): void {
+        this.setLocalStorageItem(this.FRAGMENT_TYPE_KEY, newValue)
+    }
 
     //
     // Private

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -81,7 +81,7 @@
                 />
                 <div v-if="selectedOption==='source'" class="is-flex is-justify-content-end">
                     <DownloadButton @click="handleDownload" />
-                    <o-field class="ml-4">
+                    <o-field class="ml-2">
                         <o-select v-model="selectedSource" class="h-is-text-size-3">
                             <option value="">All source files</option>
                             <optgroup label="Main contract file">
@@ -103,7 +103,19 @@
                         <input type="checkbox" v-model="showHexaOpcode">
                     </label>
                 </div>
-                <div v-else-if="selectedOption==='abi' && showDownloadABI" class="is-flex is-justify-content-end"><DownloadButton @click="handleDownloadABI"/></div>
+                <div v-else-if="selectedOption==='abi'" class="is-flex is-justify-content-end">
+                    <DownloadButton v-if="showDownloadABI" @click="handleDownloadABI"/>
+                    <o-field class="ml-2">
+                        <o-select v-model="selectedType" class="h-is-text-size-3">
+                            <option :value="FragmentType.ALL">All definitions</option>
+                            <option :value="FragmentType.READONLY">Read-only functions</option>
+                            <option :value="FragmentType.READWRITE">Read-write functions</option>
+                            <option :value="FragmentType.EVENTS">Events</option>
+                            <option :value="FragmentType.ERRORS">Errors</option>
+                            <option :value="FragmentType.OTHER">Other definitions</option>
+                        </o-select>
+                    </o-field>
+                </div>
             </div>
             <SourceCodeValue  v-if="isVerified && selectedOption==='source'" class="mt-3"
                               :source-files="solidityFiles ?? undefined"
@@ -129,7 +141,8 @@
                 </div>
             </div>
             <ContractAbiValue v-if="isVerified && selectedOption==='abi'"
-                              :contract-analyzer="contractAnalyzer">ABI</ContractAbiValue>
+                              :contract-analyzer="contractAnalyzer"
+                              :fragment-type="selectedType"/>
         </template>
     </DashboardCard>
 
@@ -159,7 +172,7 @@ import DisassembledCodeValue from "@/components/values/DisassembledCodeValue.vue
 import HexaValue from "@/components/values/HexaValue.vue";
 import {AppStorage} from "@/AppStorage";
 import SourceCodeValue from "@/components/values/SourceCodeValue.vue";
-import ContractAbiValue from "@/components/values/abi/ContractAbiValue.vue";
+import ContractAbiValue, {FragmentType} from "@/components/values/abi/ContractAbiValue.vue";
 import {SourcifyResponseItem} from "@/utils/cache/SourcifyCache";
 import DownloadButton from "@/components/DownloadButton.vue";
 import JSZip from "jszip";
@@ -274,6 +287,8 @@ export default defineComponent({
         }
     }
 
+    const selectedType = ref<FragmentType>(FragmentType.ALL)
+
     const abiBlob  = computed(() => {
       let result: Blob|null
       const itf = props.contractAnalyzer.interface.value
@@ -328,8 +343,10 @@ export default defineComponent({
       isImportFile,
       relevantPath,
       handleDownload,
+      selectedType,
       handleDownloadABI,
       showDownloadABI,
+      FragmentType
     }
   }
 });

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -142,7 +142,7 @@
             </div>
             <ContractAbiValue v-if="isVerified && selectedOption==='abi'"
                               :contract-analyzer="contractAnalyzer"
-                              :fragment-type="selectedType"/>
+                              :fragment-type="selectedType as FragmentType"/>
         </template>
     </DashboardCard>
 

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -74,7 +74,7 @@
                     <StringValue :string-value="solcVersion ?? undefined"/>
                 </template>
             </Property>
-            <div v-if="isVerified" class="is-flex is-justify-content-space-between is-align-items-center mt-5 mb-0">
+            <div v-if="isVerified" class="is-flex is-justify-content-space-between is-align-items-center mb-0">
                 <Tabs :tab-ids=tabIds :tab-labels=tabLabels
                       :selected-tab="selectedOption"
                       @update:selected-tab="handleTabUpdate($event)"
@@ -117,14 +117,14 @@
                     </o-field>
                 </div>
             </div>
-            <SourceCodeValue  v-if="isVerified && selectedOption==='source'" class="mt-3"
+            <SourceCodeValue  v-if="isVerified && selectedOption==='source'"
                               :source-files="solidityFiles ?? undefined"
                               :filter="selectedSource"/>
             <div v-if="!isVerified || selectedOption==='bytecode'" class="columns is-multiline h-is-property-text" :class="{'mt-3':!isVerified,'mt-0':isVerified}">
                 <div id="bytecode" class="column is-6 pt-0 mb-0" :class="{'is-full': !isSmallScreen}">
                     <span v-if="!isVerified" class="has-text-weight-light">Runtime Bytecode</span>
                     <div>
-                        <ByteCodeValue :byte-code="byteCode ?? undefined" class="mb-0" :class="{'mt-3':isVerified,'mt-4':!isVerified}"/>
+                        <ByteCodeValue :byte-code="byteCode ?? undefined" class="mb-0" :class="{'mt-3':!isVerified}"/>
                     </div>
                 </div>
                 <div id="assembly-code" class="column is-6 pt-0 mb-0" :class="{'h-has-column-separator':isSmallScreen}">
@@ -137,7 +137,7 @@
                             </label>
                         </div>
                     </div>
-                    <DisassembledCodeValue :byte-code="byteCode ?? undefined" :show-hexa-opcode="showHexaOpcode" class="mt-3 mb-0"/>
+                    <DisassembledCodeValue :byte-code="byteCode ?? undefined" :show-hexa-opcode="showHexaOpcode" class="mb-0"/>
                 </div>
             </div>
             <ContractAbiValue v-if="isVerified && selectedOption==='abi'"

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -287,7 +287,17 @@ export default defineComponent({
         }
     }
 
-    const selectedType = ref<FragmentType>(FragmentType.ALL)
+    const selectedType = ref<string>(FragmentType.ALL)
+    onMounted(() => {
+        const preferredType = AppStorage.getFragmentType()
+        if (preferredType && Object.values(FragmentType).includes(preferredType as FragmentType)) {
+            selectedType.value = preferredType
+        } else {
+            AppStorage.setFragmentType(null)
+            selectedType.value = FragmentType.ALL
+        }
+    })
+    watch(selectedType, () => AppStorage.setFragmentType(selectedType.value))
 
     const abiBlob  = computed(() => {
       let result: Blob|null

--- a/src/components/values/abi/ContractAbiValue.vue
+++ b/src/components/values/abi/ContractAbiValue.vue
@@ -28,60 +28,77 @@
          class="h-code-box h-has-page-background mt-2 px-3 py-1"
          style="max-height: 400px;">
 
-        <template v-if="roContractCallBuilders.length >= 1 || rwContractCallBuilders.length >= 1">
-
-            <template v-if="roContractCallBuilders.length >= 1">
-                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
-                    {{ "//\n// Functions (read-only)\n//"}}
-                </prism>
-                <div v-for="(b,i) in roContractCallBuilders" :key="b.fragment.selector">
-                    <div class="mb-2" style="margin-left: 0.6rem">
-                        <ContractAbiEntry :contract-call-builder="b" :index="i"
-                                          @did-update-contract-state="entryDidUpdateContractState"/>
-                    </div>
-                </div>
-            </template>
-            <template v-else>
-                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
-                    {{ "//\n// No read-only function\n//"}}
-                </prism>
-            </template>
-
-            <template v-if="rwContractCallBuilders.length >= 1">
-                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
-                    {{ "//\n// Functions (read-write)\n//"}}
-                </prism>
-                <div v-for="(b,i) in rwContractCallBuilders" :key="b.fragment.selector">
-                    <div class="mb-2" style="margin-left: 0.6rem">
-                        <ContractAbiEntry :contract-call-builder="b" :index="i"
-                                          @did-update-contract-state="entryDidUpdateContractState"/>
-                    </div>
-                </div>
-            </template>
-            <template v-else>
-                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
-                    {{ "//\n// No read-write function\n//"}}
-                </prism>
-            </template>
-
-        </template>
-        <template v-else>
+        <template v-if="showAll && roContractCallBuilders.length == 0 && rwContractCallBuilders.length == 0">
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
                 {{ "//\n// No function\n//"}}
             </prism>
         </template>
+        <template v-else>
+            <template v-if="showReadOnly">
+                <template v-if="roContractCallBuilders.length >= 1">
+                    <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                        {{ "//\n// Functions (read-only)\n//"}}
+                    </prism>
+                    <div v-for="(b,i) in roContractCallBuilders" :key="b.fragment.selector">
+                        <div class="mb-2" style="margin-left: 0.6rem">
+                            <ContractAbiEntry :contract-call-builder="b" :index="i"
+                                              @did-update-contract-state="entryDidUpdateContractState"/>
+                        </div>
+                    </div>
+                </template>
+                <template v-else>
+                    <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                        {{ "//\n// No read-only function\n//"}}
+                    </prism>
+                </template>
+            </template>
 
-        <hr class="has-background-grey-dark m-0" style="height: 0.5px"/>
+            <hr v-if="showAll" class="has-background-grey-dark m-0" style="height: 0.5px"/>
 
-        <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ eventList }}</prism>
+            <template v-if="showReadWrite">
+                <template v-if="rwContractCallBuilders.length >= 1">
+                    <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                        {{ "//\n// Functions (read-write)\n//"}}
+                    </prism>
+                    <div v-for="(b,i) in rwContractCallBuilders" :key="b.fragment.selector">
+                        <div class="mb-2" style="margin-left: 0.6rem">
+                            <ContractAbiEntry :contract-call-builder="b" :index="i"
+                                              @did-update-contract-state="entryDidUpdateContractState"/>
+                        </div>
+                    </div>
+                </template>
+                <template v-else>
+                    <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                        {{ "//\n// No read-write function\n//"}}
+                    </prism>
+                </template>
+            </template>
+        </template>
 
-        <hr class="has-background-grey-dark m-0" style="height: 0.5px"/>
+        <hr v-if="showAll" class="has-background-grey-dark m-0" style="height: 0.5px"/>
 
-        <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ errorList }}</prism>
+        <template v-if="showEvents">
+            <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                {{ eventList }}
+            </prism>
+        </template>
 
-        <hr class="has-background-grey-dark m-0" style="height: 0.5px"/>
+        <hr v-if="showAll" class="has-background-grey-dark m-0" style="height: 0.5px"/>
 
-        <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">{{ otherList }}</prism>
+        <template v-if="showErrors">
+            <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                {{ errorList }}
+            </prism>
+        </template>
+
+        <hr v-if="showAll" class="has-background-grey-dark m-0" style="height: 0.5px"/>
+
+        <template v-if="showOther">
+            <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                {{ otherList }}
+            </prism>
+        </template>
+
     </div>
 
 </template>
@@ -111,21 +128,47 @@ import Prism from "vue-prism-component"
 import {ContractCallBuilder} from "@/components/values/abi/ContractCallBuilder";
 import ContractAbiDialog from "@/components/values/abi/ContractAbiDialog.vue";
 
+export enum FragmentType {
+    ALL = "ALL",
+    READONLY = "READONLY",
+    READWRITE = "READWRITE",
+    EVENTS = "EVENTS",
+    ERRORS = "ERRORS",
+    OTHER = "OTHER",
+}
 
 export default defineComponent({
     components: {
         ContractAbiDialog,
         ContractAbiEntry,
-        DisassembledCodeValue, StringValue, DashboardCard, ByteCodeValue, InfoTooltip, Prism, Property},
+        DisassembledCodeValue,
+        StringValue,
+        DashboardCard,
+        ByteCodeValue,
+        InfoTooltip,
+        Prism,
+        Property
+    },
 
     props: {
         contractAnalyzer: {
             type: Object as PropType<ContractAnalyzer>,
             required: true
+        },
+        fragmentType: {
+            type: String as PropType<FragmentType>,
+            default: FragmentType.ALL
         }
     },
 
     setup: function (props) {
+
+        const showAll = computed(() => props.fragmentType === FragmentType.ALL)
+        const showReadOnly = computed(() => showAll.value || props.fragmentType === FragmentType.READONLY)
+        const showReadWrite = computed(() => showAll.value || props.fragmentType === FragmentType.READWRITE)
+        const showEvents = computed(() => showAll.value || props.fragmentType === FragmentType.EVENTS)
+        const showErrors = computed(() => showAll.value || props.fragmentType === FragmentType.ERRORS)
+        const showOther = computed(() => showAll.value || props.fragmentType === FragmentType.OTHER)
 
         const functionFragments = computed(() => {
             const result: ethers.FunctionFragment[] = []
@@ -261,6 +304,12 @@ export default defineComponent({
         }
 
         return {
+            showAll,
+            showReadOnly,
+            showReadWrite,
+            showEvents,
+            showErrors,
+            showOther,
             roContractCallBuilders,
             rwContractCallBuilders,
             eventList,

--- a/src/components/values/abi/ContractAbiValue.vue
+++ b/src/components/values/abi/ContractAbiValue.vue
@@ -129,12 +129,12 @@ import {ContractCallBuilder} from "@/components/values/abi/ContractCallBuilder";
 import ContractAbiDialog from "@/components/values/abi/ContractAbiDialog.vue";
 
 export enum FragmentType {
-    ALL = "ALL",
-    READONLY = "READONLY",
-    READWRITE = "READWRITE",
-    EVENTS = "EVENTS",
-    ERRORS = "ERRORS",
-    OTHER = "OTHER",
+    ALL = "all",
+    READONLY = "read-only",
+    READWRITE = "read-write",
+    EVENTS = "events",
+    ERRORS = "errors",
+    OTHER = "other",
 }
 
 export default defineComponent({

--- a/src/components/values/abi/ContractAbiValue.vue
+++ b/src/components/values/abi/ContractAbiValue.vue
@@ -28,16 +28,42 @@
          class="h-code-box h-has-page-background mt-2 px-3 py-1"
          style="max-height: 400px;">
 
-        <template v-if="contractCallBuilders.length >= 1">
-            <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
-                {{ "//\n// Functions\n//"}}
-            </prism>
-            <div v-for="(b,i) in contractCallBuilders" :key="b.fragment.selector">
-                <div class="mb-2" style="margin-left: 0.6rem">
-                    <ContractAbiEntry :contract-call-builder="b" :index="i"
-                                      @did-update-contract-state="entryDidUpdateContractState"/>
+        <template v-if="roContractCallBuilders.length >= 1 || rwContractCallBuilders.length >= 1">
+
+            <template v-if="roContractCallBuilders.length >= 1">
+                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                    {{ "//\n// Functions (read-only)\n//"}}
+                </prism>
+                <div v-for="(b,i) in roContractCallBuilders" :key="b.fragment.selector">
+                    <div class="mb-2" style="margin-left: 0.6rem">
+                        <ContractAbiEntry :contract-call-builder="b" :index="i"
+                                          @did-update-contract-state="entryDidUpdateContractState"/>
+                    </div>
                 </div>
-            </div>
+            </template>
+            <template v-else>
+                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                    {{ "//\n// No read-only function\n//"}}
+                </prism>
+            </template>
+
+            <template v-if="rwContractCallBuilders.length >= 1">
+                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                    {{ "//\n// Functions (read-write)\n//"}}
+                </prism>
+                <div v-for="(b,i) in rwContractCallBuilders" :key="b.fragment.selector">
+                    <div class="mb-2" style="margin-left: 0.6rem">
+                        <ContractAbiEntry :contract-call-builder="b" :index="i"
+                                          @did-update-contract-state="entryDidUpdateContractState"/>
+                    </div>
+                </div>
+            </template>
+            <template v-else>
+                <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
+                    {{ "//\n// No read-write function\n//"}}
+                </prism>
+            </template>
+
         </template>
         <template v-else>
             <prism language="solidity" style="background-color: #171920; font-size: 0.7rem">
@@ -206,6 +232,26 @@ export default defineComponent({
             return result
         })
 
+        const roContractCallBuilders = computed(() => {
+            const result: ContractCallBuilder[] = []
+            for (const b of contractCallBuilders.value) {
+                if (b.isReadOnly()) {
+                    result.push(b)
+                }
+            }
+            return result
+        })
+
+        const rwContractCallBuilders = computed(() => {
+            const result: ContractCallBuilder[] = []
+            for (const b of contractCallBuilders.value) {
+                if (!b.isReadOnly()) {
+                    result.push(b)
+                }
+            }
+            return result
+        })
+
         const entryDidUpdateContractState = () => {
             for (const b of contractCallBuilders.value) {
                 if (b.isGetter()) {
@@ -215,7 +261,8 @@ export default defineComponent({
         }
 
         return {
-            contractCallBuilders,
+            roContractCallBuilders,
+            rwContractCallBuilders,
             eventList,
             errorList,
             otherList,


### PR DESCRIPTION
**Description**:

Modify the ABI tab of ContractDetails page:
- show read-only functions and read-write functions as distinct sections
- allow to select the type of fragment definitions displayed:
  -  All definitions
  - Read-only functions
  - Read-write functions
  - Events
  - Errors
  - Other definitions

**Related issue(s)**:

Fixes #948 

**Notes for reviewer**:


<img width="1324" alt="Screenshot 2024-04-01 at 12 02 10" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/17d2ebee-77d2-40af-b50a-107318d072b6">
<img width="1324" alt="Screenshot 2024-04-01 at 12 02 45" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/0328dab7-d728-47ac-9e2a-fb9beddef24a">



**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
