### PR TITLE
fix: decoded message using ethers.toUtf8String()

### DIFF
--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -158,7 +158,7 @@ export function decodeSolidityErrorMessage(message: string | null): string | nul
         } else if (!message.startsWith("0x")) {
             result = message
         } else {
-            result = null;
+            result = ethers.toUtf8String(message);
         }
     } catch (reason) {
         result = null


### PR DESCRIPTION
**Description**:
This PR adds an extra decoding logic to decode error message using ethers.toUtf8String(). 

**UI showcase:
for example, with this transaction on previewnet https://hashscan.io/previewnet/transaction/1713967052.604875873, the error message only shows the hexa data like below
<img width="481" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/66233296/7d7cbd14-7b73-4ae4-90ca-5b9251bfd837">

but using the extra logic mentioned above, it can be decoded like below
<img width="338" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/66233296/a0d2fb95-6264-4d51-8c15-eb27b2f3ce64">


**Related issue(s)**:

Fixes #904

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
