### PR TITLE
fix: call to HTS wrongly decoded using 4byte directory

### DIFF
--- a/src/schemas/SystemContractRegistry.ts
+++ b/src/schemas/SystemContractRegistry.ts
@@ -18,6 +18,8 @@
  *
  */
 
+import {EntityID} from "@/utils/EntityID";
+
 export class SystemContractRegistry {
 
     private readonly entries = new Map<string, SystemContractEntry>()
@@ -29,6 +31,11 @@ export class SystemContractRegistry {
 
     public lookup(contractId: string): SystemContractEntry | null {
         return this.entries.get(contractId) ?? null
+    }
+
+    public lookupByAddress(contractAddress: string): SystemContractEntry | null {
+        const entityID = EntityID.fromAddress(contractAddress)
+        return entityID != null ? this.lookup(entityID.toString()) : null
     }
 
     private addEntry(contractId: string, description: string, abiFileName: string) {

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -79,6 +79,7 @@ export class FunctionCallAnalyzer {
         this.outputDecodingFailure.value = null
         this.errorDescription.value = null
         this.errorDecodingFailure.value = null
+        this.is4byteFunctionFragment.value = false
     }
 
     public readonly normalizedInput: ComputedRef<string | null> = computed(() => {

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -63,6 +63,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) mount
         analyzer.mount()
@@ -79,6 +80,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) setup timestamp
         timestamp.value = CONTRACT_RESULT.timestamp
@@ -94,6 +96,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractType.value).toBe("Post-Eip1559")
         expect(analyzer.contractResult.value).toStrictEqual(CONTRACT_RESULT_DETAILS)
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBe("0x5d123e3f")
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
         // expect(analyzer.functionCallAnalyzer.signature.value).toBe("forwardDepositToICHIVault(address,address,address,uint256,uint256,address)")
 
         // 4) unmount
@@ -110,6 +113,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 5) check history
         console.log(JSON.stringify(fetchGetURLs(mock), null, "  "))
@@ -159,6 +163,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) setup timestamp
         timestamp.value = CONTRACT_RESULT.timestamp
@@ -175,6 +180,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) mount
         analyzer.mount()
@@ -190,6 +196,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractType.value).toBe("Post-Eip1559")
         expect(analyzer.contractResult.value).toStrictEqual(CONTRACT_RESULT_DETAILS)
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBe("0x5d123e3f")
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
         // expect(analyzer.functionCallAnalyzer.signature.value).toBe("forwardDepositToICHIVault(address,address,address,uint256,uint256,address)")
 
         // 4) unmount
@@ -206,6 +213,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 5) check history
         console.log(JSON.stringify(fetchGetURLs(mock), null, "  "))
@@ -238,6 +246,11 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         const matcher3 = "http://localhost:3000/abi/IHederaTokenService.json"
         mock.onGet(matcher3).reply(200, abi)
 
+        // We also setup valid 4byte matcher to be sure it is ignored by ContractResultAnalyzer.
+        const functionHash = "0x49146bde"
+        const matcher4 = "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=" + functionHash
+        mock.onGet(matcher4).reply(200, BYTES4_RESPONSE)
+
         // 1) new
         const timestamp = ref<string | null>(null)
         const analyzer = new ContractResultAnalyzer(timestamp)
@@ -253,6 +266,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) setup timestamp
         timestamp.value = CONTRACT_RESULT_HTS.timestamp
@@ -269,13 +283,14 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) mount
         analyzer.mount()
         await flushPromises()
         expect(analyzer.timestamp.value).toBe(CONTRACT_RESULT_HTS.timestamp)
         expect(analyzer.fromId.value).toBe("0.0.1584")
-        expect(analyzer.toId.value).toBe(CONTRACT_RESULT_HTS.contract_id)
+        expect(analyzer.toId.value).toBe("0.0.359")
         expect(analyzer.gasPrice.value).toBeNull()
         expect(analyzer.maxFeePerGas.value).toBeNull()
         expect(analyzer.maxPriorityFeePerGas.value).toBeNull()
@@ -285,6 +300,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toStrictEqual(CONTRACT_RESULT_DETAILS_HTS)
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
         expect(analyzer.functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 4) unmount
         analyzer.unmount()
@@ -300,6 +316,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractResult.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
         expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 5) check history
         expect(fetchGetURLs(mock)).toStrictEqual([
@@ -821,7 +838,7 @@ const CONTRACT_RESULT_HTS = {
     "amount": 0,
     "bloom": "0x",
     "call_result": "0x0000000000000000000000000000000000000000000000000000000000000146",
-    "contract_id": "0.0.359",
+    "contract_id": null,
     "created_contract_ids": [],
     "error_message": "INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE",
     "from": "0x0000000000000000000000000000000000000630",
@@ -856,7 +873,7 @@ const CONTRACT_RESULT_DETAILS_HTS = {
     "amount": 0,
     "bloom": "0x",
     "call_result": "0x0000000000000000000000000000000000000000000000000000000000000146",
-    "contract_id": "0.0.359",
+    "contract_id": null,
     "created_contract_ids": [],
     "error_message": "INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE",
     "from": "0x0000000000000000000000000000000000000630",
@@ -887,3 +904,19 @@ const CONTRACT_RESULT_DETAILS_HTS = {
     "v": null,
     "nonce": null
 }
+
+const BYTES4_RESPONSE = {
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 951384,
+            "created_at": "2023-03-09T19:31:27.895916Z",
+            "text_signature": "associateToken(address,address)",
+            "hex_signature": "0x49146bde",
+            "bytes_signature": "I\u0014kÞ"
+        }
+    ]
+}
+

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -54,6 +54,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) mount
         functionCallAnalyzer.mount()
@@ -69,6 +70,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) input setup (valid encoding)
         input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
@@ -91,6 +93,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 4) input setup (invalid input encoding)
         input.value = "0x618dc65e0000000000000000000000000000000000163b5a70a082310000000000000000000000005fe56763c7633efefe8c2272f19732521a48e300"
@@ -108,6 +111,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBe("Decoding Error (data out-of-bounds)")
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x0000000000000000000000000000000000163b5a70a082310000000000000000000000005fe56763c7633efefe8c2272f19732521a48e300")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 5) output setup (invalid output encoding)
         input.value = "0x49146bde000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09"
@@ -129,6 +133,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBe("Decoding Error (invalid BytesLike value)")
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull() // 0x is considered as no error
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
 
         // 6) unmount
@@ -145,6 +150,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000845b706151aed537b1fd81c1ea4ea03920097abd0000000000000000000000000000000000000000000000000000000002e6ae09")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         mock.restore()
     })
@@ -174,6 +180,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) mount
         functionCallAnalyzer.mount()
@@ -189,6 +196,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) setup
         input.value = "0xf305d719000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af"
@@ -216,6 +224,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
 
         // 4) unmount
@@ -232,6 +241,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         mock.restore()
 
@@ -262,6 +272,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) setup
         input.value = "0xf305d719000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af"
@@ -280,6 +291,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) mount
         functionCallAnalyzer.mount()
@@ -304,6 +316,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
 
         // 4) unmount
@@ -320,6 +333,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         mock.restore()
 
@@ -351,6 +365,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 2) mount
         functionCallAnalyzer.mount()
@@ -366,6 +381,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBeNull()
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 3) setup
         input.value = "0xf305d719000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af"
@@ -392,6 +408,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(true)
 
 
         // 4) unmount
@@ -408,6 +425,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x000000000000000000000000000000000000000000000000000000000022d6de0000000000000000000000000000000000000000000000000000015076ac13000000000000000000000000000000000000000000000000000000014ec7ffb1a00000000000000000000000000000000000000000000000000000000f558e95eb00000000000000000000000000000000000000000000000000000000000f45b30000000000000000000000000000000000000000000000000000018cd5a698af")
+        expect(functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         mock.restore()
 


### PR DESCRIPTION
**Description**:
Root cause is that `ContractResultAnalyzer.updateToId()` attempts (and fails) to call `ContractByAddressCache.lookup()` with contract address `0x00000000000000000167`.
With changes below, `updateToId()` now checks if target is a system contract and derives contract id from the address.
Changes also include some unit test improvements to validate this situation.

**Related issue(s)**:

Fixes #994 

**Notes for reviewer**:

Use transaction to see fix in action: [1713967052.604875873](https://hashscan.io/previewnet/transaction/1713967052.604875873) (see #994 for details)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
