### PR TITLE
fix: line-height in NftDetailsTransferGraph.

### DIFF
--- a/src/components/transfer_graphs/NftDetailsTransferGraph.vue
+++ b/src/components/transfer_graphs/NftDetailsTransferGraph.vue
@@ -174,10 +174,12 @@ export default defineComponent({
 .graph-container {
   display: inline-grid;
   grid-template-columns: repeat(5, auto);
+  line-height: 1.4rem;
   column-gap: 1em;
 }
 
 .graph-container-6 {
   grid-template-columns: repeat(6, auto);
+  line-height: 1.4rem;
 }
 </style>


### PR DESCRIPTION
**Description**:

Fix layout issue in the transfer graph of the Recent Transactions table in NftDetails view.

**Related issue(s)**:

None.

**Notes for reviewer**:

Before:
<img width="1181" alt="Screenshot 2024-05-07 at 14 46 15" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/14299b1e-f453-4d7c-a0ed-ed74e4beee7d">

After:
<img width="1181" alt="Screenshot 2024-05-07 at 14 46 59" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/10e500fc-bc07-478b-b4ac-77b60d04e18b">
