### PR TITLE
feat: add `Create Transaction` link to `TokenDetails`

### DIFF
--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -79,6 +79,12 @@
             />
           </template>
         </Property>
+        <Property id="createTransaction">
+          <template v-slot:name>Mint Transaction</template>
+          <template v-slot:value>
+            <TransactionLink :transactionLoc="nftInfo?.created_timestamp ?? undefined"/>
+          </template>
+        </Property>
         <Property id="metadata">
           <template #name>Metadata</template>
           <template #value>
@@ -147,15 +153,7 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <script lang="ts">
-import {
-  computed,
-  defineComponent,
-  inject,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  watch,
-} from "vue"
+import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch,} from "vue"
 import router, {routeManager} from "@/router"
 import TimestampValue from "@/components/values/TimestampValue.vue"
 import DashboardCard from "@/components/DashboardCard.vue"
@@ -174,11 +172,13 @@ import TransactionFilterSelect from "@/components/transaction/TransactionFilterS
 import {makeTokenSymbol} from "@/schemas/HederaUtils";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import TokenLink from "@/components/values/link/TokenLink.vue";
+import TransactionLink from "@/components/values/TransactionLink.vue";
 
 export default defineComponent({
   name: "NftDetails",
 
   components: {
+    TransactionLink,
     TokenLink,
     ContractResultsSection,
     PlayPauseButton,

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -99,6 +99,12 @@
             />
           </template>
         </Property>
+        <Property id="createTransaction">
+          <template v-slot:name>Create Transaction</template>
+          <template v-slot:value>
+            <TransactionLink :transactionLoc="tokenInfo?.created_timestamp ?? undefined"/>
+          </template>
+        </Property>
         <Property id="expiresAt" tooltip="Token expiry is not turned on yet. Value in this field is not relevant.">
           <template v-slot:name>
             <span>Expires at</span>
@@ -348,12 +354,14 @@ import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";
 import ContractResultsSection from "@/components/contracts/ContractResultsSection.vue";
 import Copyable from "@/components/Copyable.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
+import TransactionLink from "@/components/values/TransactionLink.vue";
 
 export default defineComponent({
 
   name: 'TokenDetails',
 
   components: {
+    TransactionLink,
     MirrorLink,
     Copyable,
     ContractResultsSection,

--- a/tests/e2e/specs/TokenNavigation.cy.ts
+++ b/tests/e2e/specs/TokenNavigation.cy.ts
@@ -74,6 +74,17 @@ describe('Token Navigation', () => {
         cy.contains('Non Fungible Token')
         cy.contains('Token ID:' + nftId)
 
+        cy.get('#createTransactionValue')
+            cy.contains('@')
+            .click()
+            .then( () => {
+                cy.url().should('include', '/mainnet/transaction/')
+                cy.contains('Token ID' + nftId)
+            })
+
+        cy.go("back")
+        cy.url().should('include', '/mainnet/token/' + nftId)
+
         cy.get('#nft-holder-table')
             .find('tbody tr')
             .should('be.visible')
@@ -98,6 +109,17 @@ describe('Token Navigation', () => {
         cy.url().should('include', '/mainnet/token/' + tokenId)
         cy.contains('Fungible Token')
         cy.contains('Token ID:' + tokenId)
+
+        cy.get('#createTransactionValue')
+        cy.contains('@')
+            .click()
+            .then( () => {
+                cy.url().should('include', '/mainnet/transaction/')
+                cy.contains('Token ID' + tokenId)
+            })
+
+        cy.go("back")
+        cy.url().should('include', '/mainnet/token/' + tokenId)
 
         cy.get('#token-balance-table')
             .find('tbody tr')

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -18,18 +18,21 @@
  *
  */
 
-import {describe, it, expect} from 'vitest'
+import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import TokenDetails from "@/pages/TokenDetails.vue";
 import axios from "axios";
 import {
-    SAMPLE_BALANCES, SAMPLE_NETWORK_EXCHANGERATE,
-    SAMPLE_NFTS, SAMPLE_NONFUNGIBLE,
+    SAMPLE_BALANCES,
+    SAMPLE_NETWORK_EXCHANGERATE,
+    SAMPLE_NFTS,
+    SAMPLE_NONFUNGIBLE,
     SAMPLE_NONFUNGIBLE_DUDE,
     SAMPLE_TOKEN,
     SAMPLE_TOKEN_WITH_KEYS,
-    SAMPLE_TOKEN_WITHOUT_KEYS
+    SAMPLE_TOKEN_WITHOUT_KEYS,
+    SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import TokenBalanceTable from "@/components/token/TokenBalanceTable.vue";
 import MockAdapter from "axios-mock-adapter";
@@ -40,6 +43,7 @@ import TokenCustomFees from "@/components/token/TokenCustomFees.vue";
 import FixedFeeTable from "@/components/token/FixedFeeTable.vue";
 import FractionalFeeTable from "@/components/token/FractionalFeeTable.vue";
 import RoyaltyFeeTable from "@/components/token/RoyaltyFeeTable.vue";
+import {TransactionID} from "../../../src/utils/TransactionID";
 
 /*
     Bookmarks
@@ -66,6 +70,8 @@ describe("TokenDetails.vue", () => {
         mock.onGet(matcher2).reply(200, SAMPLE_BALANCES);
         const matcher3 = "/api/v1/contracts/" + testTokenId + "/results"
         mock.onGet(matcher3).reply(200, []);
+        const matcher4 = "/api/v1/transactions"
+        mock.onGet(matcher4).reply(200, SAMPLE_TRANSACTIONS);
 
         const wrapper = mount(TokenDetails, {
             global: {
@@ -103,6 +109,8 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#decimalsValue").text()).toBe("0")
         expect(wrapper.get("#evmAddress").text()).toMatch(
             RegExp("^EVM Address:0x0000000000000000000000000000000001c49eecCopy"))
+
+        expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))
 
         expect(wrapper.text()).toMatch("Balances")
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(true)

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -32,6 +32,7 @@ import {
     SAMPLE_TOKEN,
     SAMPLE_TOKEN_WITH_KEYS,
     SAMPLE_TOKEN_WITHOUT_KEYS,
+    SAMPLE_TRANSACTION,
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import TokenBalanceTable from "@/components/token/TokenBalanceTable.vue";


### PR DESCRIPTION
**Description**:

Similar to what exists already in `AccountDetails` and `ContractDetails`, this adds:
- a `Create Transaction` property to the `TokenDetails` view, with a link to the transaction which created that token.
- a `Mint Transaction` property to the `NftDetails` view, with a link to the transaction which minted that NFT.

**Related issue(s)**:

Fixes #1010 

**Notes for reviewer**:

<img width="1372" alt="Screenshot 2024-05-16 at 10 33 12" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/f5c97fde-feb8-45b3-a7e4-b8aff1aca6f3">

<img width="1544" alt="Screenshot 2024-05-16 at 14 27 02" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/b9669f8b-fe82-4dee-8b0c-31a6b120c85a">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
