### PR TITLE
00972 Use names resolved by Search Bar to label account ids

### DIFF
--- a/src/components/values/link/AccountIOL.vue
+++ b/src/components/values/link/AccountIOL.vue
@@ -34,10 +34,9 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref} from "vue";
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
 import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
-import {initialLoadingKey} from "@/AppKeys";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
 
 export default defineComponent({
@@ -54,7 +53,6 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const initialLoading = inject(initialLoadingKey, ref(false))
 
     const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.accountId))
     onMounted(
@@ -73,7 +71,6 @@ export default defineComponent({
     )
 
     return {
-      initialLoading,
       label: labelLookup.entity,
     }
   }

--- a/src/components/values/link/AccountIOL.vue
+++ b/src/components/values/link/AccountIOL.vue
@@ -36,8 +36,8 @@
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
-import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
+import {NamingStore} from "@/utils/name_service/NamingStore";
 
 export default defineComponent({
   name: "AccountIOL",
@@ -54,13 +54,9 @@ export default defineComponent({
   },
   setup(props) {
 
-    const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.accountId))
-    onMounted(
-        () => labelLookup.mount()
-    )
-    onBeforeUnmount(
-        () => labelLookup.unmount()
-    )
+    const domainName = computed(() => {
+      return props.accountId ? NamingStore.instance.lookup(props.accountId) : null
+    })
 
     const networkLookup = NetworkCache.instance.makeLookup()
     onMounted(
@@ -71,7 +67,7 @@ export default defineComponent({
     )
 
     return {
-      label: labelLookup.entity,
+      label: domainName,
     }
   }
 })

--- a/src/components/values/link/ContractIOL.vue
+++ b/src/components/values/link/ContractIOL.vue
@@ -37,6 +37,7 @@
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
+import {NamingStore} from "@/utils/name_service/NamingStore";
 
 export default defineComponent({
   name: "ContractIOL",
@@ -48,15 +49,12 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.contractId))
-    onMounted(
-        () => labelLookup.mount()
-    )
-    onBeforeUnmount(
-        () => labelLookup.unmount()
-    )
+
+    const domainName = computed(() => {
+      return props.contractId ? NamingStore.instance.lookup(props.contractId) : null
+    })
     return {
-      label: labelLookup.entity
+      label: domainName
     }
   }
 })

--- a/src/components/values/link/EntityIOL.vue
+++ b/src/components/values/link/EntityIOL.vue
@@ -58,7 +58,7 @@
 import {computed, defineComponent, inject, PropType, ref} from "vue";
 import {initialLoadingKey} from "@/AppKeys";
 
-export const MAX_LABEL_SIZE = 35
+export const DEFAULT_LABEL_SIZE = 18
 
 export default defineComponent({
 
@@ -75,7 +75,7 @@ export default defineComponent({
     },
     slice: {
       type: Number as PropType<number | null>,
-      default: MAX_LABEL_SIZE
+      default: DEFAULT_LABEL_SIZE
     },
     compact: {
       type: Boolean,
@@ -90,14 +90,13 @@ export default defineComponent({
   setup(props) {
     const initialLoading = inject(initialLoadingKey, ref(false))
 
-    const slice = computed(() => props.compact ? 12 : props.slice)
     const label = computed(() => {
       let result = props.label
       if (result != null
-          && slice.value != null
-          && slice.value > 0
-          && slice.value < result.length) {
-        result = result.slice(0, slice.value) + '…'
+          && props.slice != null
+          && props.slice > 0
+          && props.slice < result.length) {
+        result = result.slice(0, props.slice) + '…'
       }
       return result
     })

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -56,6 +56,14 @@
             <EVMAddress :show-id="false" :has-custom-font="true" :address="ethereumAddress"/>
           </div>
         </div>
+        <div v-if="domainName" id="names" class="h-is-tertiary-text mt-2" style="word-break: keep-all">
+          <div class="is-inline-block h-is-property-text has-text-weight-light" style="min-width: 115px">Domain:</div>
+          <div class="is-inline-block h-is-property-text">
+            <div class="is-inline-block">
+              <EntityIOL :label="domainName"/>
+            </div>
+          </div>
+        </div>
 
         <div v-if="!isMediumScreen && showContractVisible && contractRoute" id="showContractLink"
              class="is-inline-block mt-2">
@@ -336,12 +344,15 @@ import DateTimePicker from "@/components/DateTimePicker.vue";
 import DownloadButton from "@/components/DownloadButton.vue";
 import {DialogController} from "@/components/dialog/DialogController";
 import TransactionDownloadDialog from "@/components/download/TransactionDownloadDialog.vue";
+import EntityIOL from "@/components/values/link/EntityIOL.vue";
+import {NamingStore} from "@/utils/name_service/NamingStore";
 
 export default defineComponent({
 
   name: 'AccountDetails',
 
   components: {
+    EntityIOL,
     TransactionDownloadDialog,
     DownloadButton,
     AccountCreatedContractsTable,
@@ -492,6 +503,13 @@ export default defineComponent({
 
     const downloadController = new DialogController()
 
+    //
+    // Naming
+    //
+
+    const domainName = computed(
+        () => props.accountId ? NamingStore.instance.lookup(props.accountId) : null)
+
     return {
       isSmallScreen,
       isMediumScreen,
@@ -529,7 +547,8 @@ export default defineComponent({
       filterVerified,
       downloadController,
       timeSelection,
-      onDateCleared
+      onDateCleared,
+      domainName
     }
   }
 });

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -47,6 +47,14 @@
             <EVMAddress :show-id="false" :has-custom-font="true" :address="ethereumAddress"/>
           </div>
         </div>
+        <div v-if="domainName" id="names" class="h-is-tertiary-text mt-2" style="word-break: keep-all">
+          <div class="is-inline-block h-is-property-text has-text-weight-light" style="min-width: 115px">Domain:</div>
+          <div class="is-inline-block h-is-property-text">
+            <div class="is-inline-block">
+              <EntityIOL :label="domainName"/>
+            </div>
+          </div>
+        </div>
         <div v-if="!isMediumScreen && accountRoute" id="showAccountLink" class="is-inline-block mt-2">
           <router-link :to="accountRoute">
             <span class="h-is-property-text">Show associated account</span>
@@ -220,12 +228,15 @@ import {ContractResultsLogsAnalyzer} from "@/utils/analyzer/ContractResultsLogsA
 import {BalanceAnalyzer} from "@/utils/analyzer/BalanceAnalyzer";
 import InlineBalancesValue from "@/components/values/InlineBalancesValue.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
+import {NamingStore} from "@/utils/name_service/NamingStore";
+import EntityIOL from "@/components/values/link/EntityIOL.vue";
 
 export default defineComponent({
 
   name: 'ContractDetails',
 
   components: {
+    EntityIOL,
     InlineBalancesValue,
     MirrorLink,
     Copyable,
@@ -325,6 +336,13 @@ export default defineComponent({
     onMounted(() => contractResultsLogsAnalyzer.mount())
     onBeforeUnmount(() => contractResultsLogsAnalyzer.unmount())
 
+    //
+    // Naming
+    //
+
+    const domainName = computed(
+        () => props.contractId ? NamingStore.instance.lookup(props.contractId) : null)
+
     return {
       isSmallScreen,
       isMediumScreen,
@@ -341,7 +359,8 @@ export default defineComponent({
       normalizedContractId,
       accountRoute,
       contractAnalyzer,
-      logs: contractResultsLogsAnalyzer.logs
+      logs: contractResultsLogsAnalyzer.logs,
+      domainName
     }
   },
 });

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -41,6 +41,7 @@ import {hnsResolve} from "@/utils/name_service/HNS";
 import {Timestamp} from "@/utils/Timestamp";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import {routeManager} from "@/router";
+import {NamingStore} from "@/utils/name_service/NamingStore";
 
 export class SearchRequest {
 
@@ -350,6 +351,7 @@ export class SearchRequest {
             if (accountId !== null) {
                 const r = await axios.get<AccountBalanceTransactions>("api/v1/accounts/" + accountId)
                 this.account = r.data
+                NamingStore.instance.push(accountId, name)
             } else {
                 this.account = null
             }

--- a/src/utils/name_service/NamingStore.ts
+++ b/src/utils/name_service/NamingStore.ts
@@ -1,0 +1,37 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+
+
+export class NamingStore {
+
+    public static readonly instance = new NamingStore()
+
+    private readonly entries = new Map<string, string>()
+
+    public push(accountId: string, name: string) {
+        this.entries.set(accountId, name)
+    }
+
+    public lookup(accountId: string): string|null {
+        return this.entries.get(accountId) ?? null
+    }
+}


### PR DESCRIPTION
**Description**:

Changes below implement request #972.
When users searches for a domain name in Search Bar, result of the search is saved in memory and used by Explorer to decorate its pages.

1) `Account Details` displays the resolved name in `Domain` field (below the `EVM Address`):
<img width="1513" alt="Capture d’écran 2024-05-17 à 13 12 25" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/f4e0241e-e591-4a25-b283-27d425c9d938">

2) Explorer then displays resolved name in every places where account id is normally displayed (eg `Transfer Graphs`, `Contract Result` section)
<img width="1513" alt="Capture d’écran 2024-05-17 à 13 14 09" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/bb9008f2-c82d-446e-b9dc-0e4bdf79cada">

***Note:***
Name resolutions are saved in browser memory: they remain until next page reload.

**Related issue(s)**:

Fixes #972

**Notes for reviewer**:

<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
