### PR TITLE
chore: Decouple sonar analysis from unit tests in CI

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -35,10 +35,8 @@ jobs:
     with:
       custom-job-label: Standard
       enable-unit-tests: true
-      enable-sonar-analysis: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      sonar-token: ${{ secrets.SONAR_TOKEN }}
 
   e2e-tests:
     name: E2E Tests
@@ -48,3 +46,13 @@ jobs:
       enable-e2e-tests: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
+
+  sonar-analysis:
+    name: Sonar Analysis
+    uses: ./.github/workflows/comp-compile-explorer-code.yaml
+    with:
+      custom-job-label: Standard
+      enable-sonar-analysis: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
**Description**:

Decouple sonar analysis from unit tests execution in CI. This will allow to check the result of unit tests more easily when the PR comes from a different repository (in that case the sonar analysis step always fails by lack of Sonar token).

**Related issue(s)**:

Fixes #606
