### PR TITLE
00972 Use names resolved by Search Bar to label account ids

### DIFF
--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -219,6 +219,43 @@ export class AppStorage {
         this.setLocalStorageItem(this.SHOW_LOGIC_ABI_KEY, newValue ? "true" : null)
     }
 
+    //
+    // name resolution
+    //
+
+    private static readonly NAMING = "naming"
+
+    public static getNameRecord(entityId: string, network: string): NameRecord|null {
+        const key = this.makeNamingKey(entityId, network)
+        const jsonText = this.getLocalStorageItem(key)
+        let result: unknown|null
+        if (jsonText !== null) {
+            try {
+                result = JSON.parse(jsonText)
+            } catch {
+                result = null
+            }
+        } else {
+            result = null
+        }
+        return result as NameRecord|null
+    }
+
+    public static setNameRecord(entityId: string, name: string, network: string): void {
+        const t = new Date().getTime()
+        const newRecord: NameRecord = { entityId, name, timestamp: t}
+        const jsonText = JSON.stringify(newRecord)
+        this.setLocalStorageItem(this.makeNamingKey(entityId, network), jsonText)
+    }
+
+    public static clearNameRecord(entityId: string, network: string): void {
+        this.setLocalStorageItem(this.makeNamingKey(entityId, network), null)
+    }
+
+    private static makeNamingKey(entityId: string, network: string): string {
+        return this.NAMING + "/" + network + "/" + entityId
+    }
+
 
     //
     // Private
@@ -280,4 +317,10 @@ export class AppStorage {
         }
         return result
     }
+}
+
+export interface NameRecord {
+    entityId: string
+    name: string
+    timestamp: number // Date.getTime()
 }

--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -19,6 +19,7 @@
  */
 
 import {NetworkEntry, networkRegistry} from "@/schemas/NetworkRegistry";
+import {ref} from "vue";
 
 export class AppStorage {
 
@@ -246,11 +247,15 @@ export class AppStorage {
         const newRecord: NameRecord = { entityId, name, timestamp: t}
         const jsonText = JSON.stringify(newRecord)
         this.setLocalStorageItem(this.makeNamingKey(entityId, network), jsonText)
+        this.nameRecordChangeCounter.value += 1
     }
 
     public static clearNameRecord(entityId: string, network: string): void {
         this.setLocalStorageItem(this.makeNamingKey(entityId, network), null)
+        this.nameRecordChangeCounter.value += 1
     }
+
+    public static readonly nameRecordChangeCounter = ref(0)
 
     private static makeNamingKey(entityId: string, network: string): string {
         return this.NAMING + "/" + network + "/" + entityId

--- a/src/components/values/link/AccountIOL.vue
+++ b/src/components/values/link/AccountIOL.vue
@@ -34,10 +34,9 @@
 
 <script lang="ts">
 
-import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref} from "vue";
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
 import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
-import {initialLoadingKey} from "@/AppKeys";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
 
 export default defineComponent({
@@ -54,7 +53,6 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const initialLoading = inject(initialLoadingKey, ref(false))
 
     const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.accountId))
     onMounted(
@@ -73,7 +71,6 @@ export default defineComponent({
     )
 
     return {
-      initialLoading,
       label: labelLookup.entity,
     }
   }

--- a/src/components/values/link/AccountIOL.vue
+++ b/src/components/values/link/AccountIOL.vue
@@ -36,7 +36,7 @@
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
-import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
+import {NameQuery} from "@/utils/name_service/NameQuery";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
 
 export default defineComponent({
@@ -54,13 +54,9 @@ export default defineComponent({
   },
   setup(props) {
 
-    const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.accountId))
-    onMounted(
-        () => labelLookup.mount()
-    )
-    onBeforeUnmount(
-        () => labelLookup.unmount()
-    )
+    const nameQuery = new NameQuery(computed(() => props.accountId))
+    onMounted(() => nameQuery.mount())
+    onBeforeUnmount(() => nameQuery.unmount())
 
     const networkLookup = NetworkCache.instance.makeLookup()
     onMounted(
@@ -71,7 +67,7 @@ export default defineComponent({
     )
 
     return {
-      label: labelLookup.entity,
+      label: nameQuery.name,
     }
   }
 })

--- a/src/components/values/link/ContractIOL.vue
+++ b/src/components/values/link/ContractIOL.vue
@@ -36,6 +36,7 @@
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
 import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
+import {NameQuery} from "@/utils/name_service/NameQuery";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
 
 export default defineComponent({
@@ -48,6 +49,11 @@ export default defineComponent({
     },
   },
   setup(props) {
+
+    const nameQuery = new NameQuery(computed(() => props.contractId))
+    onMounted(() => nameQuery.mount())
+    onBeforeUnmount(() => nameQuery.unmount())
+
     const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.contractId))
     onMounted(
         () => labelLookup.mount()
@@ -56,7 +62,7 @@ export default defineComponent({
         () => labelLookup.unmount()
     )
     return {
-      label: labelLookup.entity
+      label: nameQuery.name
     }
   }
 })

--- a/src/components/values/link/ContractIOL.vue
+++ b/src/components/values/link/ContractIOL.vue
@@ -35,7 +35,6 @@
 <script lang="ts">
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
-import {LabelByIdCache} from "@/utils/cache/LabelByIdCache";
 import {NameQuery} from "@/utils/name_service/NameQuery";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
 
@@ -54,13 +53,6 @@ export default defineComponent({
     onMounted(() => nameQuery.mount())
     onBeforeUnmount(() => nameQuery.unmount())
 
-    const labelLookup = LabelByIdCache.instance.makeLookup(computed(() => props.contractId))
-    onMounted(
-        () => labelLookup.mount()
-    )
-    onBeforeUnmount(
-        () => labelLookup.unmount()
-    )
     return {
       label: nameQuery.name
     }

--- a/src/components/values/link/EntityIOL.vue
+++ b/src/components/values/link/EntityIOL.vue
@@ -60,7 +60,7 @@
 import {computed, defineComponent, inject, PropType, ref} from "vue";
 import {initialLoadingKey} from "@/AppKeys";
 
-export const MAX_LABEL_SIZE = 35
+export const DEFAULT_LABEL_SIZE = 18
 
 export default defineComponent({
 
@@ -77,7 +77,7 @@ export default defineComponent({
     },
     slice: {
       type: Number as PropType<number | null>,
-      default: MAX_LABEL_SIZE
+      default: DEFAULT_LABEL_SIZE
     },
     compact: {
       type: Boolean,
@@ -92,14 +92,13 @@ export default defineComponent({
   setup(props) {
     const initialLoading = inject(initialLoadingKey, ref(false))
 
-    const slice = computed(() => props.compact ? 12 : props.slice)
     const actualLabel = computed(() => {
       let result = props.label
       if (result != null
-          && slice.value != null
-          && slice.value > 0
-          && slice.value < result.length) {
-        result = result.slice(0, slice.value) + '…'
+          && props.slice != null
+          && props.slice > 0
+          && props.slice < result.length) {
+        result = result.slice(0, props.slice) + '…'
       }
       return result
     })

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -56,6 +56,14 @@
             <EVMAddress :show-id="false" :has-custom-font="true" :address="ethereumAddress"/>
           </div>
         </div>
+        <div v-if="domainName" id="names" class="h-is-tertiary-text mt-2" style="word-break: keep-all">
+          <div class="is-inline-block h-is-property-text has-text-weight-light" style="min-width: 115px">Domain:</div>
+          <div class="is-inline-block h-is-property-text">
+            <div class="is-inline-block">
+              <EntityIOL :label="domainName"/>
+            </div>
+          </div>
+        </div>
 
         <div v-if="!isMediumScreen && showContractVisible && contractRoute" id="showContractLink"
              class="is-inline-block mt-2">
@@ -339,12 +347,15 @@ import DateTimePicker from "@/components/DateTimePicker.vue";
 import DownloadButton from "@/components/DownloadButton.vue";
 import {DialogController} from "@/components/dialog/DialogController";
 import TransactionDownloadDialog from "@/components/download/TransactionDownloadDialog.vue";
+import {NameQuery} from "@/utils/name_service/NameQuery";
+import EntityIOL from "@/components/values/link/EntityIOL.vue";
 
 export default defineComponent({
 
   name: 'AccountDetails',
 
   components: {
+    EntityIOL,
     TransactionDownloadDialog,
     DownloadButton,
     AccountCreatedContractsTable,
@@ -494,6 +505,14 @@ export default defineComponent({
 
     const downloadController = new DialogController()
 
+    //
+    // Naming
+    //
+
+    const nameQuery = new NameQuery(computed(() => props.accountId ?? null))
+    onMounted(() => nameQuery.mount())
+    onBeforeUnmount(() => nameQuery.unmount())
+
     return {
       isSmallScreen,
       isMediumScreen,
@@ -531,7 +550,8 @@ export default defineComponent({
       filterVerified,
       downloadController,
       timeSelection,
-      onDateCleared
+      onDateCleared,
+      domainName: nameQuery.name
     }
   }
 });

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -59,9 +59,7 @@
         <div v-if="domainName" id="names" class="h-is-tertiary-text mt-2" style="word-break: keep-all">
           <div class="is-inline-block h-is-property-text has-text-weight-light" style="min-width: 115px">Domain:</div>
           <div class="is-inline-block h-is-property-text">
-            <div class="is-inline-block">
-              <EntityIOL :label="domainName"/>
-            </div>
+            <EntityIOL :label="domainName"/>
           </div>
         </div>
 

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -50,9 +50,7 @@
         <div v-if="domainName" id="names" class="h-is-tertiary-text mt-2" style="word-break: keep-all">
           <div class="is-inline-block h-is-property-text has-text-weight-light" style="min-width: 115px">Domain:</div>
           <div class="is-inline-block h-is-property-text">
-            <div class="is-inline-block">
-              <EntityIOL :label="domainName"/>
-            </div>
+            <EntityIOL :label="domainName"/>
           </div>
         </div>
         <div v-if="!isMediumScreen && accountRoute" id="showAccountLink" class="is-inline-block mt-2">

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -47,6 +47,14 @@
             <EVMAddress :show-id="false" :has-custom-font="true" :address="ethereumAddress"/>
           </div>
         </div>
+        <div v-if="domainName" id="names" class="h-is-tertiary-text mt-2" style="word-break: keep-all">
+          <div class="is-inline-block h-is-property-text has-text-weight-light" style="min-width: 115px">Domain:</div>
+          <div class="is-inline-block h-is-property-text">
+            <div class="is-inline-block">
+              <EntityIOL :label="domainName"/>
+            </div>
+          </div>
+        </div>
         <div v-if="!isMediumScreen && accountRoute" id="showAccountLink" class="is-inline-block mt-2">
           <router-link :to="accountRoute">
             <span class="h-is-property-text">Show associated account</span>
@@ -218,12 +226,15 @@ import {ContractResultsLogsAnalyzer} from "@/utils/analyzer/ContractResultsLogsA
 import {BalanceAnalyzer} from "@/utils/analyzer/BalanceAnalyzer";
 import InlineBalancesValue from "@/components/values/InlineBalancesValue.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
+import {NameQuery} from "@/utils/name_service/NameQuery";
+import EntityIOL from "@/components/values/link/EntityIOL.vue";
 
 export default defineComponent({
 
   name: 'ContractDetails',
 
   components: {
+    EntityIOL,
     InlineBalancesValue,
     MirrorLink,
     Copyable,
@@ -321,6 +332,13 @@ export default defineComponent({
     onMounted(() => contractResultsLogsAnalyzer.mount())
     onBeforeUnmount(() => contractResultsLogsAnalyzer.unmount())
 
+    //
+    // Naming
+    //
+    const nameQuery = new NameQuery(computed(() => props.contractId ?? null))
+    onMounted(() => nameQuery.mount())
+    onBeforeUnmount(() => nameQuery.unmount())
+
     return {
       isSmallScreen,
       isMediumScreen,
@@ -337,7 +355,8 @@ export default defineComponent({
       normalizedContractId,
       accountRoute,
       contractAnalyzer,
-      logs: contractResultsLogsAnalyzer.logs
+      logs: contractResultsLogsAnalyzer.logs,
+      domainName: nameQuery.name
     }
   },
 });

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -41,6 +41,7 @@ import {hnsResolve} from "@/utils/name_service/HNS";
 import {Timestamp} from "@/utils/Timestamp";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import {routeManager} from "@/router";
+import {AppStorage} from "@/AppStorage";
 
 export class SearchRequest {
 
@@ -350,6 +351,7 @@ export class SearchRequest {
             if (accountId !== null) {
                 const r = await axios.get<AccountBalanceTransactions>("api/v1/accounts/" + accountId)
                 this.account = r.data
+                AppStorage.setNameRecord(accountId, name, routeManager.currentNetwork.value)
             } else {
                 this.account = null
             }

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -51,6 +51,8 @@ import {VerifiedContractsByAccountIdCache} from "@/utils/cache/VerifiedContracts
 import {VerifiedContractsCache} from "@/utils/cache/VerifiedContractsCache";
 import {LogicContractCache} from "@/utils/cache/LogicContractCache";
 import {AdminContractCache} from "@/utils/cache/AdminContractCache";
+import {HNSCache} from "@/utils/cache/HNSCache";
+import {KNSCache} from "@/utils/cache/KNSCache";
 
 export class CacheUtils {
 
@@ -72,6 +74,8 @@ export class CacheUtils {
         ContractResultsLogsByContractIdCache.instance.clear()
         LogicContractCache.instance.clear()
         HbarPriceCache.instance.clear()
+        HNSCache.instance.clear()
+        KNSCache.instance.clear()
         // IPFSCache.instance => no clear: we preserve it because IPFS content is valid for all networks
         NetworkCache.instance.clear()
         NftCollectionCache.instance.clear()

--- a/src/utils/cache/HNSCache.ts
+++ b/src/utils/cache/HNSCache.ts
@@ -1,0 +1,31 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import {hnsResolve} from "@/utils/name_service/HNS";
+
+export class HNSCache extends EntityCache<string, string | null> {
+
+    public static readonly instance = new HNSCache()
+
+    protected async load(name: string): Promise<string | null> {
+        return hnsResolve(name)
+    }
+}

--- a/src/utils/cache/KNSCache.ts
+++ b/src/utils/cache/KNSCache.ts
@@ -1,0 +1,31 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import {knsResolve} from "@/utils/name_service/KNS";
+
+export class KNSCache extends EntityCache<string, string | null> {
+
+    public static readonly instance = new KNSCache()
+
+    protected async load(name: string): Promise<string | null> {
+        return knsResolve(name)
+    }
+}

--- a/src/utils/name_service/NameQuery.ts
+++ b/src/utils/name_service/NameQuery.ts
@@ -39,7 +39,9 @@ export class NameQuery {
     }
 
     public mount(): void {
-        this.watchHandle = watch(this.entityId, this.entityIdDidChange, {immediate: true} )
+        this.watchHandle = watch(
+            [this.entityId, AppStorage.nameRecordChangeCounter],
+            this.entityIdDidChange, {immediate: true} )
     }
 
     public unmount(): void {

--- a/src/utils/name_service/NameQuery.ts
+++ b/src/utils/name_service/NameQuery.ts
@@ -96,7 +96,7 @@ export class NameQuery {
                 // => clears local storage
                 AppStorage.clearNameRecord(record.entityId, routeManager.currentNetwork.value)
             }
-            result = AppStorage.getNameRecord(record.entityId, record.name)
+            result = AppStorage.getNameRecord(record.entityId, routeManager.currentNetwork.value)
         } else {
             result = record
         }

--- a/src/utils/name_service/NameQuery.ts
+++ b/src/utils/name_service/NameQuery.ts
@@ -21,9 +21,6 @@
 import {computed, ref, Ref, watch, WatchStopHandle} from "vue";
 import {routeManager} from "@/router";
 import {AppStorage, NameRecord} from "@/AppStorage";
-import {knsResolve} from "@/utils/name_service/KNS";
-import {hnsResolve} from "@/utils/name_service/HNS";
-import {KNS} from "@kabuto-sh/ns";
 import {KNSCache} from "@/utils/cache/KNSCache";
 import {HNSCache} from "@/utils/cache/HNSCache";
 

--- a/src/utils/name_service/NameQuery.ts
+++ b/src/utils/name_service/NameQuery.ts
@@ -1,0 +1,129 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, ref, Ref, watch, WatchStopHandle} from "vue";
+import {routeManager} from "@/router";
+import {AppStorage, NameRecord} from "@/AppStorage";
+import {knsResolve} from "@/utils/name_service/KNS";
+import {hnsResolve} from "@/utils/name_service/HNS";
+import {KNS} from "@kabuto-sh/ns";
+import {KNSCache} from "@/utils/cache/KNSCache";
+import {HNSCache} from "@/utils/cache/HNSCache";
+
+export class NameQuery {
+
+    public readonly entityId: Ref<string|null>
+    private readonly nameRecord = ref<NameRecord|null>(null)
+    private watchHandle: WatchStopHandle|null = null
+
+    //
+    // Public
+    //
+
+    public constructor(entityId: Ref<string|null>) {
+        this.entityId = entityId
+    }
+
+    public mount(): void {
+        this.watchHandle = watch(this.entityId, this.entityIdDidChange, {immediate: true} )
+    }
+
+    public unmount(): void {
+        if (this.watchHandle !== null) {
+            this.watchHandle()
+            this.watchHandle = null
+        }
+        this.nameRecord.value = null
+    }
+
+    public readonly name = computed(() => this.nameRecord.value?.name ?? null)
+
+
+    //
+    // Private
+    //
+
+    private readonly entityIdDidChange = async () => {
+        const newValue = this.entityId.value
+        if (newValue !== null) {
+            const r = AppStorage.getNameRecord(newValue, routeManager.currentNetwork.value)
+            if (r !== null) {
+                this.nameRecord.value = await this.refreshRecord(r)
+            } else {
+                this.nameRecord.value = null
+            }
+        } else {
+            this.nameRecord.value = null
+        }
+    }
+
+    //
+    // Private
+    //
+
+    private readonly FRESH_DURATION = 24 * 3600 * 1000 // one day in milliseconds
+    // private readonly FRESH_DURATION = 20 * 1000
+
+    private async refreshRecord(record: NameRecord): Promise<NameRecord|null> {
+        let result: NameRecord|null
+
+        const recordTimestamp = record.timestamp
+        const nowTimestamp = new Date().getTime()
+        const elapsed = Math.abs(nowTimestamp - recordTimestamp)
+        if (elapsed > this.FRESH_DURATION) {
+            // Record is old => we resolve again and check
+            const newEntityId = await this.resolve(record.name)
+            if (newEntityId === record.entityId) {
+                // record.name always points to record.entityId  :)
+                // => refreshes local storage
+                AppStorage.setNameRecord(record.entityId, record.name, routeManager.currentNetwork.value)
+            } else {
+                // record.name no longer points to record.entityId :(
+                // => clears local storage
+                AppStorage.clearNameRecord(record.entityId, routeManager.currentNetwork.value)
+            }
+            result = AppStorage.getNameRecord(record.entityId, record.name)
+        } else {
+            result = record
+        }
+        return Promise.resolve(result)
+    }
+
+    private async resolve(name: string): Promise<string|null> {
+        let result: string|null
+        try {
+            const promises: Promise<string | null>[] = [
+                KNSCache.instance.lookup(name, true),
+                HNSCache.instance.lookup(name, true),
+            ]
+            const responses = await Promise.allSettled(promises)
+            result = null
+            for (const r of responses) {
+                if (r.status == "fulfilled" && r.value !== null) {
+                    result = r.value
+                }
+            }
+        } catch {
+            result = null
+        }
+        return result
+    }
+
+}


### PR DESCRIPTION
**Description**:

Changes below implement request #972.
When users searches for a domain name in `Search Bar`, search result is saved in browser local storage and used by Explorer to decorate its pages.

1) `Account Details` page displays the resolved name in `Domain` field (below the `EVM Address`):


<img width="1513" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/cae24607-9a41-45bb-b7c2-28fd0778d9e0">

2) Explorer then displays resolved name in every places where entity id is normally displayed (eg `Transfer Graphs`, `Contract Result` section, …)


<img width="1513" alt="image" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/91124272/feb0d98c-6ef6-47ff-8955-a441fca881e7">


Names saved in browser local storage are periodically checked:
- when a name has spent 1 day (or more) in local storage, its entity id is resolved again and compared the stored one
- when comparison fails, name is removed from local storage

**Related issue(s)**:

Fixes #972

**Notes for reviewer**:

Sample domain names (on `mainnet`): `example.hbar`, `kabuto.hbar`, `kabuto.hh`, `karate.hbar` …
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
