### PR TITLE
fix: duplication of 'limit' query parameter in axios calls located inside a loop.

### DIFF
--- a/src/utils/cache/NetworkCache.ts
+++ b/src/utils/cache/NetworkCache.ts
@@ -33,14 +33,15 @@ export class NetworkCache extends SingletonCache<NetworkNode[]> {
     protected async load(): Promise<NetworkNode[]> {
         let result: NetworkNode[] = []
         let nextURL: string | null = "api/v1/network/nodes"
-        const params = {
-            limit: 25
+        let params = {
+            limit: 25 as number | undefined
         }
         while (nextURL !== null) {
             const response: AxiosResponse<NetworkNodesResponse>
                 = await axios.get<NetworkNodesResponse>(nextURL, {params: params})
             result = result.concat(response.data.nodes ?? [])
             nextURL = response.data.links?.next ?? null
+            params.limit = undefined
         }
         return Promise.resolve(result)
     }

--- a/src/utils/cache/NetworkCache.ts
+++ b/src/utils/cache/NetworkCache.ts
@@ -34,7 +34,7 @@ export class NetworkCache extends SingletonCache<NetworkNode[]> {
         let result: NetworkNode[] = []
         let nextURL: string | null = "api/v1/network/nodes"
         let params = {
-            limit: 25 as number | undefined
+            limit: 100 as number | undefined
         }
         while (nextURL !== null) {
             const response: AxiosResponse<NetworkNodesResponse>

--- a/src/utils/cache/NftCollectionCache.ts
+++ b/src/utils/cache/NftCollectionCache.ts
@@ -34,7 +34,7 @@ export class NftCollectionCache extends EntityCache<string, NftCollectionInfo[]>
         const result: NftCollectionInfo[] = []
         let nextURL: string | null = "api/v1/accounts/" + accountId + "/nfts"
         const params = {
-            limit: 25 as number | undefined
+            limit: 100 as number | undefined
         }
         while (nextURL !== null) {
             const response: AxiosResponse<Nfts>

--- a/src/utils/cache/NftCollectionCache.ts
+++ b/src/utils/cache/NftCollectionCache.ts
@@ -34,13 +34,14 @@ export class NftCollectionCache extends EntityCache<string, NftCollectionInfo[]>
         const result: NftCollectionInfo[] = []
         let nextURL: string | null = "api/v1/accounts/" + accountId + "/nfts"
         const params = {
-            limit: 25
+            limit: 25 as number | undefined
         }
         while (nextURL !== null) {
             const response: AxiosResponse<Nfts>
                 = await axios.get<Nfts>(nextURL, {params: params})
             this.appendNfts(response.data.nfts ?? [], result)
             nextURL = response.data.links?.next ?? null
+            params.limit = undefined
         }
         return Promise.resolve(result)
     }


### PR DESCRIPTION
**Description**:

Almost everything is in the title. We also bump the limit to 100 in these calls to reduce the number of calls to mirror-node since the goal is to get an exhaustive list of entities.

**Notes for reviewer**:

Fix can be observed on mainnet contract: 0.0.5060536
