### PR TITLE
chore: BalanceAnalyzer now extends EntityLoaderV2.

### DIFF
--- a/src/utils/analyzer/BalanceAnalyzer.ts
+++ b/src/utils/analyzer/BalanceAnalyzer.ts
@@ -22,91 +22,69 @@ import {computed, ComputedRef, Ref, ref, watch, WatchStopHandle} from "vue";
 import {BalancesResponse, TokenBalance} from "@/schemas/HederaSchemas";
 import {BalanceCache} from "@/utils/cache/BalanceCache";
 import {Duration} from "@/utils/Duration";
+import {EntityLoaderV2} from "@/utils/loader/EntityLoaderV2";
 
-export class BalanceAnalyzer {
+export class BalanceAnalyzer extends EntityLoaderV2<BalancesResponse> {
 
     public readonly accountId = ref<string | null>(null)
-    private readonly updatePeriod: number
-    private readonly response: Ref<BalancesResponse | null> = ref(null)
-    private readonly watchHandle: Ref<WatchStopHandle | null> = ref(null)
-    private timeoutID = -1
+    private watchStopHandle: WatchStopHandle | null = null
 
     //
     // Public
     //
 
     public constructor(accountId = ref<string | null>(null), updatePeriod: number) {
+        super(updatePeriod, 1_000_000 /* refresh forever */)
         this.accountId = accountId
-        this.updatePeriod = updatePeriod
     }
-
-    public mount(): void {
-        this.watchHandle.value = watch(this.accountId, this.accountIdDidChange, {immediate: true})
-    }
-
-    public unmount(): void {
-        if (this.watchHandle.value !== null) {
-            this.watchHandle.value()
-            this.watchHandle.value = null
-        }
-        this.response.value = null
-        this.balanceAge.value = null
-        if (this.timeoutID != -1) {
-            window.clearTimeout(this.timeoutID)
-            this.timeoutID = -1
-        }
-    }
-
-    public readonly mounted: ComputedRef<boolean> = computed(() => {
-        return this.watchHandle.value !== null
-    })
 
     public readonly hbarBalance: ComputedRef<number | null> = computed(() => {
-        const allBalances = this.response.value?.balances
+        const allBalances = this.entity.value?.balances
         return allBalances && allBalances.length >= 1 ? allBalances[0].balance : null
     })
 
     public readonly tokenBalances: ComputedRef<Array<TokenBalance>> = computed(() => {
-        const allBalances = this.response.value?.balances
+        const allBalances = this.entity.value?.balances
         return allBalances && allBalances.length >= 1 ? allBalances[0].tokens : []
     })
 
     public readonly balanceTimeStamp: ComputedRef<string | null> = computed(() => {
-        return this.response.value?.timestamp ?? null
+        return this.entity.value?.timestamp ?? null
     })
 
-    public readonly balanceAge: Ref<Duration | null> = ref(null)
+    public readonly balanceAge: Ref<Duration | null> = computed(() => {
+        return this.balanceTimeStamp.value !== null
+            ? Duration.decompose(new Date().getTime() / 1000 - Number.parseFloat(this.balanceTimeStamp.value))
+            : null
+    })
 
     //
-    // Private
+    // EntityLoader
     //
 
-    private readonly accountIdDidChange = async (): Promise<void> => {
-        if (this.accountId.value !== null) {
-            try {
-                const r = await BalanceCache.instance.lookup(this.accountId.value, true)
-                this.response.value = Object.freeze(r)
-            } catch {
-                this.response.value = null
-            } finally {
-                this.balanceAge.value = this.balanceTimeStamp.value !== null
-                    ? Duration.decompose(new Date().getTime() / 1000 - Number.parseFloat(this.balanceTimeStamp.value))
-                    : null
-                this.scheduleNextLookup()
-            }
-        } else {
-            this.response.value = null
-            this.balanceAge.value = null
-        }
+    public mount(): void {
+        super.mount()
+        this.watchStopHandle = watch(this.accountId, () => {
+            this.pause()
+            this.resume()
+        })
     }
 
-    private scheduleNextLookup() {
-        const accountId = this.accountId.value
-        window.setTimeout(() => {
-            if (this.accountId.value === accountId && this.watchHandle.value !== null) {
-                this.timeoutID = -1
-                this.accountIdDidChange().catch()
-            } // else accountId has changed or analyzer has been unmounted during sleep
-        }, this.updatePeriod)
+    public unmount(): void {
+        if (this.watchStopHandle != null) {
+            this.watchStopHandle()
+            this.watchStopHandle = null
+        }
+        super.unmount()
+    }
+
+    protected async load(): Promise<BalancesResponse | null> {
+        let result: BalancesResponse|null
+        if (this.accountId.value !== null) {
+            result = await BalanceCache.instance.lookup(this.accountId.value, true)
+        } else {
+            result = null
+        }
+        return Promise.resolve(result)
     }
 }

--- a/src/utils/analyzer/BalanceAnalyzer.ts
+++ b/src/utils/analyzer/BalanceAnalyzer.ts
@@ -34,7 +34,7 @@ export class BalanceAnalyzer extends EntityLoaderV2<BalancesResponse> {
     //
 
     public constructor(accountId = ref<string | null>(null), updatePeriod: number) {
-        super(updatePeriod, 1_000_000 /* refresh forever */)
+        super(updatePeriod, EntityLoaderV2.HUGE_COUNT /* refresh forever */)
         this.accountId = accountId
     }
 


### PR DESCRIPTION
**Description**:

`BalanceAnalyzer` now extends `EntityLoaderV2`.
Theses changes do not change semantic but should fix random breaking  observed when unit tests are executed by GitHub.

> ReferenceError: window is not defined
> \> BalanceAnalyzer.scheduleNextLookup src/utils/analyzer/BalanceAnalyzer.ts:105:9
> \> BalanceAnalyzer.accountIdDidChange src/utils/analyzer/BalanceAnalyzer.ts:95:22

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
