### PR TITLE
feat: allow user to navigate to account NFT collection

### DIFF
--- a/src/assets/styles/explorer.scss
+++ b/src/assets/styles/explorer.scss
@@ -179,6 +179,13 @@ body {
   line-height: 13px;
 }
 
+.h-is-text-size-4 {
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 14px;
+}
+
 .h-is-property-text {
   font-style: normal;
   font-weight: normal;

--- a/src/components/account/CollectionTable.vue
+++ b/src/components/account/CollectionTable.vue
@@ -42,7 +42,7 @@
       aria-previous-label="Previous page"
       @cell-click="handleClick"
   >
-    <o-table-column v-slot="props" field="serial" label="Serial">
+    <o-table-column v-slot="props" field="serial" label="Serial #">
       {{ props.row.serial_number }}
     </o-table-column>
   </o-table>

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -39,14 +39,14 @@
       aria-page-label="Page"
       aria-previous-label="Previous page"
   >
-    <o-table-column v-slot="props" field="token_id" label="Token">
+    <o-table-column v-slot="props" field="token_id" label="NFT Collection">
       <TokenLink
           v-bind:show-extra="true"
           v-bind:token-id="props.row.tokenId"
           v-bind:no-anchor="true"
       />
     </o-table-column>
-    <o-table-column v-slot="props" field="owned" label="Owned" position="right">
+    <o-table-column v-slot="props" field="owned" label="Nb of NFTs" position="right">
       {{ props.row.collectionSize }}
     </o-table-column>
   </o-table>

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -232,8 +232,7 @@ import {WalletDriverCancelError, WalletDriverError} from "@/utils/wallet/WalletD
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
-import {formatTokenAmount} from "@/components/values/TokenAmount.vue";
-import {makeTokenSymbol} from "@/schemas/HederaUtils";
+import {formatTokenAmount, makeTokenSymbol} from "@/schemas/HederaUtils";
 
 const VALID_ACCOUNT_MESSAGE = "Account found"
 const VALID_CONTRACT_MESSAGE = "Contract found"

--- a/src/components/values/InlineBalancesValue.vue
+++ b/src/components/values/InlineBalancesValue.vue
@@ -35,11 +35,6 @@
   <div v-for="b in displayedBalances" :key="b.token_id ?? undefined" class="h-is-tertiary-text">
     <TokenAmount v-bind:amount="BigInt(b.balance)" v-bind:show-extra="true" v-bind:token-id="b.token_id"/>
   </div>
-  <div v-if="displayAllTokenLinks" id="show-all-link">
-    <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
-      <span class="h-is-text-size-3 has-text-grey">Show all tokens</span>
-    </router-link>
-  </div>
 
 </template>
 

--- a/src/components/values/InlineBalancesValue.vue
+++ b/src/components/values/InlineBalancesValue.vue
@@ -33,7 +33,12 @@
     </div>
   </div>
   <div v-for="b in displayedBalances" :key="b.token_id ?? undefined" class="h-is-tertiary-text">
-    <TokenAmount v-bind:amount="BigInt(b.balance)" v-bind:show-extra="true" v-bind:token-id="b.token_id"/>
+    <TokenAmount
+        :amount="BigInt(b.balance)"
+        :show-extra="true"
+        :token-id="b.token_id"
+        :account-id="accountId"
+    />
   </div>
 
 </template>

--- a/src/components/values/link/TokenExtra.vue
+++ b/src/components/values/link/TokenExtra.vue
@@ -26,11 +26,11 @@
   <template v-if="tokenId != null">
     <template v-if="useAnchor && tokenRoute">
       <router-link :to="tokenRoute">
-        <span class="h-is-smaller h-is-extra-text should-wrap" style="word-break: break-all">{{ extra }}</span>
+        <span class="h-is-text-size-4 h-is-extra-text should-wrap" style="word-break: break-all">{{ extra }}</span>
       </router-link>
     </template>
     <template v-else>
-      <span class="h-is-smaller h-is-extra-text should-wrap" style="word-break: break-all">{{ extra }}</span>
+      <span class="h-is-text-size-4 h-is-extra-text should-wrap" style="word-break: break-all">{{ extra }}</span>
     </template>
   </template>
 </template>

--- a/src/pages/AccountBalances.vue
+++ b/src/pages/AccountBalances.vue
@@ -26,23 +26,27 @@
 
   <section class="section" :class="{'h-mobile-background': isTouchDevice || !isSmallScreen}">
 
-    <DashboardCard id="balanceCard">
-      <template v-slot:title>
-        <span class="h-is-primary-title">All Tokens Associated to </span>
-        <span class="h-is-secondary-text">{{ accountId }}</span>
-      </template>
-      <template v-slot:content>
-        <BalanceTable :controller="tokenRelationshipTableController"/>
-      </template>
-    </DashboardCard>
-
-    <DashboardCard id="nftsCard">
+    <DashboardCard id="nftsCard" collapsible-key="nft-collection-table">
       <template v-slot:title>
         <span class="h-is-primary-title">NFTs Owned by </span>
-        <span class="h-is-secondary-text">{{ accountId }}</span>
+        <span class="h-is-secondary-text">
+          <AccountLink :account-id="accountId"/>
+        </span>
       </template>
       <template v-slot:content>
         <NftsTable :collections="nftCollections"/>
+      </template>
+    </DashboardCard>
+
+    <DashboardCard id="balanceCard" collapsible-key="token-association-table">
+      <template v-slot:title>
+        <span class="h-is-primary-title">All Tokens Associated to </span>
+        <span class="h-is-secondary-text">
+          <AccountLink :account-id="accountId"/>
+        </span>
+      </template>
+      <template v-slot:content>
+        <BalanceTable :controller="tokenRelationshipTableController"/>
       </template>
     </DashboardCard>
 
@@ -67,12 +71,14 @@ import {useRouter} from "vue-router";
 import {EntityID} from "@/utils/EntityID";
 import NftsTable from "@/components/account/NftsTable.vue";
 import {NftCollectionCache} from "@/utils/cache/NftCollectionCache";
+import AccountLink from "@/components/values/link/AccountLink.vue";
 
 export default defineComponent({
 
   name: 'AccountBalances',
 
   components: {
+    AccountLink,
     NftsTable,
     Footer,
     DashboardCard,

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -98,9 +98,13 @@
 
         <div class="h-is-property-text">
           <Property id="balance" :full-width="isMediumScreen">
-            <template v-slot:name>{{
-                balanceAnalyzer.tokenBalances.value.length > 0 ? 'Balances' : 'Balance'
-              }}
+            <template v-slot:name>
+              <span class="h-is-tertiary-text">
+                {{balanceAnalyzer.tokenBalances.value.length > 0 ? 'Balances' : 'Balance'}}
+              </span>
+              <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
+                <div class="mt-1 h-is-extra-text">Show all tokens</div>
+              </router-link>
             </template>
             <template v-slot:value>
               <InlineBalancesValue :balance-analyzer="balanceAnalyzer"/>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -102,7 +102,7 @@
               <span class="h-is-tertiary-text">
                 {{balanceAnalyzer.tokenBalances.value.length > 0 ? 'Balances' : 'Balance'}}
               </span>
-              <router-link :to="{name: 'AccountBalances', params: {accountId: accountId}}">
+              <router-link id="show-all-link" :to="{name: 'AccountBalances', params: {accountId: accountId}}">
                 <div class="mt-1 h-is-extra-text">Show all tokens</div>
               </router-link>
             </template>

--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -29,13 +29,14 @@
   >
     <DashboardCard collapsible-key="nftDetails">
       <template #title>
-        <span class="h-is-primary-title mr-3">Serial Number {{ serialNumber }}</span>
-        <div
-            class="is-inline-block h-is-tertiary-text h-is-extra-text should-wrap"
+        <span class="h-is-primary-title mr-1">NFT</span>
+        <span class="h-is-tertiary-text mr-3">#{{ serialNumber }}</span>
+        <span
+            class=" h-is-tertiary-text h-is-extra-text should-wrap"
             style="word-break: break-all"
         >
           {{ `${tokenName} (${tokenSymbol})` }}
-        </div>
+        </span>
       </template>
 
       <template #content>
@@ -47,7 +48,7 @@
 
       <template #leftContent>
         <Property id="tokenId">
-          <template #name>Token ID</template>
+          <template #name>NFT Collection</template>
           <template #value>
             <TokenLink :token-id="tokenId" :show-extra="true"/>
           </template>

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -28,11 +28,10 @@
 
     <DashboardCard collapsible-key="tokenDetails">
       <template v-slot:title>
-        <span v-if="tokenInfo" class="h-is-primary-title">
-          <span v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'">Non Fungible</span>
-          <span v-else>Fungible</span>
+        <span v-if="tokenInfo" class="h-is-primary-title mr-2">
+          <span v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'">NFT Collection</span>
+          <span v-else>Fungible Token</span>
         </span>
-        <span class="h-is-primary-title mr-1"> Token </span>
         <div class="is-inline-block h-is-tertiary-text h-is-extra-text should-wrap" style="word-break: break-all">
           {{ `${displayName} (${displaySymbol})` }}
         </div>
@@ -289,7 +288,7 @@
     <DashboardCard v-if="tokenInfo" collapsible-key="nftHolders">
 
       <template v-slot:title>
-        <div v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'" class="h-is-secondary-title mb-2">NFT Holders</div>
+        <div v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'" class="h-is-secondary-title mb-2">NFTs</div>
         <div v-else class="h-is-secondary-title mb-2">Balances</div>
       </template>
 

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -76,6 +76,25 @@ export function makeTokenSymbol(token: TokenInfo | null, maxLength: number=11): 
     return result
 }
 
+export const MAX_TOKEN_SUPPLY = 9223372036854775807n
+
+export function formatTokenAmount(rawAmount: bigint, decimalCount: number): string {
+    let result: string
+    if (rawAmount > MAX_TOKEN_SUPPLY) {
+        rawAmount = MAX_TOKEN_SUPPLY
+    }
+    const amountFormatter = new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: decimalCount,
+        maximumFractionDigits: decimalCount
+    })
+    if (decimalCount) {
+        result = amountFormatter.format(Number(rawAmount) / Math.pow(10, decimalCount))
+    } else {
+        result = amountFormatter.format(rawAmount)
+    }
+    return result
+}
+
 export function makeNodeDescription(node: NetworkNode): string {
     let result: string
     if (node.description) {

--- a/tests/unit/account/AccountBalances.spec.ts
+++ b/tests/unit/account/AccountBalances.spec.ts
@@ -80,7 +80,7 @@ describe("AccountBalances.vue", () => {
             "0.0.49292859" + "TokenA7" + "0.00000000")
 
         const nftsCard = wrapper.get("#nftsCard")
-        expect(nftsCard.find('thead').text()).toBe("Token Owned")
+        expect(nftsCard.find('thead').text()).toBe("NFT Collection Nb of NFTs")
         expect(nftsCard.find('tbody').text()).toBe("")
 
         wrapper.unmount()
@@ -123,7 +123,7 @@ describe("AccountBalances.vue", () => {
         expect(balanceCard.find('tbody').text()).toBe("")
 
         const nftsCard = wrapper.get("#nftsCard")
-        expect(nftsCard.find('thead').text()).toBe("Token Owned")
+        expect(nftsCard.find('thead').text()).toBe("NFT Collection Nb of NFTs")
         expect(nftsCard.find('tbody').text()).toBe("0.0.748383" + SAMPLE_NONFUNGIBLE.symbol + "2")
 
         wrapper.unmount()

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -20,7 +20,7 @@
  *
  */
 
-import {describe, it, expect} from 'vitest'
+import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
@@ -33,11 +33,13 @@ import {
     SAMPLE_ACCOUNT_HBAR_BALANCE,
     SAMPLE_ACCOUNT_STAKING_ACCOUNT,
     SAMPLE_ACCOUNT_STAKING_NODE,
-    SAMPLE_FAILED_TRANSACTIONS, SAMPLE_NETWORK_EXCHANGERATE,
+    SAMPLE_FAILED_TRANSACTIONS,
+    SAMPLE_NETWORK_EXCHANGERATE,
     SAMPLE_NETWORK_NODES,
     SAMPLE_NONFUNGIBLE,
     SAMPLE_TOKEN,
-    SAMPLE_TOKEN_DUDE, SAMPLE_TRANSACTION,
+    SAMPLE_TOKEN_DUDE,
+    SAMPLE_TRANSACTION,
     SAMPLE_TRANSACTIONS,
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -118,6 +120,9 @@ describe("AccountDetails.vue", () => {
             "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
             "Copy" +
             "ED25519")
+
+        expect(wrapper.get('#show-all-link').text()).toBe("Show all tokens")
+
         expect(wrapper.get("#memoValue").text()).toBe("None")
         expect(wrapper.get("#aliasValue").text()).toBe(ALIAS_HEX + 'Copy')
         expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalize(SAMPLE_TRANSACTION.transaction_id))

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -89,7 +89,7 @@ describe("TokenDetails.vue", () => {
         expect((wrapper.vm as any).tokenBalanceTableController.mounted.value).toBe(true)
         expect((wrapper.vm as any).nftHolderTableController.mounted.value).toBe(true)
 
-        expect(wrapper.text()).toContain("Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("Fungible Token" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         expect(wrapper.get("#nameValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
         expect(wrapper.get("#symbolValue").text()).toBe("23423")
@@ -156,7 +156,7 @@ describe("TokenDetails.vue", () => {
         expect((wrapper.vm as any).tokenBalanceTableController.mounted.value).toBe(true)
         expect((wrapper.vm as any).nftHolderTableController.mounted.value).toBe(true)
 
-        expect(wrapper.text()).toContain("Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         expect(wrapper.get("#nameValue").text()).toBe("Ħ Frens Kingdom Dude")
         expect(wrapper.get("#symbolValue").text()).toBe("ĦFRENSKINGDOM")
@@ -175,7 +175,7 @@ describe("TokenDetails.vue", () => {
         expect(wrapper.get("#decimalsValue").text()).toBe("0")
         expect(wrapper.get("#metadataValue").text()).toBe("None")
 
-        expect(wrapper.text()).toMatch("NFT Holders")
+        expect(wrapper.text()).toMatch("NFTs")
         expect(wrapper.findComponent(NftHolderTable).exists()).toBe(true)
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(false)
 
@@ -217,10 +217,10 @@ describe("TokenDetails.vue", () => {
         expect((wrapper.vm as any).tokenBalanceTableController.mounted.value).toBe(true)
         expect((wrapper.vm as any).nftHolderTableController.mounted.value).toBe(true)
 
-        expect(wrapper.text()).toContain("Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
         expect(wrapper.get("#nameValue").text()).toBe("Ħ Frens Kingdom Dude")
         expect(wrapper.get("#symbolValue").text()).toBe("ĦFRENSKINGDOM")
-        expect(wrapper.text()).toMatch("NFT Holders")
+        expect(wrapper.text()).toMatch("NFTs")
         expect(wrapper.findComponent(NftHolderTable).exists()).toBe(true)
         expect(wrapper.findComponent(TokenBalanceTable).exists()).toBe(false)
 
@@ -242,7 +242,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toContain("Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("Fungible Token" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
         expect(wrapper.get("#nameValue").text()).toBe("QmVGABnvpbPwLcfG4iuW2JSzY8MLkALhd54bdPAbJxoEkB")
         expect(wrapper.get("#symbolValue").text()).toBe("23423")
         expect(wrapper.text()).toMatch("Balances")
@@ -310,7 +310,7 @@ describe("TokenDetails.vue", () => {
         expect((wrapper.vm as any).tokenBalanceTableController.mounted.value).toBe(true)
         expect((wrapper.vm as any).nftHolderTableController.mounted.value).toBe(true)
 
-        expect(wrapper.text()).toContain("Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         expect(wrapper.text()).toMatch("Token Keys")
         expect(wrapper.find("#adminKey").text()).toBe("Admin Keyc539 536f 9599 daef eeb7 7767 7aa1 aeea 2242 dfc7 cca9 2348 c228 a518 7a0f af2bCopyED25519")
@@ -360,7 +360,7 @@ describe("TokenDetails.vue", () => {
         expect((wrapper.vm as any).tokenBalanceTableController.mounted.value).toBe(true)
         expect((wrapper.vm as any).nftHolderTableController.mounted.value).toBe(true)
 
-        expect(wrapper.text()).toContain("Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         expect(wrapper.text()).toMatch("Token Keys")
         expect(wrapper.find("#adminKey").text()).toBe("Admin KeyNoneToken is immutable")
@@ -410,7 +410,7 @@ describe("TokenDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toContain(
-            "Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenIdWithChecksum
+            "NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenIdWithChecksum
                 + 'EVM Address:' + testTokenEVMAddress + "Copy")
         expect(wrapper.text()).toMatch("Token is deleted")
 
@@ -448,7 +448,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toContain("Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("Fungible Token" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         const customFees = wrapper.findComponent(TokenCustomFees)
         expect(customFees.exists()).toBe(true)
@@ -506,7 +506,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toContain("Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         const customFees = wrapper.findComponent(TokenCustomFees)
         expect(customFees.exists()).toBe(true)
@@ -562,7 +562,7 @@ describe("TokenDetails.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toContain("Non Fungible Token " + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
+        expect(wrapper.text()).toContain("NFT Collection" + testTokenName + ' (' + testTokenSymbol + ')' + 'Token ID:' + testTokenId)
 
         const customFees = wrapper.findComponent(TokenCustomFees)
         expect(customFees.exists()).toBe(false)

--- a/tests/unit/values/InlineBalancesValue.spec.ts
+++ b/tests/unit/values/InlineBalancesValue.spec.ts
@@ -244,8 +244,6 @@ describe("InlineBalancesValue.vue", () => {
             "3" + "NFT-3" +
             "4" + "NFT-4" +
             "5" + "NFT-5")
-        // expect(wrapper.text()).toContain("Show all tokens")
-        expect(wrapper.get('#show-all-link').text()).toBe("Show all tokens")
 
         wrapper.unmount()
         await flushPromises()
@@ -361,7 +359,6 @@ describe("InlineBalancesValue.vue", () => {
         expect(wrapper.text()).toContain("100.00000000" + ">")
         expect(wrapper.text()).toContain("years ago" +
             "1" + "NFT-1")
-        expect(wrapper.get('#show-all-link').text()).toBe("Show all tokens")
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/values/TokenAmount.spec.ts
+++ b/tests/unit/values/TokenAmount.spec.ts
@@ -173,7 +173,7 @@ describe("TokenAmount.vue", () => {
         expect(wrapper.get('span').text()).toBe("?")
         expect(wrapper.get('a').attributes('href')).toMatch(RegExp("/token/" + SAMPLE_TOKEN_WITH_LARGE_DECIMAL_COUNT.token_id + "$"))
         expect(wrapper.get('.h-is-extra-text').text()).toBe(SAMPLE_TOKEN_WITH_LARGE_DECIMAL_COUNT.symbol)
-        expect(wrapper.text()).toBe("?TTOK0This token amount cannot be displayed because the number of decimals (75) of the token is too large")
+        expect(wrapper.text()).toBe("? TTOK0This token amount cannot be displayed because the number of decimals (75) of the token is too large")
 
         wrapper.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

Allow the user, when clicking an NFT balance in the AccountDetails view, to navigate to the NFT collection for that account -- i.e. the table listing all serial numbers owned by that account  for that NFT collection.

Also include minor UI adjustments around the display of NFTs.

**Related issue(s)**:

Fixes #1046

**Notes for reviewer**:

See screen captures. This is not deployed on staging server.

<img width="1080" alt="Screenshot 2024-05-28 at 12 26 49" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/5e146b8f-b503-46cd-9938-86473d3a7510">
<img width="1080" alt="Screenshot 2024-05-28 at 12 29 30" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/2e5619b0-47a8-4dfc-b154-c5fd1f2f9bef">
<img width="1080" alt="Screenshot 2024-05-28 at 12 30 00" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/c912d992-2ae9-4d0d-8a10-37c336052b14">
