### PR TITLE
chore: name service refactoring

### DIFF
--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -24,10 +24,8 @@ import {NetworkRegistry, networkRegistry} from "@/schemas/NetworkRegistry";
 import {computed, ref, watch, WatchStopHandle} from "vue";
 import router from "@/router";
 import {AppStorage} from "@/AppStorage";
-import {knsSetNetwork} from '@/utils/name_service/KNS';
 import axios from "axios";
 import {CacheUtils} from "@/utils/cache/CacheUtils";
-import {hnsSetNetwork} from "@/utils/name_service/HNS";
 
 export class RouteManager {
 
@@ -40,8 +38,6 @@ export class RouteManager {
     public constructor(router: Router) {
         this.router = router
         watch(this.currentNetwork, () => {
-            knsSetNetwork(this.currentNetworkEntry.value.name)
-            hnsSetNetwork(this.currentNetworkEntry.value.name)
             AppStorage.setLastNetwork(this.currentNetworkEntry.value)
             axios.defaults.baseURL = this.currentNetworkEntry.value.url
             this.updateSelectedNetworkSilently()

--- a/src/utils/name_service/NameService.ts
+++ b/src/utils/name_service/NameService.ts
@@ -67,7 +67,7 @@ export class NameService {
         let result: NameServiceProvider|null = null
         for (const p of nameServiceProviders) {
             if (p.providerAlias == providerAlias) {
-                result = null
+                result = p
                 break
             }
         }

--- a/src/utils/name_service/NameService.ts
+++ b/src/utils/name_service/NameService.ts
@@ -1,0 +1,97 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {NameServiceProvider} from "@/utils/name_service/provider/NameServiceProvider";
+import {nameServiceProviders} from "@/utils/name_service/provider/AllProviders";
+
+export class NameService {
+
+    public static readonly instance = new NameService()
+
+    //
+    // Public
+    //
+
+    public async resolve(name: string, network: string): Promise<NameRecord[]> {
+        const promises: Promise<NameRecord|null>[] = []
+        for (const p of nameServiceProviders) {
+            promises.push(this.resolveWithProvider(name, network, p))
+        }
+
+        let result: NameRecord[] = []
+        const responses = await Promise.allSettled(promises)
+        for (const r of responses) {
+            if (r.status == "fulfilled" && r.value !== null) {
+                result.push(r.value)
+            }
+        }
+
+        return Promise.resolve(result)
+    }
+
+    public async singleResolve(name: string, network: string, providerAlias: string): Promise<NameRecord|null> {
+        let result: NameRecord|null
+        const provider = this.lookupProvider(providerAlias)
+        if (provider !== null) {
+            result = await this.resolveWithProvider(name, network, provider)
+        } else {
+            result = null
+        }
+        return Promise.resolve(result)
+    }
+
+    //
+    // Private
+    //
+
+    private constructor() {}
+
+    private lookupProvider(providerAlias: string): NameServiceProvider|null {
+        let result: NameServiceProvider|null = null
+        for (const p of nameServiceProviders) {
+            if (p.providerAlias == providerAlias) {
+                result = null
+                break
+            }
+        }
+        return result
+    }
+
+    private async resolveWithProvider(name: string, network: string, provider: NameServiceProvider): Promise<NameRecord|null> {
+        let result: NameRecord|null
+        const entityId = await provider.resolve(name, network)
+        if (entityId !== null) {
+            const timestamp = new Date().getTime()
+            const providerAlias = provider.providerAlias
+            result = { entityId, name, providerAlias, timestamp }
+        } else {
+            result = null
+        }
+        return Promise.resolve(result)
+    }
+}
+
+
+export interface NameRecord {
+    entityId: string
+    name: string
+    providerAlias: string
+    timestamp: number // Date.getTime()
+}

--- a/src/utils/name_service/provider/AllProviders.ts
+++ b/src/utils/name_service/provider/AllProviders.ts
@@ -1,0 +1,28 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {NameServiceProvider} from "@/utils/name_service/provider/NameServiceProvider"
+import {KNSProvider} from "@/utils/name_service/provider/KNSProvider"
+import {HNSProvider} from "@/utils/name_service/provider/HNSProvider"
+
+export const nameServiceProviders: NameServiceProvider[] = [
+    new KNSProvider(),
+    new HNSProvider()
+]

--- a/src/utils/name_service/provider/HNSProvider.ts
+++ b/src/utils/name_service/provider/HNSProvider.ts
@@ -1,0 +1,83 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {NameServiceProvider} from "@/utils/name_service/provider/NameServiceProvider";
+import {Resolver} from '@hedera-name-service/hns-resolution-sdk'
+
+export class HNSProvider extends NameServiceProvider {
+
+    private readonly resolverCache = new Map<string,Resolver>()
+
+    //
+    // Public
+    //
+
+    public constructor() {
+        super("HNS", "Hashgraph Name Service", null);
+    }
+
+    //
+    // NameServiceProvider
+    //
+
+    public async resolve(name: string, network: string): Promise<string|null> {
+        let result: string|null
+        const r = this.findResolver(network)
+        if (r !== null) {
+            result = await r.resolveSLD(name) ?? null
+        } else {
+            result = null
+        }
+        return Promise.resolve(result)
+    }
+
+    //
+    // Private
+    //
+
+    private findResolver(network: string): Resolver|null {
+
+        let service: string | null
+        switch (network) {
+            case "mainnet":
+                service = "hedera_main"
+                break
+            case "testnet":
+                service = "hedera_test"
+                break
+            default: // network is unsupported by HNS
+                service = null
+                break
+        }
+
+        let result: Resolver|null
+        if (service !== null) {
+            result = this.resolverCache.get(service) ?? null
+            if (result == null) {
+                result = new Resolver(service as any)
+                this.resolverCache.set(service, result)
+            }
+        } else {
+            result = null
+        }
+
+        return result
+    }
+}

--- a/src/utils/name_service/provider/KNSProvider.ts
+++ b/src/utils/name_service/provider/KNSProvider.ts
@@ -1,0 +1,77 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {NameServiceProvider} from "@/utils/name_service/provider/NameServiceProvider";
+import {KNS, NameNotFoundError} from "@kabuto-sh/ns";
+
+export class KNSProvider extends NameServiceProvider {
+
+    private readonly serviceCache = new Map<string, KNS>()
+
+    //
+    // Public
+    //
+
+    public constructor() {
+        super("KNS", "Kabuto Name Service", null);
+    }
+
+    //
+    // NameServiceProvider
+    //
+
+    public async resolve(name: string, network: string): Promise<string|null> {
+        let result: string|null
+        const s = this.findService(network)
+        if (s !== null) {
+            try {
+                const accountId = await s.getHederaAddress(name)
+                result = accountId.toString()
+            } catch(error) {
+                if (error instanceof NameNotFoundError) {
+                    result = null
+                } else {
+                    throw error
+                }
+            }
+        } else {
+            result = null
+        }
+        return Promise.resolve(result)
+    }
+
+    //
+    // Private
+    //
+
+    private findService(network: string): KNS|null {
+        let result: KNS|null
+        if (network == "mainnet" || network == "testnet") {
+            result = this.serviceCache.get(network) ?? null
+            if (result === null) {
+                result = new KNS({network})
+                this.serviceCache.set(network, result)
+            }
+        } else {
+            result = null
+        }
+        return result
+    }
+}

--- a/src/utils/name_service/provider/NameServiceProvider.ts
+++ b/src/utils/name_service/provider/NameServiceProvider.ts
@@ -1,0 +1,40 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export abstract class NameServiceProvider {
+
+    //
+    // Public
+    //
+
+    public async resolve(name: string, network: string): Promise<string|null> {
+        throw "must be subclassed"
+    }
+
+
+    //
+    // Protected
+    //
+
+    protected constructor(
+        public readonly providerAlias: string,
+        public readonly providerDisplayName: string,
+        public readonly providerHomeURL: string|null) {}
+}

--- a/tests/unit/utils/name_service/NameService.spec.ts
+++ b/tests/unit/utils/name_service/NameService.spec.ts
@@ -125,6 +125,11 @@ class TestProvider extends NameServiceProvider {
         this.resolutionCount += result !== null ? 1 : 0
         return Promise.resolve(result)
     }
+
+    public reset(): void {
+        this.requestCount = 0
+        this.resolutionCount = 0
+    }
 }
 
 const castor = new TestProvider("P1", [
@@ -142,4 +147,6 @@ function installTestProviders() {
     nameServiceProviders.splice(0)
     nameServiceProviders.push(castor)
     nameServiceProviders.push(pollux)
+    castor.reset()
+    pollux.reset()
 }

--- a/tests/unit/utils/name_service/NameService.spec.ts
+++ b/tests/unit/utils/name_service/NameService.spec.ts
@@ -1,0 +1,145 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, test, expect} from 'vitest'
+import {NameService} from "../../../../src/utils/name_service/NameService";
+import {NameServiceProvider} from "../../../../src/utils/name_service/provider/NameServiceProvider";
+import {nameServiceProviders} from "../../../../src/utils/name_service/provider/AllProviders";
+
+describe("NameService", () => {
+
+    test("resolve()", async () => {
+
+        installTestProviders()
+
+        const r1 = await NameService.instance.resolve("castor1", TEST_NETWORK)
+        expect(r1.length).toBe(1)
+        expect(r1[0].entityId).toBe("0.0.100")
+        expect(r1[0].name).toBe("castor1")
+        expect(castor.requestCount).toBe(1)
+        expect(castor.resolutionCount).toBe(1)
+        expect(pollux.requestCount).toBe(1)
+        expect(pollux.resolutionCount).toBe(0)
+
+        const r2 = await NameService.instance.resolve("castor2", TEST_NETWORK)
+        expect(r2.length).toBe(1)
+        expect(r2[0].entityId).toBe("0.0.101")
+        expect(r2[0].name).toBe("castor2")
+        expect(castor.requestCount).toBe(2)
+        expect(castor.resolutionCount).toBe(2)
+        expect(pollux.requestCount).toBe(2)
+        expect(pollux.resolutionCount).toBe(0)
+
+        const r3 = await NameService.instance.resolve("ambiguous", TEST_NETWORK)
+        expect(r3.length).toBe(2)
+        expect(r3[0].entityId).toBe("0.0.102")
+        expect(r3[0].name).toBe("ambiguous")
+        expect(castor.requestCount).toBe(3)
+        expect(castor.resolutionCount).toBe(3)
+        expect(pollux.requestCount).toBe(3)
+        expect(pollux.resolutionCount).toBe(1)
+
+        const r4 = await NameService.instance.resolve("unknown", TEST_NETWORK)
+        expect(r4.length).toBe(0)
+        expect(castor.requestCount).toBe(4)
+        expect(castor.resolutionCount).toBe(3)
+        expect(pollux.requestCount).toBe(4)
+        expect(pollux.resolutionCount).toBe(1)
+
+    })
+
+    test("singleResolve()", async () => {
+
+        installTestProviders()
+
+        const r1 = await NameService.instance.singleResolve("castor1", TEST_NETWORK, "P1")
+        expect(r1).not.toBeNull()
+        expect(r1.entityId).toBe("0.0.100")
+        expect(r1.name).toBe("castor1")
+        expect(r1.providerAlias).toBe("P1")
+        expect(castor.requestCount).toBe(1)
+        expect(castor.resolutionCount).toBe(1)
+        expect(pollux.requestCount).toBe(0)
+        expect(pollux.resolutionCount).toBe(0)
+
+        const r2 = await NameService.instance.singleResolve("castor1", TEST_NETWORK, "P2")
+        expect(r2).toBeNull()
+        expect(castor.requestCount).toBe(1)
+        expect(castor.resolutionCount).toBe(1)
+        expect(pollux.requestCount).toBe(1)
+        expect(pollux.resolutionCount).toBe(0)
+
+        const r3 = await NameService.instance.singleResolve("ambiguous", TEST_NETWORK, "P1")
+        expect(r3.entityId).toBe("0.0.102")
+        expect(r3.name).toBe("ambiguous")
+        expect(r3.providerAlias).toBe("P1")
+        expect(castor.requestCount).toBe(2)
+        expect(castor.resolutionCount).toBe(2)
+        expect(pollux.requestCount).toBe(1)
+        expect(pollux.resolutionCount).toBe(0)
+
+    })
+
+})
+
+const TEST_NETWORK = "testnet"
+
+class TestProvider extends NameServiceProvider {
+
+    public requestCount = 0
+    public resolutionCount = 0
+    private readonly resolutions: Map<string, string>
+
+    constructor(private readonly alias: string, resolutions: [string, string][]) {
+        super(alias, "Test Provider 1", null)
+        this.resolutions = new Map<string, string>(resolutions)
+    }
+
+    public async resolve(name: string, network: string): Promise<string|null> {
+        let result: string|null
+        if (network == TEST_NETWORK) {
+            result = this.resolutions.get(name) ?? null
+        } else {
+            result = null
+        }
+        this.requestCount +=1
+        this.resolutionCount += result !== null ? 1 : 0
+        return Promise.resolve(result)
+    }
+}
+
+const castor = new TestProvider("P1", [
+    ["castor1",     "0.0.100"],
+    ["castor2",     "0.0.101"],
+    ["ambiguous",   "0.0.102"],
+])
+const pollux = new TestProvider("P2", [
+    ["pollux1",     "0.0.200"],
+    ["pollux2",     "0.0.201"],
+    ["ambiguous",   "0.0.202"],
+])
+
+function installTestProviders() {
+    nameServiceProviders.splice(0)
+    nameServiceProviders.push(castor)
+    nameServiceProviders.push(pollux)
+}


### PR DESCRIPTION
**Description**:

Changes below refactor name service part of explorer. Goal is twofold:
1) make addition  of a new name service easier
2) ease further work on name display (see #972).

Changes summary:
1) new abstract `NameServiceProvider` is introduced with two implementations `KNSProvider` and `HNSProvider`.
2) `NameService` class singleton is now the interface used by the rest of explorer code
3) `SearchRequest` class now delegates name resolution to `NameService.resolve()`
4) `NameService` has its own unit test


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
