### PR TITLE
Fix: use ascending order in token tables

### DIFF
--- a/src/components/account/CollectionTableController.ts
+++ b/src/components/account/CollectionTableController.ts
@@ -55,11 +55,12 @@ export class CollectionTableController extends TableController<Nft, number> {
             order: string
         }
         params.limit = limit
-        params.order = order
+        params.order = TableController.invertSortOrder(order)
+        const keyOperator = TableController.invertKeyOperator(operator)
         params["token.id"] = this.tokenId
 
         if (serialNumber !== null) {
-            params.serialnumber = operator + ":" + serialNumber
+            params.serialnumber = keyOperator + ":" + serialNumber
         }
 
         const {data} = await axios.get<Nfts>(

--- a/src/components/token/NftHolderTableController.ts
+++ b/src/components/token/NftHolderTableController.ts
@@ -51,9 +51,10 @@ export class NftHolderTableController extends TableController<Nft, string> {
                 serialnumber: string | undefined
             }
             params.limit = limit
-            params.order = order
+            params.order = TableController.invertSortOrder(order)
+            const keyOperator = TableController.invertKeyOperator(operator)
             if (serialNumber !== null) {
-                params.serialnumber = operator + ":" + serialNumber
+                params.serialnumber = keyOperator + ":" + serialNumber
             }
             const cb = (r: AxiosResponse<Nfts>): Promise<Nft[] | null> => {
                 return Promise.resolve(r.data.nfts ?? [])

--- a/src/components/token/TokenBalanceTableController.ts
+++ b/src/components/token/TokenBalanceTableController.ts
@@ -51,9 +51,10 @@ export class TokenBalanceTableController extends TableController<TokenDistributi
                 'account.id': string | undefined
             }
             params.limit = limit
-            params.order = order
+            params.order = TableController.invertSortOrder(order)
+            const keyOperator = TableController.invertKeyOperator(operator)
             if (accountId !== null) {
-                params['account.id'] = operator + ":" + accountId
+                params['account.id'] = keyOperator + ":" + accountId
             }
             const cb = (r: AxiosResponse<TokenBalancesResponse>): Promise<TokenDistribution[] | null> => {
                 return Promise.resolve(r.data.balances ?? [])

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -23,7 +23,7 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div class="is-flex is is-align-items-baseline">
+  <div>
     <span v-if="decimalOverflow" :class="{'mr-2': showExtra && tokenId}">
       ?
     </span>

--- a/src/pages/AccountCollection.vue
+++ b/src/pages/AccountCollection.vue
@@ -28,13 +28,15 @@
 
     <DashboardCard>
       <template v-slot:title>
-        <span v-if="tokenInfo" class="h-is-primary-title mr-2">
+        <span v-if="tokenInfo" class="h-is-primary-title mr-3">
           <span v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'">NFT Collection</span>
           <span v-else>Fungible Token</span>
         </span>
-        <div class="is-inline-block h-is-tertiary-text h-is-extra-text should-wrap" style="word-break: break-all">
-          {{ `${displayName} (${displaySymbol})` }}
-        </div>
+        <router-link :to="tokenRoute">
+          <div class="is-inline-block h-is-tertiary-text h-is-extra-text should-wrap" style="word-break: break-all">
+            {{ `${displayName} (${displaySymbol})` }}
+          </div>
+        </router-link>
       </template>
 
       <template v-slot:subtitle>
@@ -74,6 +76,7 @@ import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";
 import {makeTokenName, makeTokenSymbol} from "@/schemas/HederaUtils";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
+import {routeManager} from "@/router";
 
 export default defineComponent({
 
@@ -133,6 +136,8 @@ export default defineComponent({
       collectionTableController.unmount()
     })
 
+    const tokenRoute = computed(() => routeManager.makeRouteToToken(props.tokenId))
+
     return {
       isSmallScreen,
       isTouchDevice,
@@ -141,6 +146,7 @@ export default defineComponent({
       displaySymbol,
       collectionTableController,
       normalizedAccountId,
+      tokenRoute
     }
   }
 });

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -197,6 +197,29 @@
 
     </DashboardCard>
 
+    <DashboardCard v-if="tokenInfo" collapsible-key="nftHolders">
+
+      <template v-slot:title>
+        <div v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'" class="h-is-secondary-title mb-2">NFTs</div>
+        <div v-else class="h-is-secondary-title mb-2">Balances</div>
+      </template>
+
+      <template v-slot:control>
+        <PlayPauseButton v-if="isNft" :controller="nftHolderTableController"/>
+        <PlayPauseButton v-else :controller="tokenBalanceTableController"/>
+      </template>
+
+      <template v-slot:content>
+        <div v-if="isNft" id="nft-holder-table">
+          <NftHolderTable :controller="nftHolderTableController"/>
+        </div>
+        <div v-else id="token-balance-table">
+          <TokenBalanceTable :controller="tokenBalanceTableController"/>
+        </div>
+      </template>
+
+    </DashboardCard>
+
     <DashboardCard v-if="tokenInfo" collapsible-key="tokenKeys">
 
       <template v-slot:title>
@@ -284,29 +307,6 @@
     </DashboardCard>
 
     <TokenCustomFees v-if="hasCustomFees" :analyzer="analyzer"/>
-
-    <DashboardCard v-if="tokenInfo" collapsible-key="nftHolders">
-
-      <template v-slot:title>
-        <div v-if="tokenInfo.type === 'NON_FUNGIBLE_UNIQUE'" class="h-is-secondary-title mb-2">NFTs</div>
-        <div v-else class="h-is-secondary-title mb-2">Balances</div>
-      </template>
-
-      <template v-slot:control>
-        <PlayPauseButton v-if="isNft" :controller="nftHolderTableController"/>
-        <PlayPauseButton v-else :controller="tokenBalanceTableController"/>
-      </template>
-
-      <template v-slot:content>
-        <div v-if="isNft" id="nft-holder-table">
-          <NftHolderTable :controller="nftHolderTableController"/>
-        </div>
-        <div v-else id="token-balance-table">
-          <TokenBalanceTable :controller="tokenBalanceTableController"/>
-        </div>
-      </template>
-
-    </DashboardCard>
 
     <ContractResultsSection :contract-id="normalizedTokenId ?? undefined"/>
 


### PR DESCRIPTION
**Description**:

- Use ascending order in the following tables:
   * `NFTs` table in `TokenDetails` (for NFT collection)
   * `Balances` table in `TokenDetails` (for Fungible)

Other (unrelated) fixes:
- Adds a link to the NFT Collection from the `AccountCollection` view
- Put the `NFTs`/`Balances` tables as top section in `TokenDetails` view.
- Fix alignment of token amounts in `Balances` table.

**Notes for reviewer**:

Changes visible on staging server, although mixed to more substantial NFT changes.
