### PR TITLE
feat: enabling search with partial transaction id

### DIFF
--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -75,7 +75,10 @@ export class SearchRequest {
                                              |                  | api/v1/tokens/0.0.{integer}
                                              |                  | api/v1/topics/0.0.{integer}/messages
         -------------------------------------+------------------+------------------------------------------------------
-        shard.realm.num@seconds.nanoseconds  | Transaction ID   | api/v1/transactions/normalize({searchId}
+        shard.realm.num@seconds.nanoseconds  | Transaction ID   | api/v1/transactions/normalize({searchId})
+        -------------------------------------+------------------+------------------------------------------------------
+        shard.realm.num@seconds              | Incomplete       | api/v1/transactions/normalize({searchId}.000000000)
+                                             | Transaction ID   |
         -------------------------------------+------------------+------------------------------------------------------
         shard.realm.num-seconds-nanoseconds  | Transaction ID   | api/v1/transactions/{searchId}
                                              | (normalized)     |
@@ -109,7 +112,7 @@ export class SearchRequest {
 
 
         const entityID = EntityID.parseWithChecksum(this.searchedId, true)
-        const transactionID = TransactionID.parse(this.searchedId)
+        const transactionID = TransactionID.parse(this.searchedId, true)
         const hexBytes = hexToByte(this.searchedId)
         const alias = base32ToAlias(this.searchedId) != null ? this.searchedId : null
         const timestamp = Timestamp.parse(this.searchedId)

--- a/src/utils/SearchRequest.ts
+++ b/src/utils/SearchRequest.ts
@@ -18,6 +18,7 @@
  *
  */
 
+
 import {
     AccountBalanceTransactions,
     AccountInfo,

--- a/src/utils/TransactionID.ts
+++ b/src/utils/TransactionID.ts
@@ -31,9 +31,10 @@ export class TransactionID {
     // Public
     //
 
-    public static parse(value: string): TransactionID | null {
+    public static parse(value: string, autoComplete = false): TransactionID | null {
         // 0.0.88-1640084590-665216882                      useArobas == false
         // 0.0.88@1640084590.665216882                      useArobas == true
+        // 0.0.88@1640084590                                useArobas == true
         // 00881640084590665216882
 
         let result: TransactionID | null
@@ -44,7 +45,7 @@ export class TransactionID {
         const i1 = value.indexOf(sep1)
         const i2 = i1 != -1 ? value.indexOf(sep2, i1 + 1) : -1
 
-        if (i1 != -1 && i2 != -1) {
+        if (i1 != -1 && i2 != -1) { // 0.0.88-1640084590-665216882 or 0.0.88@1640084590.665216882 ?
             const s0 = value.substring(0, i1)
             const s1 = value.substring(i1 + 1, i2)
             const s2 = value.substring(i2 + 1)
@@ -56,7 +57,17 @@ export class TransactionID {
             } else {
                 result = new TransactionID(v0, v1, v2)
             }
-        } else if (i1 == -1 && i2 == -1) {
+        } else if (i1 != -1 && i2 == -1 && autoComplete) { // 0.0.88@1640084590 ?
+            const s0 = value.substring(0, i1)
+            const s1 = value.substring(i1 + 1)
+            const v0 = EntityID.parse(s0)
+            const v1 = EntityID.parsePositiveInt(s1)
+            if (v0 == null || v1 == null) {
+                result = null;
+            } else {
+                result = new TransactionID(v0, v1, 0)
+            }
+        } else if (i1 == -1 && i2 == -1) { // 00881640084590665216882 ?
             // 00881640084590665216882
             // 0088 1640084590 665216882
             const i2 = value.length - 9

--- a/tests/unit/utils/TransactionID.spec.ts
+++ b/tests/unit/utils/TransactionID.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -47,6 +49,23 @@ describe("TransactionID.ts", () => {
         expect(obj?.seconds).toBe(1640084590)
         expect(obj?.nanoSeconds).toBe(665216882)
         expect(obj?.toString(true)).toBe(str)
+    })
+
+    test("0.0.88@1640084590 (without autocomplete)", () => {
+        const str = "0.0.88@1640084590"
+        const obj = TransactionID.parse(str) // autocomplete
+        expect(obj).toBeNull()
+    })
+
+    test("0.0.88@1640084590 (with autocomplete)", () => {
+        const str = "0.0.88@1640084590"
+        const obj = TransactionID.parse(str, true)
+        expect(obj?.entityID.shard).toBe(0)
+        expect(obj?.entityID.realm).toBe(0)
+        expect(obj?.entityID.num).toBe(88)
+        expect(obj?.seconds).toBe(1640084590)
+        expect(obj?.nanoSeconds).toBe(0)
+        expect(obj?.toString(true)).toBe(str + ".000000000")
     })
 
     test("00881640084590665216882", () => {


### PR DESCRIPTION
**Description**:
Changes below implement #1065. They also extend unit tests for `TransactionID` class.

**Related issue(s)**:
Fixes #1065 

**Notes for reviewer**:
Transaction for testing on `mainnet`: [0.0.1280@1716576300.000000000](https://hashscan.io/testnet/transaction/1716576305.279219003)

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
