### PR TITLE
chore: some tuning in unit tests to avoid some warning/error messages

### DIFF
--- a/tests/unit/utils/EVMAddress.spec.ts
+++ b/tests/unit/utils/EVMAddress.spec.ts
@@ -153,6 +153,11 @@ describe("EVMAddress", () => {
 
     test("Constructing with System Contract address", async () => {
 
+        const abi = require('../../../public/abi/IHederaTokenService.json')
+        const mock = new MockAdapter(axios);
+        const matcher1 = "http://localhost:3000/abi/IHederaTokenService.json"
+        mock.onGet(matcher1).reply(200, abi)
+
         await router.push("/") // To avoid "missing required param 'network'" error
         const wrapper = mount(EVMAddress, {
             global: {
@@ -168,6 +173,7 @@ describe("EVMAddress", () => {
 
         wrapper.unmount()
         await flushPromises()
+        mock.restore()
     })
 
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,5 +44,8 @@ export default defineConfig({
   },
   worker: {
     format: "es",
+  },
+  test: {
+    environment: "jsdom" // https://vitest.dev/config/#environment
   }
 })


### PR DESCRIPTION
**Description**:

Changes below bring two updates:
1) Vite configuration parameter `test.environment` is set with `jsdom` to avoid `window is undefined` that randomly appears in unit tests (especially `BalanceAnalyzer` unit test)
2) Add some missing mock in `EVMAddress` unit test to avoid (harmless but irritating) `connect ECONNREFUSED 127.0.0.1:3000` message

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
