### PR TITLE
chore: add new slots in DashboardCard

### DIFF
--- a/src/components/DashboardCard.vue
+++ b/src/components/DashboardCard.vue
@@ -47,11 +47,27 @@
     <div v-if="!isCollapsed">
       <hr class="h-card-separator mb-3"/>
 
-      <div class="h-is-property-text">
+      <div v-if="slots.content" class="h-is-property-text">
         <slot name="content"></slot>
       </div>
 
-      <div class="columns is-multiline h-is-property-text">
+      <div v-if="slots.mediaContent || slots.mediaDescription"
+           class="h-is-property-text"
+           :class="{'is-flex':isMediumScreen}"
+           style="gap: 20px"
+      >
+
+        <div class="is-flex is-justify-content-center" :class="{'my-4':!isMediumScreen}">
+          <slot name="mediaContent"></slot>
+        </div>
+
+        <div style="flex-grow: 0.8" :class="{'h-has-column-separator': isMediumScreen}">
+          <slot name="mediaDescription"></slot>
+        </div>
+
+      </div>
+
+      <div v-if="slots.leftContent || slots.rightContent" class="columns is-multiline h-is-property-text">
 
         <div :class="{'is-full': !isMediumScreen}" class="column is-6-desktop">
           <slot name="leftContent"></slot>

--- a/tests/unit/values/DashboardCard.spec.ts
+++ b/tests/unit/values/DashboardCard.spec.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {describe, it, expect} from 'vitest'
+import {describe, expect, it} from 'vitest'
 import {mount} from "@vue/test-utils"
 import DashboardCard from "@/components/DashboardCard.vue";
 
@@ -40,20 +40,35 @@ describe("DashboardCard.vue", () => {
     it("should have all slots setup", async () => {
 
         const sampleTitle = "ZeTitle"
+        const sampleSubtitle = "ZeSubTitle"
         const sampleControl = "ZeControl"
+        const sampleMediaContent = "ZeMediaContent"
+        const sampleMediaDescription = "ZeMediaDescription"
         const sampleContent = "ZeContent"
+        const sampleLeftContent = "ZeLeftContent"
+        const sampleRightContent = "ZeRightContent"
 
         const wrapper = mount(DashboardCard, {
             slots: {
                 title: sampleTitle,
+                subtitle: sampleSubtitle,
                 control: sampleControl,
+                mediaContent: sampleMediaContent,
+                mediaDescription: sampleMediaDescription,
                 content: sampleContent,
+                leftContent: sampleLeftContent,
+                rightContent: sampleRightContent,
             }
         });
 
         expect(wrapper.text()).toContain(sampleTitle)
+        expect(wrapper.text()).toContain(sampleSubtitle)
         expect(wrapper.text()).toContain(sampleControl)
+        expect(wrapper.text()).toContain(sampleMediaContent)
+        expect(wrapper.text()).toContain(sampleMediaDescription)
         expect(wrapper.text()).toContain(sampleContent)
+        expect(wrapper.text()).toContain(sampleLeftContent)
+        expect(wrapper.text()).toContain(sampleRightContent)
 
         wrapper.unmount()
     })


### PR DESCRIPTION
**Description**:

Slightly refactor `DashboardCard`:
* avoid inserting div for content slot when empty.
* add 2 new slots for further use (`mediaContent` & `mediaDescription`)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
