### PR TITLE
fix: `Call Trace` entries contain the same parameters for each call

### DIFF
--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -123,9 +123,9 @@ import PlainAmount from "@/components/values/PlainAmount.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import FunctionInput from "@/components/values/FunctionInput.vue";
 import FunctionResult from "@/components/values/FunctionResult.vue";
-import {ContractResultAnalyzer} from "@/utils/analyzer/ContractResultAnalyzer";
 import FunctionError from "@/components/values/FunctionError.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
+import {ContractActionAnalyzer} from "@/utils/analyzer/ContractActionAnalyzer";
 
 export default defineComponent({
   name: 'ContractActionDetails',
@@ -147,9 +147,9 @@ export default defineComponent({
     const isMediumScreen = inject('isMediumScreen', ref(false))
     const propertySizeClass = 'is-one-fifth'
 
-    const contractResultAnalyzer = new ContractResultAnalyzer(computed(() => props.action?.timestamp ?? null))
-    onMounted(() => contractResultAnalyzer.mount())
-    onBeforeUnmount(() => contractResultAnalyzer.unmount())
+    const contractActionAnalyzer = new ContractActionAnalyzer(computed(() => props.action ?? null))
+    onMounted(() => contractActionAnalyzer.mount())
+    onBeforeUnmount(() => contractActionAnalyzer.unmount())
 
     return {
       isTouchDevice,
@@ -157,9 +157,9 @@ export default defineComponent({
       isMediumScreen,
       propertySizeClass,
       ORUGA_MOBILE_BREAKPOINT,
-      functionCallAnalyzer: contractResultAnalyzer.functionCallAnalyzer,
-      functionHash: contractResultAnalyzer.functionCallAnalyzer.functionHash,
-      signature: contractResultAnalyzer.functionCallAnalyzer.signature,
+      functionCallAnalyzer: contractActionAnalyzer.functionCallAnalyzer,
+      functionHash: contractActionAnalyzer.functionCallAnalyzer.functionHash,
+      signature: contractActionAnalyzer.functionCallAnalyzer.signature,
     }
   }
 });

--- a/src/utils/analyzer/ContractActionAnalyzer.ts
+++ b/src/utils/analyzer/ContractActionAnalyzer.ts
@@ -1,0 +1,127 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {computed, ref, Ref, watch, WatchStopHandle} from "vue";
+import {ContractAction, ResultDataType} from "@/schemas/HederaSchemas";
+import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
+import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
+import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
+
+export class ContractActionAnalyzer {
+
+    public readonly action: Ref<ContractAction | null>
+    public readonly functionCallAnalyzer: FunctionCallAnalyzer
+    public readonly toId: Ref<string | null> = ref(null)
+    public readonly fromId: Ref<string | null> = ref(null)
+    private readonly watchHandle: Ref<WatchStopHandle[]> = ref([])
+
+    //
+    // Public
+    //
+
+    public constructor(action: Ref<ContractAction | null>) {
+        this.action = action
+        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.error, this.contractId)
+    }
+
+    public mount(): void {
+        this.watchHandle.value = [
+            watch(this.action, this.actionDidChange, {immediate: true}),
+        ]
+        this.functionCallAnalyzer.mount()
+    }
+
+    public unmount(): void {
+        this.functionCallAnalyzer.unmount()
+        for (const wh of this.watchHandle.value) {
+            wh()
+        }
+        this.functionCallAnalyzer.unmount()
+        this.toId.value = null
+        this.fromId.value = null
+    }
+
+    //
+    // Private
+    //
+
+    private readonly actionDidChange = async () => {
+
+        // fromId
+        try {
+            if (this.action.value?.caller) { // We have the entity id :)
+                this.fromId.value = this.action.value.caller
+            } else if (this.action.value?.from) { // We have evm address only :|
+                const r = await AccountByAddressCache.instance.lookup(this.action.value.from)
+                this.fromId.value = r?.account ?? null
+            } else { // We have nothing :(
+                this.fromId.value = null
+            }
+        } catch {
+            this.fromId.value = null
+        }
+
+        // toId
+        try {
+            if (this.action.value?.recipient) { // We have the entity id :)
+                this.toId.value = this.action.value?.recipient
+            } else if (this.action.value?.to) { // We have evm address only :|
+                // => if it's a system contract, then id is computed
+                // => else we must fetch contract by address and get its contract id
+                const systemContractEntry = systemContractRegistry.lookupByAddress(this.action.value.to)
+                if (systemContractEntry !== null) {
+                    this.toId.value = systemContractEntry.contractId
+                } else {
+                    const r = await AccountByAddressCache.instance.lookup(this.action.value.to)
+                    this.toId.value = r?.account ?? null
+                }
+            } else { // We have nothing :(
+                this.toId.value = null
+            }
+        } catch {
+            this.toId.value = null
+        }
+
+    }
+
+    private readonly contractId = computed(() => this.action.value?.recipient ?? null)
+
+    private readonly input = computed(() => this.action.value?.input ?? null)
+
+    private readonly output = computed(() => {
+        let result: string | null
+        if (this.action?.value?.result_data_type == ResultDataType.OUTPUT) {
+            result = this.action.value.result_data ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly error = computed(() => {
+        let result: string | null
+        if (this.action?.value?.result_data_type != ResultDataType.OUTPUT) {
+            result = this.action?.value?.result_data ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
+}

--- a/tests/unit/MockUtils.ts
+++ b/tests/unit/MockUtils.ts
@@ -1,0 +1,38 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+//
+// Tools
+//
+
+import MockAdapter from "axios-mock-adapter";
+
+export function cloneMock(mock: object): any {
+    return JSON.parse(JSON.stringify(mock))
+}
+
+export function fetchGetURLs(mock: MockAdapter): string[] {
+    const result: string[] = []
+    for (const e of mock.history.get) {
+        result.push(e.url)
+    }
+    return result
+}

--- a/tests/unit/utils/analyzer/ABIAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ABIAnalyzer.spec.ts
@@ -32,7 +32,7 @@ import {
     SAMPLE_LOGIC_ADDRESS_RESPONSE
 } from "../../Mocks";
 import {flushPromises} from "@vue/test-utils";
-import {fetchGetURLs} from "./ContractResultAnalyzer.spec";
+import {fetchGetURLs} from "../../MockUtils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {ABIController, ABIMode} from "../../../../src/components/contract/ABIController";

--- a/tests/unit/utils/analyzer/ContractActionAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractActionAnalyzer.spec.ts
@@ -1,0 +1,326 @@
+// noinspection DuplicatedCode
+
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, test} from "vitest"
+import MockAdapter from "axios-mock-adapter"
+import axios from "axios"
+import {ref} from "vue"
+import {ContractActionAnalyzer} from "@/utils/analyzer/ContractActionAnalyzer"
+import {flushPromises} from "@vue/test-utils"
+import {SAMPLE_CONTRACT_ACTIONS, SAMPLE_TOKEN} from "../../Mocks"
+import ContractAction from "@/schemas/HederaSchemas"
+import {SignatureCache} from "@/utils/cache/SignatureCache";
+import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
+import {cloneMock, fetchGetURLs} from "../../MockUtils";
+
+describe("ContractActionAnalyzer.spec.ts", () => {
+
+    test("ContractAction caller and recipient are defined", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        // 1) new
+        const action = ref<ContractAction | null>(null)
+        const analyzer = new ContractActionAnalyzer(action)
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 2) mount
+        analyzer.mount()
+        await flushPromises()
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 3) setup action
+        const SAMPLE_ACTION = SAMPLE_CONTRACT_ACTIONS.actions[1]
+        action.value = SAMPLE_ACTION
+        await flushPromises()
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBe("0.0.96039")
+        expect(analyzer.toId.value).toBe("0.0.96037")
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+            "api/v1/contracts/0.0.96037",
+        ])
+
+        // 4) unmount
+        analyzer.unmount()
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+            "api/v1/contracts/0.0.96037",
+        ])
+
+        SignatureCache.instance.clear()
+        mock.restore()
+        await flushPromises()
+
+    })
+
+    test("ContractAction caller is undefined", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const SAMPLE_ACTION = cloneMock(SAMPLE_CONTRACT_ACTIONS.actions[1])
+        SAMPLE_ACTION.caller = undefined
+        expect(SAMPLE_ACTION.from).toBe(SAMPLE_CALLER.evm_address)
+
+        const matcher1 = "api/v1/accounts/" + SAMPLE_ACTION.from
+        mock.onGet(matcher1).reply(200, SAMPLE_CALLER)
+
+        // 1) new
+        const action = ref<ContractAction | null>(null)
+        const analyzer = new ContractActionAnalyzer(action)
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 2) mount
+        analyzer.mount()
+        await flushPromises()
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 3) setup action
+        action.value = SAMPLE_ACTION
+        await flushPromises()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+            "api/v1/accounts/0x0000000000000000000000000000000000017727",
+            "api/v1/contracts/0.0.96037",
+        ])
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBe("0.0.96039")
+        expect(analyzer.toId.value).toBe("0.0.96037")
+
+        // 4) unmount
+        analyzer.unmount()
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+            "api/v1/accounts/0x0000000000000000000000000000000000017727",
+            "api/v1/contracts/0.0.96037",
+        ])
+
+        AccountByAddressCache.instance.clear()
+        SignatureCache.instance.clear()
+        mock.restore()
+        await flushPromises()
+
+    })
+
+    test("ContractAction recipient is undefined", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const SAMPLE_ACTION = cloneMock(SAMPLE_CONTRACT_ACTIONS.actions[1])
+        SAMPLE_ACTION.recipient = undefined
+        expect(SAMPLE_ACTION.to).toBe(SAMPLE_RECIPIENT.evm_address)
+
+        const matcher1 = "api/v1/accounts/" + SAMPLE_ACTION.to
+        mock.onGet(matcher1).reply(200, SAMPLE_RECIPIENT)
+
+        // 1) new
+        const action = ref<ContractAction | null>(null)
+        const analyzer = new ContractActionAnalyzer(action)
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 2) mount
+        analyzer.mount()
+        await flushPromises()
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 3) setup action
+        action.value = SAMPLE_ACTION
+        await flushPromises()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+            "api/v1/accounts/0x0000000000000000000000000000000000017725",
+        ])
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBe("0.0.96039")
+        expect(analyzer.toId.value).toBe("0.0.96037")
+
+        // 4) unmount
+        analyzer.unmount()
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+            "api/v1/accounts/0x0000000000000000000000000000000000017725",
+        ])
+
+        AccountByAddressCache.instance.clear()
+        SignatureCache.instance.clear()
+        mock.restore()
+        await flushPromises()
+
+    })
+
+    test("ContractAction recipient is undefined and to is HTS", async () => {
+
+        const mock = new MockAdapter(axios)
+
+        const SAMPLE_ACTION = cloneMock(SAMPLE_CONTRACT_ACTIONS.actions[1])
+        SAMPLE_ACTION.recipient = undefined
+        SAMPLE_ACTION.to = "0x0000000000000000000000000000000000000167"
+
+        // 1) new
+        const action = ref<ContractAction | null>(null)
+        const analyzer = new ContractActionAnalyzer(action)
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.functionHash.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.signature.value).toBeNull()
+        expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 2) mount
+        analyzer.mount()
+        await flushPromises()
+        expect(analyzer.action.value).toBeNull()
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        // 3) setup action
+        action.value = SAMPLE_ACTION
+        await flushPromises()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+        ])
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBe("0.0.96039")
+        expect(analyzer.toId.value).toBe("0.0.359")
+
+        // 4) unmount
+        analyzer.unmount()
+        expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
+        expect(analyzer.fromId.value).toBeNull()
+        expect(analyzer.toId.value).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
+        ])
+
+        SignatureCache.instance.clear()
+        mock.restore()
+        await flushPromises()
+
+    })
+
+})
+
+
+
+const SAMPLE_CALLER = {
+    "account": "0.0.96039",
+    "alias": "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ",
+    "auto_renew_period": 7776000,
+    "balance": {
+        "balance": 2342647909,
+        "timestamp": "1646333100.356842286",
+        "tokens": [
+            {
+                "token_id": SAMPLE_TOKEN.token_id,
+                "balance": 10
+            }
+        ]
+    },
+    "created_timestamp": "1646025151.667604000",
+    "deleted": false,
+    "expiry_timestamp": null,
+    "key":
+        {
+            "_type": "ED25519",
+            "key": "aa2f7b3e759f4531ec2e7941afa449e6a6e610efb52adae89e9cd8e9d40ddcbf"
+        },
+    "max_automatic_token_associations": 0,
+    "memo": "",
+    "receiver_sig_required": false,
+    "evm_address": "0x0000000000000000000000000000000000017727",
+    "ethereum_nonce": 0,
+    "decline_reward": null,
+    "staked_node_id": null,
+    "staked_account_id": null,
+    "stake_period_start": null
+}
+
+const SAMPLE_RECIPIENT = {
+    "account": "0.0.96037",
+    "alias": "CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ",
+    "auto_renew_period": 7776000,
+    "balance": {
+        "balance": 2342647909,
+        "timestamp": "1646333100.356842286",
+        "tokens": [
+            {
+                "token_id": SAMPLE_TOKEN.token_id,
+                "balance": 10
+            }
+        ]
+    },
+    "created_timestamp": "1646025151.667604000",
+    "deleted": false,
+    "expiry_timestamp": null,
+    "key":
+        {
+            "_type": "ED25519",
+            "key": "aa2f7b3e759f4531ec2e7941afa449e6a6e610efb52adae89e9cd8e9d40ddcbf"
+        },
+    "max_automatic_token_associations": 0,
+    "memo": "",
+    "receiver_sig_required": false,
+    "evm_address": "0x0000000000000000000000000000000000017725",
+    "ethereum_nonce": 0,
+    "decline_reward": null,
+    "staked_node_id": null,
+    "staked_account_id": null,
+    "stake_period_start": null
+}

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -26,6 +26,7 @@ import {ContractResultAnalyzer} from "@/utils/analyzer/ContractResultAnalyzer";
 import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import {fetchGetURLs} from "../../MockUtils";
 
 describe("ContractResultAnalyzer.spec.ts", () => {
 
@@ -319,14 +320,6 @@ describe("ContractResultAnalyzer.spec.ts", () => {
     })
 
 })
-
-export function fetchGetURLs(mock: MockAdapter): string[] {
-    const result: string[] = []
-    for (const e of mock.history.get) {
-        result.push(e.url)
-    }
-    return result
-}
 
 const CONTRACT = {
     admin_key: null,


### PR DESCRIPTION
**Description**:

This is a regression introduced in #1000.
Change below restore (wrongly removed) `ContractActionAnalyzer` class and add unit tests to avoid regression.

**Related issue(s)**:

Fixes #1117 

**Notes for reviewer**:

Use [1718213391.883698003](https://hashscan.io/mainnet/transaction/1718213391.883698003) to see fix in action.
See #1117 for additional details.

Fix is deployed on staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
