### PR TITLE
chore: unit tests for `SearchRequest` now validates `MockAdaptor` history.

### DIFF
--- a/tests/unit/utils/SearchRequest.spec.ts
+++ b/tests/unit/utils/SearchRequest.spec.ts
@@ -22,7 +22,7 @@
 
 import {describe, test, expect} from 'vitest'
 import MockAdapter from "axios-mock-adapter";
-import axios from "axios";
+import axios, {AxiosInstance} from "axios";
 import {
     SAMPLE_ACCOUNT,
     SAMPLE_ACCOUNTS,
@@ -36,70 +36,8 @@ import {
 import {SearchRequest} from "@/utils/SearchRequest";
 import {base32ToAlias, base64DecToArr, byteToHex, hexToByte} from "@/utils/B64Utils";
 import {EntityID} from "@/utils/EntityID";
+import {fetchGetURLs} from "../MockUtils";
 
-const mock = new MockAdapter(axios)
-
-// Account
-
-const matcher_account = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
-mock.onGet(matcher_account).reply(200, SAMPLE_ACCOUNT)
-
-const matcher_account_with_alias = "/api/v1/accounts/" + SAMPLE_ACCOUNT.alias
-mock.onGet(matcher_account_with_alias).reply(200, SAMPLE_ACCOUNT)
-
-const SAMPLE_ACCOUNT_ADDRESS = EntityID.parse(SAMPLE_ACCOUNT.account)!.toAddress()
-const matcher_account_with_address = "/api/v1/accounts/" + SAMPLE_ACCOUNT_ADDRESS
-mock.onGet(matcher_account_with_address).reply(200, SAMPLE_ACCOUNT)
-
-const matcher_account_with_public_key = "/api/v1/accounts/?account.publickey="
-    + SAMPLE_ACCOUNTS.accounts[0].key.key + "&limit=2"
-mock.onGet(matcher_account_with_public_key).reply(200, SAMPLE_ACCOUNTS)
-
-
-// Transaction
-
-const matcher_transaction = "/api/v1/transactions/" + SAMPLE_TRANSACTION.transaction_id
-mock.onGet(matcher_transaction).reply(200, SAMPLE_TRANSACTIONS)
-
-const TRANSACTION_HASH = byteToHex(base64DecToArr(SAMPLE_TRANSACTION.transaction_hash))
-const matcher_transaction_with_hash = "/api/v1/transactions/" + TRANSACTION_HASH
-mock.onGet(matcher_transaction_with_hash).reply(200, SAMPLE_TRANSACTIONS)
-
-const EVM_HASH = SAMPLE_CONTRACT_RESULT_DETAILS.hash.slice(2) // To remove 0x
-const matcher_contract_result = "/api/v1/contracts/results/" + EVM_HASH
-mock.onGet(matcher_contract_result).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
-
-const matcher_transaction_with_timestamp = "/api/v1/transactions?timestamp=" + SAMPLE_CONTRACT_RESULT_DETAILS.timestamp
-mock.onGet(matcher_transaction_with_timestamp).reply(200, SAMPLE_TRANSACTIONS)
-
-// Block
-
-const BLOCK_HASH = byteToHex(hexToByte(SAMPLE_BLOCKSRESPONSE.blocks[0].hash) ?? new Uint8Array(0))
-const matcher_block_with_hash = "/api/v1/blocks/" + BLOCK_HASH
-mock.onGet(matcher_block_with_hash).reply(200, SAMPLE_BLOCKSRESPONSE.blocks[0])
-const BLOCK_HASH_PREFIX = byteToHex(hexToByte(SAMPLE_BLOCKSRESPONSE.blocks[0].hash)?.slice(0, 32) ?? new Uint8Array(0))
-const matcher_block_with_hash_prefix = "/api/v1/blocks/" + BLOCK_HASH_PREFIX
-mock.onGet(matcher_block_with_hash_prefix).reply(200, SAMPLE_BLOCKSRESPONSE.blocks[0])
-
-// Token
-
-const matcher_token = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
-mock.onGet(matcher_token).reply(200, SAMPLE_TOKEN)
-const SAMPLE_TOKEN_ADDRESS = EntityID.parse(SAMPLE_TOKEN.token_id)!.toAddress()
-
-const SAMPLE_TOPIC_ID = SAMPLE_TOPIC_MESSAGES.messages[0].topic_id
-const matcher_topic = "/api/v1/topics/" + SAMPLE_TOPIC_ID + "/messages"
-mock.onGet(matcher_topic).reply(200, SAMPLE_TOPIC_MESSAGES)
-
-const matcher_contracts = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
-mock.onGet(matcher_contracts).reply(200, SAMPLE_CONTRACT)
-
-const matcher_contracts_with_evm_address = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address.slice(2)
-mock.onGet(matcher_contracts_with_evm_address).reply(200, SAMPLE_CONTRACT)
-
-const INVALID_EVM_ADDRESS = "0102030405060708090102030405060708"; // 19 bytes : should be 20
-const matcher_contracts_with_invalid_evm_address = "/api/v1/contracts/" + INVALID_EVM_ADDRESS
-mock.onGet(matcher_contracts_with_invalid_evm_address).reply(400)
 
 const TEST_NETWORK = "mainnet"
 
@@ -110,6 +48,8 @@ describe("SearchRequest.ts", () => {
     //
 
     test("account", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_ACCOUNT.account ?? "", TEST_NETWORK)
         await r.run()
 
@@ -125,9 +65,19 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_ACCOUNT.account,
+            "api/v1/contracts/" + SAMPLE_ACCOUNT.account,
+            "api/v1/tokens/" + SAMPLE_ACCOUNT.account,
+            "api/v1/topics/" + SAMPLE_ACCOUNT.account + "/messages",
+        ])
+
+        mock.restore()
     })
 
     test("account (with eth address)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_ACCOUNT_ADDRESS, TEST_NETWORK)
         await r.run()
 
@@ -143,9 +93,18 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBe("0x" + SAMPLE_ACCOUNT_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_ACCOUNT_ADDRESS,
+            "api/v1/contracts/" + SAMPLE_ACCOUNT_ADDRESS,
+            "api/v1/tokens/" + SAMPLE_ACCOUNT.account,
+        ])
+
+        mock.restore()
     })
 
     test("account (with public key)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_ACCOUNT.key.key, TEST_NETWORK)
         await r.run()
 
@@ -161,9 +120,18 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/contracts/results/" + SAMPLE_ACCOUNT.key.key,
+            "api/v1/blocks/" + SAMPLE_ACCOUNT.key.key,
+            "api/v1/accounts/?account.publickey=" + SAMPLE_ACCOUNT.key.key + "&limit=2",
+        ])
+
+        mock.restore()
     })
 
     test("account (with alias)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_ACCOUNT.alias, TEST_NETWORK)
         await r.run()
 
@@ -179,9 +147,16 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_ACCOUNT.alias,
+        ])
+
+        mock.restore()
     })
 
     test("account (with alias expressed in hex)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const SAMPLE_ALIAS_HEX = byteToHex(base32ToAlias(SAMPLE_ACCOUNT.alias)!)
         const r = new SearchRequest(SAMPLE_ALIAS_HEX, TEST_NETWORK)
         await r.run()
@@ -198,6 +173,11 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_ACCOUNT.alias,
+        ])
+
+        mock.restore()
     })
 
     //
@@ -205,6 +185,8 @@ describe("SearchRequest.ts", () => {
     //
 
     test("transaction", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_TRANSACTION.transaction_id ?? "", TEST_NETWORK)
         await r.run()
 
@@ -220,9 +202,16 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/transactions/" + SAMPLE_TRANSACTION.transaction_id,
+        ])
+
+        mock.restore()
     })
 
     test("transaction (with hedera hash)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(TRANSACTION_HASH, TEST_NETWORK)
         await r.run()
 
@@ -238,9 +227,17 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/transactions/" + TRANSACTION_HASH,
+            "api/v1/blocks/" + TRANSACTION_HASH,
+        ])
+
+        mock.restore()
     })
 
     test("transaction (with evm hash)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_CONTRACT_RESULT_DETAILS.hash, TEST_NETWORK)
         await r.run()
 
@@ -256,6 +253,14 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/contracts/results/" + EVM_HASH,
+            "api/v1/blocks/" + EVM_HASH,
+            "api/v1/accounts/?account.publickey=" + EVM_HASH + "&limit=2",
+            "api/v1/transactions?timestamp=" + SAMPLE_TRANSACTION.consensus_timestamp,
+        ])
+
+        mock.restore()
     })
 
     //
@@ -263,6 +268,8 @@ describe("SearchRequest.ts", () => {
     //
 
     test("block (with hash)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(BLOCK_HASH, TEST_NETWORK)
         await r.run()
 
@@ -278,9 +285,16 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/transactions/" + BLOCK_HASH,
+            "api/v1/blocks/" + BLOCK_HASH,
+        ])
+        mock.restore()
     })
 
     test("block (with hash prefix)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(BLOCK_HASH_PREFIX, TEST_NETWORK)
         await r.run()
 
@@ -296,6 +310,12 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/contracts/results/" + BLOCK_HASH_PREFIX,
+            "api/v1/blocks/" + BLOCK_HASH_PREFIX,
+            "api/v1/accounts/?account.publickey=" + BLOCK_HASH_PREFIX + "&limit=2",
+        ])
+        mock.restore()
     })
 
     //
@@ -303,6 +323,8 @@ describe("SearchRequest.ts", () => {
     //
 
     test("token", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_TOKEN.token_id, TEST_NETWORK)
         await r.run()
 
@@ -318,9 +340,18 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_TOKEN.token_id,
+            "api/v1/contracts/" + SAMPLE_TOKEN.token_id,
+            "api/v1/tokens/" + SAMPLE_TOKEN.token_id,
+            "api/v1/topics/" + SAMPLE_TOKEN.token_id + "/messages",
+        ])
+        mock.restore()
     })
 
     test("token (with ethereum address)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_TOKEN_ADDRESS, TEST_NETWORK)
         await r.run()
 
@@ -336,6 +367,12 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBe("0x" + SAMPLE_TOKEN_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_TOKEN_ADDRESS,
+            "api/v1/contracts/" + SAMPLE_TOKEN_ADDRESS,
+            "api/v1/tokens/" + SAMPLE_TOKEN.token_id,
+        ])
+        mock.restore()
     })
 
     //
@@ -343,6 +380,8 @@ describe("SearchRequest.ts", () => {
     //
 
     test("topic", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_TOPIC_ID, TEST_NETWORK)
         await r.run()
 
@@ -358,6 +397,13 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_TOPIC_ID,
+            "api/v1/contracts/" + SAMPLE_TOPIC_ID,
+            "api/v1/tokens/" + SAMPLE_TOPIC_ID,
+            "api/v1/topics/" + SAMPLE_TOPIC_ID + "/messages",
+        ])
+        mock.restore()
     })
 
     //
@@ -365,6 +411,8 @@ describe("SearchRequest.ts", () => {
     //
 
     test("contract", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_CONTRACT.contract_id, TEST_NETWORK)
         await r.run()
 
@@ -380,9 +428,18 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id,
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id,
+            "api/v1/tokens/" + SAMPLE_CONTRACT.contract_id,
+            "api/v1/topics/" + SAMPLE_CONTRACT.contract_id + "/messages",
+        ])
+        mock.restore()
     })
 
     test("contract (with evm address)", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(SAMPLE_CONTRACT.evm_address, TEST_NETWORK)
         await r.run()
 
@@ -398,9 +455,17 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBe(SAMPLE_CONTRACT.evm_address)
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + SAMPLE_CONTRACT.evm_address.slice(2),
+            "api/v1/contracts/" + SAMPLE_CONTRACT.evm_address.slice(2),
+            "api/v1/tokens/" + SAMPLE_CONTRACT.contract_id,
+        ])
+        mock.restore()
     })
 
     test("unknown id", async () => {
+        const mock = makeMockAdapter(axios)
+
         const UNKNOWN_ID = "1.2.3"
         const r = new SearchRequest(UNKNOWN_ID, TEST_NETWORK)
         await r.run()
@@ -417,9 +482,18 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + UNKNOWN_ID,
+            "api/v1/contracts/" + UNKNOWN_ID,
+            "api/v1/tokens/" + UNKNOWN_ID,
+            "api/v1/topics/" + UNKNOWN_ID + "/messages",
+        ])
+        mock.restore()
     })
 
     test("unknown account alias and invalid evm address", async () => {
+        const mock = makeMockAdapter(axios)
+
         const r = new SearchRequest(INVALID_EVM_ADDRESS, TEST_NETWORK)
         await r.run()
 
@@ -434,6 +508,13 @@ describe("SearchRequest.ts", () => {
         expect(r.block).toBeNull()
         expect(r.ethereumAddress).toBe("0x000000" + INVALID_EVM_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/AEBAGBAFAYDQQCIBAIBQIBIGA4EA",
+            "api/v1/accounts/" + "000000" + INVALID_EVM_ADDRESS,
+            "api/v1/contracts/" + "000000" + INVALID_EVM_ADDRESS,
+        ])
+        mock.restore()
 
         const aliasHex2 = "0x" + INVALID_EVM_ADDRESS
         const r2 = new SearchRequest(aliasHex2, TEST_NETWORK)
@@ -451,9 +532,18 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBe("0x000000" + INVALID_EVM_ADDRESS)
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/AEBAGBAFAYDQQCIBAIBQIBIGA4EA",
+            "api/v1/accounts/" + "000000" + INVALID_EVM_ADDRESS,
+            "api/v1/contracts/" + "000000" + INVALID_EVM_ADDRESS,
+        ])
+
+        mock.restore()
     })
 
     test("invalid id", async () => {
+        const mock = makeMockAdapter(axios)
+
         const INVAlID_ID = "a.b.c"
         const r = new SearchRequest(INVAlID_ID, TEST_NETWORK)
         await r.run()
@@ -470,7 +560,80 @@ describe("SearchRequest.ts", () => {
         expect(r.ethereumAddress).toBeNull()
         expect(r.getErrorCount()).toBe(0)
 
+        expect(fetchGetURLs(mock)).toStrictEqual([])
+
+        mock.restore()
     }, 50 * 1000)
 
 })
 
+const SAMPLE_ACCOUNT_ADDRESS = EntityID.parse(SAMPLE_ACCOUNT.account)!.toAddress()
+const EVM_HASH = SAMPLE_CONTRACT_RESULT_DETAILS.hash.slice(2) // To remove 0x
+const TRANSACTION_HASH = byteToHex(base64DecToArr(SAMPLE_TRANSACTION.transaction_hash))
+const BLOCK_HASH = byteToHex(hexToByte(SAMPLE_BLOCKSRESPONSE.blocks[0].hash) ?? new Uint8Array(0))
+const BLOCK_HASH_PREFIX = byteToHex(hexToByte(SAMPLE_BLOCKSRESPONSE.blocks[0].hash)?.slice(0, 32) ?? new Uint8Array(0))
+const SAMPLE_TOKEN_ADDRESS = EntityID.parse(SAMPLE_TOKEN.token_id)!.toAddress()
+const SAMPLE_TOPIC_ID = SAMPLE_TOPIC_MESSAGES.messages[0].topic_id
+const INVALID_EVM_ADDRESS = "0102030405060708090102030405060708"; // 19 bytes : should be 20
+
+
+function makeMockAdapter(axiosInstance: AxiosInstance): MockAdapter {
+
+    const mock = new MockAdapter(axiosInstance)
+
+// Account
+
+    const matcher_account = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
+    mock.onGet(matcher_account).reply(200, SAMPLE_ACCOUNT)
+
+    const matcher_account_with_alias = "/api/v1/accounts/" + SAMPLE_ACCOUNT.alias
+    mock.onGet(matcher_account_with_alias).reply(200, SAMPLE_ACCOUNT)
+
+    const matcher_account_with_address = "/api/v1/accounts/" + SAMPLE_ACCOUNT_ADDRESS
+    mock.onGet(matcher_account_with_address).reply(200, SAMPLE_ACCOUNT)
+
+    const matcher_account_with_public_key = "/api/v1/accounts/?account.publickey="
+        + SAMPLE_ACCOUNTS.accounts[0].key.key + "&limit=2"
+    mock.onGet(matcher_account_with_public_key).reply(200, SAMPLE_ACCOUNTS)
+
+
+// Transaction
+
+    const matcher_transaction = "/api/v1/transactions/" + SAMPLE_TRANSACTION.transaction_id
+    mock.onGet(matcher_transaction).reply(200, SAMPLE_TRANSACTIONS)
+
+    const matcher_transaction_with_hash = "/api/v1/transactions/" + TRANSACTION_HASH
+    mock.onGet(matcher_transaction_with_hash).reply(200, SAMPLE_TRANSACTIONS)
+
+    const matcher_contract_result = "/api/v1/contracts/results/" + EVM_HASH
+    mock.onGet(matcher_contract_result).reply(200, SAMPLE_CONTRACT_RESULT_DETAILS)
+
+    const matcher_transaction_with_timestamp = "/api/v1/transactions?timestamp=" + SAMPLE_CONTRACT_RESULT_DETAILS.timestamp
+    mock.onGet(matcher_transaction_with_timestamp).reply(200, SAMPLE_TRANSACTIONS)
+
+// Block
+
+    const matcher_block_with_hash = "/api/v1/blocks/" + BLOCK_HASH
+    mock.onGet(matcher_block_with_hash).reply(200, SAMPLE_BLOCKSRESPONSE.blocks[0])
+    const matcher_block_with_hash_prefix = "/api/v1/blocks/" + BLOCK_HASH_PREFIX
+    mock.onGet(matcher_block_with_hash_prefix).reply(200, SAMPLE_BLOCKSRESPONSE.blocks[0])
+
+// Token
+
+    const matcher_token = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
+    mock.onGet(matcher_token).reply(200, SAMPLE_TOKEN)
+
+    const matcher_topic = "/api/v1/topics/" + SAMPLE_TOPIC_ID + "/messages"
+    mock.onGet(matcher_topic).reply(200, SAMPLE_TOPIC_MESSAGES)
+
+    const matcher_contracts = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+    mock.onGet(matcher_contracts).reply(200, SAMPLE_CONTRACT)
+
+    const matcher_contracts_with_evm_address = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address.slice(2)
+    mock.onGet(matcher_contracts_with_evm_address).reply(200, SAMPLE_CONTRACT)
+
+    const matcher_contracts_with_invalid_evm_address = "/api/v1/contracts/" + INVALID_EVM_ADDRESS
+    mock.onGet(matcher_contracts_with_invalid_evm_address).reply(400)
+
+    return mock
+}


### PR DESCRIPTION
**Description**:

Changes below improve unit tests for `SearchRequest` class.
They don't include any semantic changes.

Each test now verifies REST urls invoked by `SearchRequest`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
