### PR TITLE
feat: display that you can search by domain name

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -43,7 +43,7 @@
           class="input has-text-white h-is-navbar-item"
           style="z-index: 1; height: 40px"
           type="text"
-          placeholder="Search accounts, transactions, tokens, contracts and topics"
+          placeholder="Search by ID / Address / Domain Name / Public Key / Hash / Alias / Timestamp"
           v-model="searchedId"
           v-bind:disabled="searchInputDisabled"
           ref="search-input"

--- a/src/pages/MobileSearch.vue
+++ b/src/pages/MobileSearch.vue
@@ -28,7 +28,7 @@
 
     <div class="is-flex is-align-items-center mb-6">
       <img alt="Search bar" src="@/assets/large-search-icon.png" style="width: 42px;">
-      <span class="ml-4">Search accounts, transactions, tokens, contracts and topics</span>
+      <span class="ml-4">Search by ID / Address / Domain Name / Public Key / Hash / Alias / Timestamp</span>
     </div>
 
     <SearchBar/>

--- a/src/pages/NoSearchResult.vue
+++ b/src/pages/NoSearchResult.vue
@@ -42,7 +42,7 @@
         This might be transient. Try to search again in a few moments.
       </template>
       <template v-else>
-        <span>No account, transaction, contract, token or topic matches "</span>
+        <span>No account, transaction, contract, token, topic or block matches "</span>
         <span style="font-weight: 400">{{ searchedId }}</span>
         <span>".</span>
         <br/><br/>
@@ -52,6 +52,15 @@
           <div class="has-text-left" style="display: inline-block; max-width: 1024px">
             <span style="display: inline-block">Make sure you enter one of the expressions below:</span>
             <br/><br/>
+            <div>
+              &bull; a domain name<br/>
+              <div class="should-wrap h-help-item">
+                Example:&nbsp;domain1.hbar
+              </div>
+              <div class="should-wrap h-help-item">
+                or:&nbsp;domain2.hh
+              </div>
+            </div>
             <div>
               &bull; an entity ID with or without checksum (0.0.x or 0.0.x-abcde)<br/>
               <div class="should-wrap h-help-item">


### PR DESCRIPTION
**Description**:

Modify the search prompt and message displayed when the search fails, to explain that the search can be done by domain name.

**Related issue(s)**:

Fixes #975 

**Notes for reviewer**:

<img width="720" alt="Screenshot 2024-07-03 at 14 35 41" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/6d91f02b-4fcf-40fc-988d-fd62c9c19a18">

<img width="784" alt="Screenshot 2024-07-03 at 14 36 06" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/c299be54-1b48-40d2-8208-fb63c2f1d04c">

<img width="964" alt="Screenshot 2024-07-03 at 14 35 16" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/40720a9b-1102-4679-8fa2-f4f2146f55e9">

