### PR TITLE
feature: improve tables on the AccountBalances page

### DIFF
--- a/src/components/account/BalanceTable.vue
+++ b/src/components/account/BalanceTable.vue
@@ -51,15 +51,47 @@
   >
     <o-table-column v-slot="props" field="token_id" label="Token">
       <TokenLink
-          v-bind:show-extra="true"
-          v-bind:token-id="props.row.token_id"
-          v-bind:no-anchor="true"
+          :show-extra="false"
+          :token-id="props.row.token_id"
+          :no-anchor="true"
       />
     </o-table-column>
 
-    <o-table-column v-slot="props" field="balance" label="Balance/Nb of NFTs" position="right">
-      <TokenAmount v-bind:amount="BigInt(props.row.balance)"
-                   v-bind:token-id="props.row.token_id"/>
+    <o-table-column v-slot="props" field="name" label="Name">
+      <TokenCell
+          :token-id="props.row.token_id"
+          :property="TokenCellItem.tokenName"
+      />
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="symbol" label="Symbol">
+      <TokenCell
+          :token-id="props.row.token_id"
+          :property="TokenCellItem.tokenSymbol"
+      />
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="type" label="Type">
+      <TokenCell
+          :token-id="props.row.token_id"
+          :property="TokenCellItem.tokenType"
+      />
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="balance" label="Balance" position="right">
+      <TokenCell
+          :token-id="props.row.token_id"
+          :property="TokenCellItem.tokenBalance"
+          :balance-or-nb-serials="props.row.balance"
+      />
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="nb-nfts" label="Nb. of NFTs" position="right">
+      <TokenCell
+          :token-id="props.row.token_id"
+          :property="TokenCellItem.tokenNbSerials"
+          :balance-or-nb-serials="props.row.balance"
+      />
     </o-table-column>
 
   </o-table>
@@ -82,11 +114,13 @@ import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import {TokenRelationshipsTableController} from "@/components/account/TokenRelationshipsTableController";
+import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 
 export default defineComponent({
   name: 'BalanceTable',
 
   components: {
+    TokenCell,
     EmptyTable,
     TokenLink,
     TokenAmount
@@ -119,6 +153,7 @@ export default defineComponent({
       onPageChange: props.controller.onPageChange,
       pageSize: props.controller.pageSize as Ref<Number>,
       handleClick,
+      TokenCellItem,
       ORUGA_MOBILE_BREAKPOINT
     }
   }

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -42,16 +42,31 @@
       aria-page-label="Page"
       aria-previous-label="Previous page"
   >
-    <o-table-column v-slot="props" field="token_id" label="NFT Collection">
+
+    <o-table-column v-slot="props" field="collection" label="Collection">
       <TokenLink
-          v-bind:show-extra="true"
-          v-bind:token-id="props.row.tokenId"
-          v-bind:no-anchor="true"
+          :show-extra="false"
+          :token-id="props.row.tokenId"
+          :no-anchor="true"
       />
     </o-table-column>
-    <o-table-column v-slot="props" field="owned" label="Nb of NFTs" position="right">
-      {{ props.row.collectionSize }}
+
+    <o-table-column v-slot="props" field="name" label="Name">
+      <TokenCell :token-id="props.row.tokenId" :property="TokenCellItem.tokenName"/>
     </o-table-column>
+
+    <o-table-column v-slot="props" field="symbol" label="Symbol">
+      <TokenCell :token-id="props.row.tokenId" :property="TokenCellItem.tokenSymbol"/>
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="serials" label="Serial Numbers" position="left">
+      {{ formatSerials(props.row.serials) }}
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="owned" label="Total" position="right">
+      {{ props.row.serials.length }}
+    </o-table-column>
+
   </o-table>
 
   <EmptyTable v-if="!collections.length"/>
@@ -71,11 +86,13 @@ import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import {useRoute} from "vue-router";
 import {NftCollectionInfo} from "@/utils/cache/NftCollectionCache";
+import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 
 export default defineComponent({
   name: 'NftsTable',
 
   components: {
+    TokenCell,
     EmptyTable,
     TokenLink,
   },
@@ -101,11 +118,27 @@ export default defineComponent({
       }
     }
 
+    const MAX_DISPLAYED_SERIALS = 6
+    const formatSerials = (serials: number[]): string => {
+      let result = ''
+      for (let i = 0; i < serials.length; i++) {
+        if (i < MAX_DISPLAYED_SERIALS) {
+          result += (i == 0 ? `#${serials[i]}` : `, #${serials[i]}`)
+        } else {
+          result += `… (${serials.length - MAX_DISPLAYED_SERIALS} more)`
+          break
+        }
+      }
+      return result
+    }
+
     return {
       isTouchDevice,
       isMediumScreen,
       perPage,
       handleClick,
+      formatSerials,
+      TokenCellItem,
       ORUGA_MOBILE_BREAKPOINT
     }
   }

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -118,7 +118,7 @@ export default defineComponent({
       }
     }
 
-    const MAX_DISPLAYED_SERIALS = 6
+    const MAX_DISPLAYED_SERIALS = 20
     const formatSerials = (serials: number[]): string => {
       let result = ''
       for (let i = 0; i < serials.length; i++) {

--- a/src/components/account/TokenRelationshipsTableController.ts
+++ b/src/components/account/TokenRelationshipsTableController.ts
@@ -50,9 +50,10 @@ export class TokenRelationshipsTableController extends TableController<TokenRela
                 order: string
             }
             params.limit = limit
-            params.order = order
+            params.order = TableController.invertSortOrder(order)
+            const keyOperator = TableController.invertKeyOperator(operator)
             if (tokenId !== null) {
-                params["token.id"] = operator + ":" + tokenId
+                params["token.id"] = keyOperator + ":" + tokenId
             }
             const url = `api/v1/accounts/${this.accountId.value}/tokens`
             const r = await axios.get<TokenRelationshipResponse>(url, {params: params})

--- a/src/components/token/TokenCell.vue
+++ b/src/components/token/TokenCell.vue
@@ -1,0 +1,130 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <TokenAmount
+      v-if="property === TokenCellItem.tokenBalance && propertyValue"
+      :amount="BigInt(propertyValue)"
+      :token-id="tokenId"
+  />
+
+  <BlobValue
+      v-else
+      :blob-value="propertyValue"
+  />
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
+import BlobValue from "@/components/values/BlobValue.vue";
+import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
+import {makeTokenName, makeTokenSymbol} from "@/schemas/HederaUtils";
+import TokenAmount from "@/components/values/TokenAmount.vue";
+
+export enum TokenCellItem {
+  tokenName = "tokenName",
+  tokenSymbol = "tokenSymbol",
+  tokenType = "tokenType",
+  tokenBalance = "tokenBalance",
+  tokenNbSerials = "tokenNbSerials"
+}
+
+export default defineComponent({
+  name: "TokenCell",
+  components: {TokenAmount, BlobValue},
+
+  props: {
+    tokenId: {
+      type: String as PropType<string | null>,
+      default: null
+    },
+    property: {
+      type: String as PropType<TokenCellItem>,
+      default: TokenCellItem.tokenName
+    },
+    balanceOrNbSerials: {
+      type: Number as PropType<number | null>,
+      default: null
+    }
+  },
+
+  setup(props) {
+    const FUNGIBLE = "FUNGIBLE_COMMON"
+    const NONFUNGIBLE = "NON_FUNGIBLE_UNIQUE"
+
+    const id = computed(() => props.tokenId)
+
+    const infoLookup = TokenInfoCache.instance.makeLookup(id)
+    onMounted(() => infoLookup.mount())
+    onBeforeUnmount(() => infoLookup.unmount())
+
+    const propertyValue = computed(() => {
+      let result: string | null
+      switch (props.property) {
+        case TokenCellItem.tokenName:
+          result = makeTokenName(infoLookup.entity.value)
+          break
+        case TokenCellItem.tokenSymbol:
+          result = makeTokenSymbol(infoLookup.entity.value)
+          break
+        case TokenCellItem.tokenType:
+          result = infoLookup.entity.value?.type === FUNGIBLE ? 'Fungible' : 'NFT'
+          break
+        case TokenCellItem.tokenBalance:
+          result = infoLookup.entity.value?.type === FUNGIBLE
+              ? (props.balanceOrNbSerials?.toString() ?? '')
+              : null
+          break
+        case TokenCellItem.tokenNbSerials:
+          result = infoLookup.entity.value?.type === NONFUNGIBLE
+              ? (props.balanceOrNbSerials?.toString() ?? '')
+              : null
+          break
+        default:
+          result = null
+      }
+      return result
+    })
+
+    return {
+      propertyValue,
+      TokenCellItem,
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/tests/unit/account/AccountBalances.spec.ts
+++ b/tests/unit/account/AccountBalances.spec.ts
@@ -74,13 +74,14 @@ describe("AccountBalances.vue", () => {
         // console.log(wrapper.find('tbody').text())
 
         const balanceCard = wrapper.get("#balanceCard")
-        expect(balanceCard.find('thead').text()).toBe("Token Balance/Nb of NFTs")
+        expect(balanceCard.find('thead').text()).toBe("Token Name Symbol Type Balance Nb. of NFTs")
         expect(balanceCard.find('tbody').text()).toBe(
-            "0.0.34332104" + "HSuite" + "0.0000" +
-            "0.0.49292859" + "TokenA7" + "0.00000000")
+            "0.0.34332104" + "HSUITE" + "HSuite" + "Fungible" + "0.0000" +
+            "0.0.49292859" + "Token SymbolA7" + "TokenA7" + "Fungible" + "0.00000000"
+        )
 
         const nftsCard = wrapper.get("#nftsCard")
-        expect(nftsCard.find('thead').text()).toBe("NFT Collection Nb of NFTs")
+        expect(nftsCard.find('thead').text()).toBe("Collection Name Symbol Serial Numbers Total")
         expect(nftsCard.find('tbody').text()).toBe("")
 
         wrapper.unmount()
@@ -119,12 +120,14 @@ describe("AccountBalances.vue", () => {
         // console.log(wrapper.find('tbody').text())
 
         const balanceCard = wrapper.get("#balanceCard")
-        expect(balanceCard.find('thead').text()).toBe("Token Balance/Nb of NFTs")
+        expect(balanceCard.find('thead').text()).toBe("Token Name Symbol Type Balance Nb. of NFTs")
         expect(balanceCard.find('tbody').text()).toBe("")
 
         const nftsCard = wrapper.get("#nftsCard")
-        expect(nftsCard.find('thead').text()).toBe("NFT Collection Nb of NFTs")
-        expect(nftsCard.find('tbody').text()).toBe("0.0.748383" + SAMPLE_NONFUNGIBLE.symbol + SAMPLE_NFTS.nfts.length)
+        expect(nftsCard.find('thead').text()).toBe("Collection Name Symbol Serial Numbers Total")
+        expect(nftsCard.find('tbody').text()).toBe(
+            "0.0.748383" + "Ħ Frens Kingdom" + "ĦFRENSKINGD…" + "#2, #1, #342" + "3"
+        )
 
         wrapper.unmount()
         await flushPromises()

--- a/tests/unit/token/NftCell.spec.ts
+++ b/tests/unit/token/NftCell.spec.ts
@@ -1,0 +1,197 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, test} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils";
+import NftCell, {NftCellItem} from "../../../src/components/token/NftCell.vue";
+import router from "../../../src/router";
+import Oruga from "@oruga-ui/oruga-next";
+import {IPFS_IMAGE_URL, IPFS_METADATA_CONTENT, IPFS_METADATA_CONTENT_URL, SAMPLE_NFTS} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+describe("NftCell.vue", () => {
+
+    test("default props", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(NftCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {},
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('')
+        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        wrapper.unmount()
+    })
+
+    test("tokenId and no serialNumber", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const nft = SAMPLE_NFTS.nfts[2]
+        const nftId = nft.token_id
+        const serial = nft.serial_number
+
+        const matcher1 = "/api/v1/tokens/" + nftId + "/nfts/" + serial
+        mock.onGet(matcher1).reply(200, nft);
+        mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
+
+        const wrapper = mount(NftCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                tokenId: nftId
+            },
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('')
+        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        wrapper.unmount()
+    })
+
+    test("tokenId and serialNumber", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const nft = SAMPLE_NFTS.nfts[2]
+        const nftId = nft.token_id
+        const serial = nft.serial_number
+        const nftName = IPFS_METADATA_CONTENT.name
+
+        const matcher1 = "/api/v1/tokens/" + nftId + "/nfts/" + serial
+        mock.onGet(matcher1).reply(200, nft);
+        mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
+
+        const wrapper = mount(NftCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                tokenId: nftId,
+                serialNumber: serial
+            },
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe(nftName)
+        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        wrapper.unmount()
+    })
+
+    test("tokenId, serialNumber and property", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const nft = SAMPLE_NFTS.nfts[2]
+        const nftId = nft.token_id
+        const serial = nft.serial_number
+        const name = IPFS_METADATA_CONTENT.name
+        const description = IPFS_METADATA_CONTENT.description
+        const creator = "@Buckyoto + @JuicyUnlimited for @KarateC…"
+
+        const matcher1 = "/api/v1/tokens/" + nftId + "/nfts/" + serial
+        mock.onGet(matcher1).reply(200, nft);
+        mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
+
+        const wrapper = mount(NftCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                tokenId: nftId,
+                serialNumber: serial,
+                property: NftCellItem.name
+            },
+        })
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe(name)
+        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        await wrapper.setProps({
+            property: NftCellItem.description
+        })
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(description)
+        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        await wrapper.setProps({
+            property: NftCellItem.creator
+        })
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(creator)
+        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        await wrapper.setProps({
+            property: NftCellItem.image
+        })
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('NFT')
+        const image = wrapper.find('img')
+        expect(image.exists()).toBe(true)
+        expect(image.attributes('src')).toBe(IPFS_IMAGE_URL)
+        expect(image.attributes('class')).toContain('is-invisible')
+        expect(wrapper.find('video').exists()).toBe(false)
+
+        wrapper.unmount()
+    })
+})
+

--- a/tests/unit/token/TokenCell.spec.ts
+++ b/tests/unit/token/TokenCell.spec.ts
@@ -1,0 +1,199 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, test} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils";
+import TokenCell, {TokenCellItem} from "../../../src/components/token/TokenCell.vue";
+import router from "../../../src/router";
+import Oruga from "@oruga-ui/oruga-next";
+import {SAMPLE_ASSOCIATED_TOKEN, SAMPLE_NONFUNGIBLE} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+describe("TokenCell.vue", () => {
+
+    test("default props", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(TokenCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {},
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('?')
+
+        wrapper.unmount()
+    })
+
+    test("tokenId and default property", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const tokenId = SAMPLE_NONFUNGIBLE.token_id
+        const name = SAMPLE_NONFUNGIBLE.name
+
+        const matcher1 = "/api/v1/tokens/" + tokenId
+        mock.onGet(matcher1).reply(200, SAMPLE_NONFUNGIBLE);
+
+        const wrapper = mount(TokenCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                tokenId: tokenId
+            },
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe(name)
+
+        wrapper.unmount()
+    })
+
+    test("tokenId and property for NFT", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const token = SAMPLE_NONFUNGIBLE
+        const tokenId = token.token_id
+
+        const matcher1 = "/api/v1/tokens/" + tokenId
+        mock.onGet(matcher1).reply(200, token);
+
+        const wrapper = mount(TokenCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                tokenId: tokenId,
+                property: TokenCellItem.tokenName
+            },
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe(token.name)
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenSymbol
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe("ĦFRENSKINGD…")
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenType
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe('NFT')
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenNbSerials,
+            balanceOrNbSerials: 42,
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe('42')
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenBalance,
+            balanceOrNbSerials: 42,
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe('')
+
+        wrapper.unmount()
+    })
+
+    test("tokenId and property for Fungible", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const token = SAMPLE_ASSOCIATED_TOKEN
+        const tokenId = token.token_id
+
+        const matcher1 = "/api/v1/tokens/" + tokenId
+        mock.onGet(matcher1).reply(200, token);
+
+        const wrapper = mount(TokenCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                tokenId: tokenId,
+                property: TokenCellItem.tokenName
+            },
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe(token.name)
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenSymbol
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe(token.symbol)
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenType
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe('Fungible')
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenNbSerials,
+            balanceOrNbSerials: 42,
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe('')
+
+        await wrapper.setProps({
+            property: TokenCellItem.tokenBalance,
+            balanceOrNbSerials: 42,
+        })
+        await flushPromises()
+        expect(wrapper.text()).toBe('0.0042')
+
+        wrapper.unmount()
+    })
+})
+


### PR DESCRIPTION
**Description**:

- Improve `NftsTable` to display as separate columns:
  -  Name
  - Symbol
  - List of serial numbers 
- Improve `BalanceTable` to display as separate columns:
  - Name
  - Symbol
  - Type
  - Balance (for fungibles)
  - Nb. of NFTs
- Also sort both tables in ASC instead of DESC order

**Related issue(s)**:

Fixes #1085 

**Notes for reviewer**:

<img width="1149" alt="Screenshot 2024-07-05 at 10 04 31" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/f5c5cbda-a7ed-4a24-bac3-4417b1f48b1c">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
