### PR TITLE
fix: confusing message when interacting with Smart Contract

### DIFF
--- a/src/components/dialog/DialogStatus.vue
+++ b/src/components/dialog/DialogStatus.vue
@@ -63,7 +63,10 @@ export default defineComponent({
       type: Object as PropType<DialogController>,
       required: true
     },
-    isSuccess: Boolean as PropType<boolean | undefined>,
+    isSuccess: {
+      type: Boolean as PropType<boolean | undefined>,
+      default: undefined
+    }
   },
   setup(props) {
 


### PR DESCRIPTION
**Description**:

Fix for #949 added a new props to `DialogStatus`:
```
isSuccess: Boolean as PropType<boolean|undefined>
```
For some reason, when `isSuccess` is not specified, its value in `DialogStatus.setup()` is not `undefined` but `false`.
However everything works when `isSuccess` is declared like this:
```
isSuccess: {
      type: Boolean as PropType<boolean | undefined>,
      default: undefined
}
```

**Related issue(s)**:

Fixes #1129

**Notes for reviewer**:

Go to [0.0.4419770](https://hashscan.io/testnet/contract/0.0.4419770) and run `update()` function.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
