### PR TITLE
feat: show abridged message field on the home page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -94,6 +94,11 @@ export default defineComponent({
     })
     provide('isLargeScreen', isLargeScreen)
 
+    const isXLargeScreen = computed(() => {
+      return windowWidth.value >= XLARGE_BREAKPOINT
+    })
+    provide('isXLargeScreen', isXLargeScreen)
+
     const onResizeHandler = () => {
       windowWidth.value = window.innerWidth
     }

--- a/src/components/dashboard/MessageTransactionTable.vue
+++ b/src/components/dashboard/MessageTransactionTable.vue
@@ -79,7 +79,6 @@ import {ComputedRef, defineComponent, PropType, Ref} from 'vue';
 import {Transaction} from "@/schemas/HederaSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";
-import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
@@ -89,7 +88,7 @@ import TopicMessageCell, {TopicMessageCellItem} from "@/components/topic/TopicMe
 export default defineComponent({
   name: 'MessageTransactionTable',
 
-  components: {TopicMessageCell, TopicIOL, EmptyTable, TimestampValue, BlobValue},
+  components: {TopicMessageCell, TopicIOL, EmptyTable, TimestampValue},
 
   props: {
     controller: {

--- a/src/components/dashboard/MessageTransactionTable.vue
+++ b/src/components/dashboard/MessageTransactionTable.vue
@@ -55,10 +55,8 @@
       <TopicIOL class="w200" :topic-id="props.row.entity_id"/>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="memo" label="Memo">
-      <div class="w250">
-        <BlobValue v-bind:blob-value="props.row.memo_base64" v-bind:base64="true" v-bind:show-none="true"/>
-      </div>
+    <o-table-column v-slot="props" field="content" label="Content">
+      <TopicMessageCell :timestamp="props.row.consensus_timestamp" :property="TopicMessageCellItem.message"/>
     </o-table-column>
 
     <o-table-column v-slot="props" field="consensus_timestamp" label="Time">
@@ -86,11 +84,12 @@ import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import TopicIOL from "@/components/values/link/TopicIOL.vue";
+import TopicMessageCell, {TopicMessageCellItem} from "@/components/topic/TopicMessageCell.vue";
 
 export default defineComponent({
   name: 'MessageTransactionTable',
 
-  components: {TopicIOL, EmptyTable, TimestampValue, BlobValue},
+  components: {TopicMessageCell, TopicIOL, EmptyTable, TimestampValue, BlobValue},
 
   props: {
     controller: {
@@ -113,7 +112,7 @@ export default defineComponent({
       onPageChange: props.controller.onPageChange,
       perPage: props.controller.pageSize as Ref<number>,
       handleClick,
-
+      TopicMessageCellItem,
       // From App
       ORUGA_MOBILE_BREAKPOINT,
     }

--- a/src/components/topic/TopicMessageCell.vue
+++ b/src/components/topic/TopicMessageCell.vue
@@ -1,0 +1,108 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <BlobValue
+      :blob-value="propertyValue"
+      :base64="isMessage"
+  />
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts">
+
+import {computed, defineComponent, onBeforeUnmount, onMounted, PropType} from "vue";
+import BlobValue from "@/components/values/BlobValue.vue";
+import {TopicMessageCache} from "@/utils/cache/TopicMessageCache";
+
+export enum TopicMessageCellItem {
+  sequenceNumber = "sequenceNumber",
+  message = "message"
+}
+
+export default defineComponent({
+  name: "TopicMessageCell",
+  components: {BlobValue},
+
+  props: {
+    timestamp: {
+      type: String as PropType<string | null>,
+      default: null
+    },
+    property: {
+      type: String as PropType<TopicMessageCellItem>,
+      default: TopicMessageCellItem.message
+    }
+  },
+
+  setup(props) {
+    const timestamp = computed(() => props.timestamp)
+
+    const messageLookup = TopicMessageCache.instance.makeLookup(timestamp)
+    onMounted(() => messageLookup.mount())
+    onBeforeUnmount(() => messageLookup.unmount())
+
+    const isMessage = computed(() =>
+        props.property === TopicMessageCellItem.message && propertyValue.value !== null
+    )
+
+    const propertyValue = computed(() => {
+      let result: string | null
+      switch (props.property) {
+        case TopicMessageCellItem.message:
+          result = truncate(messageLookup.entity.value?.message ?? '', 150)
+          break
+        case TopicMessageCellItem.sequenceNumber:
+          result = messageLookup.entity.value?.sequence_number.toString() ?? ''
+          break
+        default:
+          result = null
+      }
+      return result
+    })
+
+    const truncate = (value: string, length: number): string => {
+      return value.length > length ? value.slice(0, length) + '…' : value
+    }
+
+    return {
+      propertyValue,
+      isMessage,
+      TopicMessageCellItem,
+    }
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -48,7 +48,7 @@
 
     <div class="columns is-multiline">
 
-      <div class="column" :class="{'is-full': !displaySideBySide}">
+      <div class="column" :class="{'is-full':!isXLargeScreen}">
         <DashboardCard data-cy="smartContractCalls">
           <template v-slot:title>
             <span class="h-is-secondary-title">Smart Contract Calls</span>
@@ -124,7 +124,7 @@ export default defineComponent({
     const isSmallScreen = inject('isSmallScreen', true)
     const isMediumScreen = inject('isMediumScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
-    const displaySideBySide = inject('isLargeScreen', true)
+    const isXLargeScreen = inject('isXLargeScreen', true)
 
     const router = useRouter()
     const pageSize = computed(() => isMediumScreen ? 5 : 6)
@@ -162,7 +162,7 @@ export default defineComponent({
     return {
       isSmallScreen,
       isTouchDevice,
-      displaySideBySide,
+      isXLargeScreen,
       cryptoTableController,
       messageTableController,
       contractTableController,

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -3138,7 +3138,7 @@ export const SAMPLE_TOPIC_MESSAGES = {
         {
             "chunk_info": null,
             "consensus_timestamp": "1642097184.056478572",
-            "message": "AAABflSejDhfTmV3IG1lc3NhZ2VfNQ==",
+            "message": "YmFja2dyb3VuZE1lc3NhZ2U=",
             "payer_account_id": "0.0.950",
             "running_hash": "8byKHCHutoTADN1e83GtFAMek+5BffakLZUuGOre0cAt3s4yk1jnxLvWsttLfs3n",
             "running_hash_version": 3,

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import {describe, test, expect} from 'vitest'
+import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
@@ -28,6 +28,7 @@ import {
     SAMPLE_NETWORK_EXCHANGERATE,
     SAMPLE_NETWORK_SUPPLY,
     SAMPLE_TOKEN,
+    SAMPLE_TOPIC_MESSAGES,
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import MainDashboard from "@/pages/MainDashboard.vue";
@@ -76,6 +77,11 @@ describe("MainDashboard.vue", () => {
         const matcher4 = "/api/v1/network/exchangerate"
         mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
 
+        const matcher5 = "/api/v1/topics/messages/"
+        mock.onGet(matcher5 + SAMPLE_MESSAGE_TRANSACTIONS.transactions[0].consensus_timestamp)
+            .reply(200, SAMPLE_TOPIC_MESSAGES.messages[0]);
+        mock.onGet(matcher5 + SAMPLE_MESSAGE_TRANSACTIONS.transactions[1].consensus_timestamp)
+            .reply(200, SAMPLE_TOPIC_MESSAGES.messages[1]);
 
         const wrapper = mount(MainDashboard, {
             global: {
@@ -129,10 +135,10 @@ describe("MainDashboard.vue", () => {
         expect(cards[2].findComponent(PlayPauseButton).exists()).toBe(true)
         const t2 = cards[2].findComponent(MessageTransactionTable)
         expect(t2.exists()).toBe(true)
-        expect(t2.get('thead').text()).toBe("Topic ID Memo Time")
+        expect(t2.get('thead').text()).toBe("Topic ID Content Time")
         expect(t2.get('tbody').text()).toBe(
-            "0.0.120438" + "None" + "1:59:03.9969 PMMar 8, 2022, UTC" +
-            "0.0.120438" + "None" + "1:59:03.9622 PMMar 8, 2022, UTC"
+            "0.0.120438" + "backgroundMessage" + "1:59:03.9969 PMMar 8, 2022, UTC" +
+            "0.0.120438" + "backgroundMessage" + "1:59:03.9622 PMMar 8, 2022, UTC"
         )
 
         mock.restore()

--- a/tests/unit/topic/TopicMessageCell.spec.ts
+++ b/tests/unit/topic/TopicMessageCell.spec.ts
@@ -1,0 +1,121 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, expect, test} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils";
+import TopicMessageCell, {TopicMessageCellItem} from "../../../src/components/topic/TopicMessageCell.vue";
+import router from "../../../src/router";
+import Oruga from "@oruga-ui/oruga-next";
+import {SAMPLE_TOPIC_MESSAGES} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+describe("TopicMessageCell.vue", () => {
+
+    test("default props", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const wrapper = mount(TopicMessageCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {},
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('')
+
+        wrapper.unmount()
+    })
+
+    test("timestamp and default property", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const topicMessage = SAMPLE_TOPIC_MESSAGES.messages[0]
+        const timestamp = topicMessage.consensus_timestamp
+
+        const matcher1 = "/api/v1/topics/messages/" + timestamp
+        mock.onGet(matcher1).reply(200, topicMessage);
+
+        const wrapper = mount(TopicMessageCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                timestamp: timestamp
+            },
+        })
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('backgroundMessage')
+
+        wrapper.unmount()
+    })
+
+    test("timestamp and property", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        // Mock axios
+        const mock = new MockAdapter(axios)
+
+        const topicMessage = SAMPLE_TOPIC_MESSAGES.messages[0]
+        const timestamp = topicMessage.consensus_timestamp
+
+        const matcher1 = "/api/v1/topics/messages/" + timestamp
+        mock.onGet(matcher1).reply(200, topicMessage);
+
+        const wrapper = mount(TopicMessageCell, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                timestamp: timestamp,
+                property: TopicMessageCellItem.message
+            },
+        })
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toBe('backgroundMessage')
+
+        await wrapper.setProps({
+            property: TopicMessageCellItem.sequenceNumber
+        })
+        await flushPromises()
+
+        expect(wrapper.text()).toBe(topicMessage.sequence_number.toString())
+
+        wrapper.unmount()
+    })
+})
+


### PR DESCRIPTION
**Description**:

Replaces the memo column by a column providing the (possibly abridged) topic message in the `HCS Messages` table shown on the MainDashboard view.

**Related issue(s)**:

Fixes #1053

**Notes for reviewer**:

<img width="1033" alt="Screenshot 2024-07-08 at 18 55 52" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/4d1c2dfc-838a-46a6-ac35-79214fe32be5">

<img width="1033" alt="Screenshot 2024-07-08 at 18 56 54" src="https://github.com/hashgraph/hedera-mirror-node-explorer/assets/16097111/47d81d14-8a05-4e83-8440-489f3742441a">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
