### PR TITLE
chore: migrate vitest-coverage-report-action to step-security maintained version

### DIFF
--- a/.github/workflows/comp-compile-explorer-code.yaml
+++ b/.github/workflows/comp-compile-explorer-code.yaml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
 
       - name: Report Unit Test Coverage
-        uses: davelosert/vitest-coverage-report-action@65846c957a86d94dcdfc49195da0059476cebb3f # v2.5.0
+        uses: step-security/vitest-coverage-report-action@001298986397447c590e077e9cc1e88e6935b1a9 # v2.5.0
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
 
       - name: Cypress run


### PR DESCRIPTION
**Description**:
 This PR migrates the `vitest-coverage-report-action` action to the step-security maintained version
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #1213 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
