### PR TITLE
chore: bump axios-mock-adapter from 1.22.0 to 2.0.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@vue/eslint-config-typescript": "^13.0.0",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.5.1",
-        "axios-mock-adapter": "^1.22.0",
+        "axios-mock-adapter": "^2.0.0",
         "cypress": "^13.13.2",
         "esbuild": "^0.23.0",
         "eslint": "^8.57.0",
@@ -6917,11 +6917,10 @@
       }
     },
     "node_modules/axios-mock-adapter": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
-      "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.0.0.tgz",
+      "integrity": "sha512-D/K0J5Zm6KvaMTnsWrBQZWLzKN9GxUFZEa0mx2qeEHXDeTugCoplWehy8y36dj5vuSjhe1u/Dol8cZ8lzzmDew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "is-buffer": "^2.0.5"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@vue/eslint-config-typescript": "^13.0.0",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.5.1",
-    "axios-mock-adapter": "^1.22.0",
+    "axios-mock-adapter": "^2.0.0",
     "cypress": "^13.13.2",
     "esbuild": "^0.23.0",
     "eslint": "^8.57.0",

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -58,7 +58,7 @@ describe("ContractResult.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {timestamp: timestamp, internal: true}
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
 
@@ -109,7 +109,7 @@ describe("ContractResult.vue", () => {
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {timestamp: timestamp, internal: true}
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_REVERT_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
 
@@ -150,7 +150,7 @@ describe("ContractResult.vue", () => {
         const timestamp = SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.timestamp
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {timestamp: timestamp, internal: true}
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES], "links": {"next": null}
         });
 

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -178,7 +178,7 @@ describe("TransactionDetails.vue", () => {
 
         const param3 = {timestamp: timestamp, internal: true}
         const matcher3 = "/api/v1/contracts/results"
-        mock.onGet(matcher3, param3).reply(200, {
+        mock.onGet(matcher3, {params: param3}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
 
@@ -281,7 +281,7 @@ describe("TransactionDetails.vue", () => {
 
         const param3 = {timestamp: timestamp, internal: true}
         const matcher3 = "/api/v1/contracts/results"
-        mock.onGet(matcher3, param3).reply(200, {
+        mock.onGet(matcher3, {params: param3}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
 
@@ -1041,7 +1041,7 @@ describe("TransactionDetails.vue", () => {
 
         const param3 = {timestamp: timestamp, internal: true}
         const matcher3 = "/api/v1/contracts/results"
-        mock.onGet(matcher3, param3).reply(200, {
+        mock.onGet(matcher3, {params: param3}).reply(200, {
             results: [result], "links": {"next": null}
         });
 

--- a/tests/unit/transaction/TransactionTableControllerXL.spec.ts
+++ b/tests/unit/transaction/TransactionTableControllerXL.spec.ts
@@ -20,7 +20,7 @@
  *
  */
 
-import {describe, test, expect} from 'vitest'
+import {describe, expect, test} from 'vitest'
 import {makeRouter} from "@/router";
 import {computed, ref} from "vue";
 import {TransactionTableControllerXL} from "@/components/transaction/TransactionTableControllerXL";
@@ -163,7 +163,7 @@ describe("TransactionTableController.ts", () => {
             "account.id": ACCOUNT_ID,
             "timestamp": "lte:" + TIMESTAMP0
         }
-        mock.onGet(matcher1, param1).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS)
+        mock.onGet(matcher1, {params: param1}).reply(200, SAMPLE_CONTRACTCALL_TRANSACTIONS)
 
         // Setup controller
         const router = makeRouter()

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -39,7 +39,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
 
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {timestamp: CONTRACT_RESULT.timestamp, internal: true}
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [CONTRACT_RESULT], "links": {"next": null}
         });
 
@@ -135,7 +135,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
 
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {timestamp: CONTRACT_RESULT.timestamp, internal: true}
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [CONTRACT_RESULT], "links": {"next": null}
         });
 
@@ -228,7 +228,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
 
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {timestamp: CONTRACT_RESULT_HTS.timestamp, internal: true}
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [CONTRACT_RESULT_HTS], "links": {"next": null}
         });
 

--- a/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
+++ b/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
@@ -21,7 +21,7 @@
  */
 
 
-import {describe, test, expect} from 'vitest'
+import {describe, expect, test} from 'vitest'
 import {SAMPLE_CONTRACT_RESULT_DETAILS, SAMPLE_ERROR_RESULTS} from "../../Mocks";
 import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
@@ -43,7 +43,7 @@ describe("ContractResultByTsCache", () => {
             timestamp: timestamp,
             internal: true
         }
-        mock.onGet(matcher1, param1).reply(200, {
+        mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
         const contractId = SAMPLE_CONTRACT_RESULT_DETAILS.contract_id
@@ -82,7 +82,7 @@ describe("ContractResultByTsCache", () => {
             timestamp: timestamp,
             internal: true
         }
-        mock.onGet(matcher1, param1).reply(200, SAMPLE_ERROR_RESULTS);
+        mock.onGet(matcher1, {params: param1}).reply(200, SAMPLE_ERROR_RESULTS);
         const ethereumHash = SAMPLE_ERROR_RESULTS.results[0].hash
         const matcher2 = "/api/v1/contracts/results/" + ethereumHash
         mock.onGet(matcher2).reply(200, SAMPLE_ERROR_RESULTS.results[0]);


### PR DESCRIPTION
**Description**:

Bumps [axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter) from 1.22.0 to 2.0.0.

Supersedes dependabot PR #1252 by including the changes needed in the tests due to breaking mock API changes (release notes linked from that PR).
