### PR TITLE
Fix: reduce text of prev./next buttons in BlockDetails when on mobile screen

### DIFF
--- a/src/pages/BlockDetails.vue
+++ b/src/pages/BlockDetails.vue
@@ -33,11 +33,21 @@
 
       <template v-slot:control>
         <div class="is-flex is-justify-content-flex-end is-align-items-center">
-          <button id="prev-block-button" :disabled="disablePreviousButton"
-                  class="button is-white is-small" @click="handlePreviousBlock">&lt; PREV. BLOCK
+          <button
+              id="prev-block-button"
+              :disabled="disablePreviousButton"
+              class="button is-white is-small"
+              @click="handlePreviousBlock"
+          >
+            &lt; {{ isSmallScreen ? 'PREV. BLOCK' : 'PREV.'}}
           </button>
-          <button id="next-block-button" :disabled="disableNextButton"
-                  class="button is-white is-small ml-4" @click="handleNextBlock">NEXT BLOCK &gt;
+          <button
+              id="next-block-button"
+              :disabled="disableNextButton"
+              class="button is-white is-small ml-4"
+              @click="handleNextBlock"
+          >
+            {{ isSmallScreen ? 'NEXT BLOCK' : 'NEXT'}} &gt;
           </button>
         </div>
       </template>


### PR DESCRIPTION
**Description**:

All is in the title.

**Related issue(s)**:

Fixes #1240 

**Notes for reviewer**:

![IMG_90B9548AD164-1](https://github.com/user-attachments/assets/12a4bd59-8245-419a-8a95-6b5290fc162b)
