### PR TITLE
fix: nft metadata not visible

### DIFF
--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -84,7 +84,7 @@
           <BlobValue :blob-value="format" :show-none="true"/>
         </template>
       </Property>
-      <Property id="image" :full-width="true">
+      <Property v-if="image" id="image" :full-width="true">
         <template #name>
           Image
         </template>
@@ -92,7 +92,7 @@
           <BlobValue :blob-value="image" :show-none="true"/>
         </template>
       </Property>
-      <Property id="type" :full-width="true">
+      <Property v-if="type" id="type" :full-width="true">
         <template #name>
           Type
         </template>
@@ -100,7 +100,7 @@
           <BlobValue :blob-value="type" :show-none="true"/>
         </template>
       </Property>
-      <Property id="checksum" v-if="checksum" :full-width="true">
+      <Property v-if="checksum" id="checksum" :full-width="true">
         <template #name>
           Checksum
         </template>

--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -60,7 +60,7 @@
           <BlobValue :blob-value="rawMetadata" :show-none="true"/>
         </template>
       </Property>
-      <Property id="metadata-location" :full-width="true">
+      <Property v-if="rawMetadata" id="metadata-location" :full-width="true">
         <template #name>Content Location</template>
         <template #value>
           <BlobValue

--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -25,7 +25,6 @@
 <template>
 
   <DashboardCard
-      v-if="rawMetadata"
       id="metadata-section"
       class="h-card"
       collapsible-key="metadataSection"

--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -43,14 +43,7 @@
       </div>
     </template>
 
-    <template v-if="showRawMetadata" #content>
-      <BlobValue
-          :blob-value="metadataString"
-          :pretty="true"
-      />
-    </template>
-
-    <template v-else #content>
+    <template #content>
 
       <Property id="raw-metadata-property" :full-width="true">
         <template #name>
@@ -76,74 +69,92 @@
           />
         </template>
       </Property>
-      <Property v-if="format" id="format" :full-width="true">
-        <template #name>
-          Format
-        </template>
-        <template #value>
-          <BlobValue :blob-value="format" :show-none="true"/>
-        </template>
-      </Property>
-      <Property v-if="image" id="image" :full-width="true">
-        <template #name>
-          Image
-        </template>
-        <template #value>
-          <BlobValue :blob-value="image" :show-none="true"/>
-        </template>
-      </Property>
-      <Property v-if="type" id="type" :full-width="true">
-        <template #name>
-          Type
-        </template>
-        <template #value>
-          <BlobValue :blob-value="type" :show-none="true"/>
-        </template>
-      </Property>
-      <Property v-if="checksum" id="checksum" :full-width="true">
-        <template #name>
-          Checksum
-        </template>
-        <template #value>
-          <BlobValue :blob-value="checksum" :show-none="true"/>
-        </template>
-      </Property>
-      <Property v-if="creatorDID" id="creator-did" :full-width="true">
-        <template #name>
-          Creator DID
-        </template>
-        <template #value>
-          <BlobValue :blob-value="creatorDID" :show-none="true"/>
-        </template>
-      </Property>
-      <Property v-if="properties" id="properties" :full-width="true">
-        <template #name>
-          Properties
-        </template>
-        <template #value>
-          <BlobValue :blob-value="properties" :pretty="true" :show-none="true"/>
-        </template>
-      </Property>
 
-      <template v-if="attributes.length">
-        <p class="h-is-tertiary-text mt-5 mb-3">Attributes</p>
-        <template v-for="attr in attributes" :key="attr.trait_type">
-          <NftAttribute :attribute="attr"/>
+      <template v-if="showRawMetadata">
+        <Property id="raw-content" :full-width="true">
+          <template #name>
+            Content
+          </template>
+          <template #value>
+            <BlobValue
+                :blob-value="metadataString"
+                :pretty="true"
+            />
+          </template>
+        </Property>
+      </template>
+
+      <template v-else>
+        <Property v-if="format" id="format" :full-width="true">
+          <template #name>
+            Format
+          </template>
+          <template #value>
+            <BlobValue :blob-value="format" :show-none="true"/>
+          </template>
+        </Property>
+        <Property v-if="image" id="image" :full-width="true">
+          <template #name>
+            Image
+          </template>
+          <template #value>
+            <BlobValue :blob-value="image" :show-none="true"/>
+          </template>
+        </Property>
+        <Property v-if="type" id="type" :full-width="true">
+          <template #name>
+            Type
+          </template>
+          <template #value>
+            <BlobValue :blob-value="type" :show-none="true"/>
+          </template>
+        </Property>
+        <Property v-if="checksum" id="checksum" :full-width="true">
+          <template #name>
+            Checksum
+          </template>
+          <template #value>
+            <BlobValue :blob-value="checksum" :show-none="true"/>
+          </template>
+        </Property>
+        <Property v-if="creatorDID" id="creator-did" :full-width="true">
+          <template #name>
+            Creator DID
+          </template>
+          <template #value>
+            <BlobValue :blob-value="creatorDID" :show-none="true"/>
+          </template>
+        </Property>
+        <Property v-if="properties" id="properties" :full-width="true">
+          <template #name>
+            Properties
+          </template>
+          <template #value>
+            <BlobValue :blob-value="properties" :pretty="true" :show-none="true"/>
+          </template>
+        </Property>
+
+        <template v-if="attributes.length">
+          <p class="h-is-tertiary-text mt-5 mb-3">Attributes</p>
+          <template v-for="attr in attributes" :key="attr.trait_type">
+            <NftAttribute :attribute="attr"/>
+          </template>
+        </template>
+
+        <template v-if="files.length">
+          <p class="h-is-tertiary-text mt-5 mb-3">Files</p>
+          <div id="file-container-area" class="file-container">
+            <NftFile
+                v-for="(file) in files" :key="file.uri"
+                class="file-container-item mt-3"
+                :type="file.type"
+                :url="file.url"
+                :size="200"
+            />
+          </div>
         </template>
       </template>
 
-      <template v-if="files.length">
-        <p class="h-is-tertiary-text mt-5 mb-3">Files</p>
-        <div id="file-container-area" class="file-container">
-          <NftFile
-              v-for="(file) in files" :key="file.uri"
-              class="file-container-item mt-3"
-              :type="file.type"
-              :url="file.url"
-              :size="200"
-          />
-        </div>
-      </template>
     </template>
 
   </DashboardCard>

--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -35,7 +35,7 @@
     </template>
 
     <template #control>
-      <div v-if="metadataString" class="is-flex is-align-items-center is-justify-content-end">
+      <div v-if="metadataString" class="is-flex is-align-items-baseline is-justify-content-end">
         <p class="has-text-weight-light">Raw content</p>
         <label class="checkbox pt-1 ml-3">
           <input type="checkbox" v-model="showRawMetadata">

--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -25,7 +25,7 @@
 <template>
 
   <DashboardCard
-      v-if="metadata"
+      v-if="rawMetadata"
       id="metadata-section"
       class="h-card"
       collapsible-key="metadataSection"
@@ -37,7 +37,7 @@
 
     <template #control>
       <div v-if="metadataString" class="is-flex is-align-items-center is-justify-content-end">
-        <p class="has-text-weight-light">Show raw metadata</p>
+        <p class="has-text-weight-light">Raw content</p>
         <label class="checkbox pt-1 ml-3">
           <input type="checkbox" v-model="showRawMetadata">
         </label>
@@ -53,12 +53,19 @@
 
     <template v-else #content>
 
-      <Property id="metadata" :full-width="true">
-        <template #name>Metadata Location</template>
+      <Property id="raw-metadata-property" :full-width="true">
+        <template #name>
+          Raw Metadata
+        </template>
+        <template #value>
+          <BlobValue :blob-value="rawMetadata" :show-none="true"/>
+        </template>
+      </Property>
+      <Property id="metadata-location" :full-width="true">
+        <template #name>Content Location</template>
         <template #value>
           <BlobValue
               class="is-inline-block"
-              :base64="true"
               :blob-value="metadata"
               :show-none="true"
           />
@@ -187,7 +194,8 @@ export default defineComponent({
       showRawMetadata,
       metadataInfo: props.metadataAnalyzer.metadataInfo,
       metadataWarning: props.metadataAnalyzer.metadataWarning,
-      metadata: props.metadataAnalyzer.rawMetadata,
+      metadata: props.metadataAnalyzer.metadata,
+      rawMetadata: props.metadataAnalyzer.rawMetadata,
       metadataString: props.metadataAnalyzer.metadataString,
       attributes: props.metadataAnalyzer.attributes,
       creatorDID: props.metadataAnalyzer.creatorDID,

--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -262,7 +262,7 @@ export class TokenMetadataAnalyzer {
             } else {
                 try {
                     CID.parse(metadata.value)
-                    content.value = await this.readMetadataFromUrl(`${ipfsGatewayPrefix}${metadata}`)
+                    content.value = await this.readMetadataFromUrl(`${ipfsGatewayPrefix}${metadata.value}`)
                 } catch {
                     content.value = null
                 }

--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -81,15 +81,7 @@ export class TokenMetadataAnalyzer {
     public loadSuccess = computed(() => this.loadSuccessRef.value)
     public loadError = computed(() => this.loadErrorRef.value)
 
-    public readonly metadata = computed(() => {
-        let result
-        try {
-            result = Buffer.from(this.rawMetadata.value ?? '', 'base64').toString()
-        } catch {
-            result = this.rawMetadata.value
-        }
-        return result
-    })
+    public readonly metadata = ref('')
 
     public metadataInfo = computed(() => {
         let result: string | null
@@ -242,34 +234,34 @@ export class TokenMetadataAnalyzer {
 
     private async metadataDidChange(value: string | null): Promise<void> {
         const content = this.metadataContentRef
+        const metadata = this.metadata
 
-        let metadata
         try {
-            metadata = Buffer.from(value ?? '', 'base64').toString()
+            metadata.value = Buffer.from(value ?? '', 'base64').toString()
         } catch {
-            metadata = value
+            metadata.value = value ?? ''
         }
 
-        if (metadata !== null) {
-            if (metadata.startsWith('ipfs://')) {
-                content.value = await this.readMetadataFromUrl(`${ipfsGatewayPrefix}${metadata.substring(7)}`)
-            } else if (metadata.startsWith('hcs://')) {
-                const i = metadata.lastIndexOf('/');
-                const id = metadata.substring(i + 1);
+        if (metadata.value !== null) {
+            if (metadata.value.startsWith('ipfs://')) {
+                content.value = await this.readMetadataFromUrl(`${ipfsGatewayPrefix}${metadata.value.substring(7)}`)
+            } else if (metadata.value.startsWith('hcs://')) {
+                const i = metadata.value.lastIndexOf('/');
+                const id = metadata.value.substring(i + 1);
                 if (EntityID.parse(id) !== null) {
                     content.value = await this.readMetadataFromTopic(id)
                 } else {
                     content.value = null
                 }
-            } else if (metadata.startsWith('https://')) {
-                content.value = await this.readMetadataFromUrl(metadata)
-            } else if (EntityID.parse(metadata) !== null) {
-                content.value = await this.readMetadataFromTopic(metadata)
-            } else if (Timestamp.parse(metadata) !== null) {
-                content.value = await this.readMetadataFromTimestamp(metadata)
+            } else if (metadata.value.startsWith('https://')) {
+                content.value = await this.readMetadataFromUrl(metadata.value)
+            } else if (EntityID.parse(metadata.value) !== null) {
+                content.value = await this.readMetadataFromTopic(metadata.value)
+            } else if (Timestamp.parse(metadata.value) !== null) {
+                content.value = await this.readMetadataFromTimestamp(metadata.value)
             } else {
                 try {
-                    CID.parse(metadata)
+                    CID.parse(metadata.value)
                     content.value = await this.readMetadataFromUrl(`${ipfsGatewayPrefix}${metadata}`)
                 } catch {
                     content.value = null

--- a/tests/unit/token/MetadataSection.spec.ts
+++ b/tests/unit/token/MetadataSection.spec.ts
@@ -116,8 +116,14 @@ describe("MetadataSection.vue", () => {
         expect(wrapper.get("#raw-metadata-propertyName").text()).toBe('Raw Metadata')
         expect(wrapper.get("#raw-metadata-propertyValue").text()).toBe(UNUSABLE_METADATA)
 
-        expect(wrapper.get("#typeValue").text()).toBe('None')
-        expect(wrapper.get("#imageValue").text()).toBe('None')
+        expect(wrapper.find("#formatValue").exists()).toBe(false)
+        expect(wrapper.find("#imageValue").exists()).toBe(false)
+        expect(wrapper.find("#typeValue").exists()).toBe(false)
+        expect(wrapper.find("#checksumValue").exists()).toBe(false)
+        expect(wrapper.find("#creatorDIDValue").exists()).toBe(false)
+        expect(wrapper.find("#propertiesValue").exists()).toBe(false)
+        expect(wrapper.text()).not.contains('Attributes')
+        expect(wrapper.text()).not.contains('Files')
 
         wrapper.unmount()
         analyzer.unmount()

--- a/tests/unit/token/MetadataSection.spec.ts
+++ b/tests/unit/token/MetadataSection.spec.ts
@@ -50,6 +50,7 @@ describe("MetadataSection.vue", () => {
         mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
 
         const metadata = ref(IPFS_METADATA)
+        const decodedMetadata = atob(IPFS_METADATA)
         const analyzer = new TokenMetadataAnalyzer(metadata)
         analyzer.mount()
 
@@ -66,6 +67,12 @@ describe("MetadataSection.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
+        expect(wrapper.get("#raw-metadata-propertyName").text()).toBe('Raw Metadata')
+        expect(wrapper.get("#raw-metadata-propertyValue").text()).toBe(metadata.value)
+
+        expect(wrapper.get("#metadata-locationName").text()).toBe('Content Location')
+        expect(wrapper.get("#metadata-locationValue").text()).toBe(decodedMetadata)
+
         expect(wrapper.get("#typeValue").text()).toBe(IPFS_METADATA_CONTENT.type)
         expect(wrapper.get("#imageValue").text()).toBe(IPFS_METADATA_CONTENT.image)
         expect(wrapper.get("#formatValue").text()).toBe(IPFS_METADATA_CONTENT.format)
@@ -79,6 +86,39 @@ describe("MetadataSection.vue", () => {
         }
 
         mock.restore()
+        wrapper.unmount()
+        analyzer.unmount()
+        await flushPromises()
+    });
+
+    it("Should display raw metadata property when metadata unusable", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const UNUSABLE_METADATA = '==AA'
+        const metadata = ref(UNUSABLE_METADATA)
+        const analyzer = new TokenMetadataAnalyzer(metadata)
+        analyzer.mount()
+
+        const wrapper = mount(MetadataSection, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                metadataAnalyzer: analyzer,
+                collapsed: false
+            },
+        });
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.get("#raw-metadata-propertyName").text()).toBe('Raw Metadata')
+        expect(wrapper.get("#raw-metadata-propertyValue").text()).toBe(UNUSABLE_METADATA)
+
+        expect(wrapper.get("#typeValue").text()).toBe('None')
+        expect(wrapper.get("#imageValue").text()).toBe('None')
+
         wrapper.unmount()
         analyzer.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

- Always display the `Metadata Details` section in NFT details view (collapsed by default).
- Always display the `Raw Metadata` property from the NFT.
- When the metadata content is retrieved, always display the `Raw Metadata` and `Content Location` properties, even if user chooses to display the content in raw form.
- Do not display metadata content properties when `None`
- A bit of `TokenMetadataAnalyzer` refactoring.

**Related issue(s)**:

Fixes #1269 

**Notes for reviewer**:

On staging server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
