### PR TITLE
ci: update workflows to use latitude.sh based runners

### DIFF
--- a/.github/workflows/comp-compile-explorer-code.yaml
+++ b/.github/workflows/comp-compile-explorer-code.yaml
@@ -47,7 +47,7 @@ env:
 jobs:
   compile:
     name: ${{ inputs.custom-job-label || 'Compiles' }}
-    runs-on: [ self-hosted, Linux, large, ephemeral ]
+    runs-on: mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1

--- a/.github/workflows/xflow-release-docker-image.yaml
+++ b/.github/workflows/xflow-release-docker-image.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   prepare-release:
     name: Release / Prepare
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: mirror-node-linux-medium
     outputs:
       version: ${{ steps.extract.outputs.version }}
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   deploy-docker-image:
     name: Deploy / Docker / Image
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: mirror-node-linux-medium
     needs:
       - prepare-release
     steps:


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the CI workflows `runs-on` labels to use the new Latitude.sh based runners.

### Related Issues

- Closes #1313 