### PR TITLE
chore: attempt to fix `window undefined` error, added missing mocks 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:http": "npm run install:branding && cp ./networks-config-example.json ./public/networks-config.json  && vite --config nossl.config.ts",
     "build": "run-p type-check build-only",
     "preview": "npm run install:branding && vite preview",
-    "test:unit": "vitest run",
+    "test:unit": "vitest run --sequence.setupFiles list",
     "cover:unit": "vitest run --coverage",
     "test:e2e": "npm run install:branding && START_SERVER_AND_TEST_INSECURE=1 start-server-and-test dev https://localhost:5173 'cypress run --browser chrome --e2e'",
     "test:e2e:dev": "npm run install:branding && START_SERVER_AND_TEST_INSECURE=1 start-server-and-test 'vite dev --port 5173' https://localhost:5173 'cypress open --e2e'",

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -379,7 +379,6 @@ export async function isOwnedSerials(accountId: string | null, tokenId: string |
 
 export function labelForAutomaticTokenAssociation(rawProperty: number): string {
     let result: string
-    console.log(`labelForAutomaticTokenAssociation - property: ${rawProperty}`)
     switch (rawProperty) {
         case -1:
             result = 'Unlimited Auto Associations'

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -102,6 +102,15 @@ describe("AccountDetails.vue", () => {
         const matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
 
+        const matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        const matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        const matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -191,6 +200,15 @@ describe("AccountDetails.vue", () => {
         let matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
 
+        let matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        let matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        let matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -225,6 +243,12 @@ describe("AccountDetails.vue", () => {
 
         matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
+
+        matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
 
         await wrapper.setProps({
             accountId: SAMPLE_ACCOUNT_DUDE.account ?? undefined
@@ -308,6 +332,15 @@ describe("AccountDetails.vue", () => {
         const matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DELETED.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
 
+        const matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DELETED.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        const matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        const matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT_DELETED.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -362,6 +395,15 @@ describe("AccountDetails.vue", () => {
         const matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_NODE.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
 
+        const matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_NODE.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        const matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        const matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_NODE.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -415,6 +457,15 @@ describe("AccountDetails.vue", () => {
         const matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_ACCOUNT.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
 
+        const matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_ACCOUNT.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        const matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        const matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT_STAKING_ACCOUNT.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -449,6 +500,21 @@ describe("AccountDetails.vue", () => {
 
         const matcher2 = "/api/v1/transactions"
         mock.onGet(matcher2).reply(200, SAMPLE_TRANSACTIONS);
+
+        const matcher9 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/crypto"
+        mock.onGet(matcher9).reply(200, {rewards: []})
+
+        const matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/tokens"
+        mock.onGet(matcher10).reply(200, {rewards: []})
+
+        const matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        const matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        const matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
 
         const wrapper = mount(AccountDetails, {
             global: {

--- a/tests/unit/account/AdminKeyDetails.spec.ts
+++ b/tests/unit/account/AdminKeyDetails.spec.ts
@@ -60,8 +60,14 @@ describe("AdminKeyDetails.vue", () => {
         mock.onGet(matcher31).reply(200, {rewards: []})
         const matcher32 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_PROTOBUF_KEY.account + "/allowances/tokens"
         mock.onGet(matcher32).reply(200, {rewards: []})
+        const matcher33 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_PROTOBUF_KEY.account + "/allowances/nfts"
+        mock.onGet(matcher33).reply(200, {nfts: []})
         const matcher4 = "/api/v1/tokens/0.0.29662956"
         mock.onGet(matcher4).reply(200, SAMPLE_TOKEN);
+        const matcher5 = "api/v1/tokens"
+        mock.onGet(matcher5).reply(200, { tokens: [] });
+        const matcher6 = "api/v1/accounts/" + SAMPLE_ACCOUNT_PROTOBUF_KEY.account + "/nfts"
+        mock.onGet(matcher6).reply(200, { nfts: [] });
 
         const wrapper = mount(AccountDetails, {
             global: {

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -87,6 +87,13 @@ describe("ContractDetails.vue", () => {
         const matcher8 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
 
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, { tokens: [] });
+
+        const matcher11 = "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, { nfts: [] });
+
+
         const wrapper = mount(ContractDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -179,6 +186,12 @@ describe("ContractDetails.vue", () => {
         const matcher8 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
 
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, { tokens: [] });
+
+        const matcher11 = "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, { nfts: [] });
+
         const wrapper = mount(ContractDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -268,6 +281,12 @@ describe("ContractDetails.vue", () => {
         const matcher8 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
 
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, { tokens: [] });
+
+        const matcher11 = "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, { nfts: [] });
+
         const wrapper = mount(ContractDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -330,6 +349,12 @@ describe("ContractDetails.vue", () => {
         let matcher8 = "api/v1/contracts/" + contract1.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
 
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, { tokens: [] });
+
+        const matcher11 = "api/v1/accounts/" + contract1.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, { nfts: [] });
+
         const wrapper = mount(ContractDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -367,6 +392,9 @@ describe("ContractDetails.vue", () => {
 
         matcher8 = "api/v1/contracts/" + contract2.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
+
+        const matcher12 = "api/v1/accounts/" + contract2.contract_id + "/nfts"
+        mock.onGet(matcher12).reply(200, { nfts: [] });
 
         await wrapper.setProps({
             contractId: SAMPLE_CONTRACT_DUDE.contract_id ?? undefined
@@ -462,6 +490,12 @@ describe("ContractDetails.vue", () => {
         const matcher8 = "api/v1/contracts/" + contract.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
 
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, { tokens: [] });
+
+        const matcher11 = "api/v1/accounts/" + contract.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, { nfts: [] });
+
         const wrapper = mount(ContractDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -508,6 +542,12 @@ describe("ContractDetails.vue", () => {
 
         const matcher8 = "api/v1/contracts/" + contract.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
         mock.onGet(matcher8).reply<ContractStateResponse>(200, { state: [], links: undefined })
+
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, { tokens: [] });
+
+        const matcher11 = "api/v1/accounts/" + contract.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, { nfts: [] });
 
         const wrapper = mount(ContractDetails, {
             global: {

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -137,6 +137,15 @@ describe("NodeDetails.vue", () => {
         let matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
 
+        let matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        let matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        let matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
+
         const wrapper = mount(AccountDetails, {
             global: {
                 plugins: [router, Oruga]
@@ -164,6 +173,15 @@ describe("NodeDetails.vue", () => {
 
         matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/tokens"
         mock.onGet(matcher10).reply(200, {rewards: []})
+
+        matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []})
+
+        matcher12 = "api/v1/tokens"
+        mock.onGet(matcher12).reply(200, { tokens: [] });
+
+        matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/nfts"
+        mock.onGet(matcher13).reply(200, { nfts: [] });
 
         const token2 = SAMPLE_TOKEN_DUDE
         matcher3 = "/api/v1/tokens/" + token2.token_id


### PR DESCRIPTION
**Description**:

- Added missing mocks in unit tests for `AccountDetails`, `ContractDetails`, `NodeDetails` and `AdminKeyDetails` vue (to avoid `404` warnings during test executions)
- Removed debug trace from `HederaUtils.labelForAutomaticTokenAssociation()`
- Added `--sequence.setupFiles list` to `vitest run` (it seems to fix the `window undefined` error breaking the tests in GitHub env)

