### PR TITLE
chore: may be a fix for window undefined error reported by unit tests in CI env

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:http": "npm run install:branding && cp ./networks-config-example.json ./public/networks-config.json  && vite --config nossl.config.ts",
     "build": "run-p type-check build-only",
     "preview": "npm run install:branding && vite preview",
-    "test:unit": "vitest run --sequence.setupFiles list",
+    "test:unit": "vitest run",
     "cover:unit": "vitest run --coverage",
     "test:e2e": "npm run install:branding && START_SERVER_AND_TEST_INSECURE=1 start-server-and-test dev https://localhost:5173 'cypress run --browser chrome --e2e'",
     "test:e2e:dev": "npm run install:branding && START_SERVER_AND_TEST_INSECURE=1 start-server-and-test 'vite dev --port 5173' https://localhost:5173 'cypress open --e2e'",

--- a/tests/unit/values/InlineBalancesValue.spec.ts
+++ b/tests/unit/values/InlineBalancesValue.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 /*-
  *
  * Hedera Mirror Node Explorer
@@ -173,6 +175,9 @@ describe("InlineBalancesValue.vue", () => {
         expect(wrapper.text()).toContain("100.00000000" + ">")
         expect(wrapper.text()).toContain("years ago")
 
+        balanceAnalyzer.unmount()
+        await flushPromises()
+
         wrapper.unmount()
         await flushPromises()
     });
@@ -225,6 +230,9 @@ describe("InlineBalancesValue.vue", () => {
         expect(wrapper.text()).toContain("100.00000000" + ">")
         expect(wrapper.text()).toContain("years ago")
 
+        balanceAnalyzer.unmount()
+        await flushPromises()
+
         wrapper.unmount()
         await flushPromises()
     });
@@ -275,6 +283,9 @@ describe("InlineBalancesValue.vue", () => {
 
         expect(wrapper.text()).toContain("100.00000000" + ">")
         expect(wrapper.text()).toContain("years ago")
+
+        balanceAnalyzer.unmount()
+        await flushPromises()
 
         wrapper.unmount()
         await flushPromises()
@@ -327,6 +338,9 @@ describe("InlineBalancesValue.vue", () => {
 
         expect(wrapper.text()).toContain("100.00000000" + ">")
         expect(wrapper.text()).toContain("years ago")
+
+        balanceAnalyzer.unmount()
+        await flushPromises()
 
         wrapper.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

Changes below add some missing calls to `BalanceAnalyzer.unmount()` in `InlineBalancesValue.spec.ts`.
May be the root cause of the `window undefined` errors that are reported when unit tests are run in GitHub env…

Changes also remove use of the `--sequence.setupFiles` option in `vitest run` (a tentative fix for the pb above … that does not fix the pb above).