### PR TITLE
Fix: entity ID in TOKENREJECT

### DIFF
--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -81,6 +81,7 @@ export class EntityDescriptor {
             case TransactionType.TOKENREVOKEKYC:
             case TransactionType.TOKENFREEZE:
             case TransactionType.TOKENUNFREEZE:
+            case TransactionType.TOKENREJECT:
                 result = new EntityDescriptor("Account ID", "AccountDetails")
                 break;
 
@@ -109,7 +110,6 @@ export class EntityDescriptor {
             case TransactionType.TOKENFEESCHEDULEUPDATE:
             case TransactionType.TOKENMINT:
             case TransactionType.TOKENPAUSE:
-            case TransactionType.TOKENREJECT:
             case TransactionType.TOKENUNPAUSE:
             case TransactionType.TOKENWIPE:
                 result = new EntityDescriptor("Token ID", "TokenDetails");

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -47,6 +47,7 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.TOKENREVOKEKYC:
         case TransactionType.TOKENFREEZE:
         case TransactionType.TOKENUNFREEZE:
+        case TransactionType.TOKENREJECT:
         case TransactionType.CRYPTOADDLIVEHASH:
         case TransactionType.CRYPTODELETELIVEHASH:
             result = row.entity_id ? "Account ID: " + row.entity_id : ""
@@ -57,7 +58,6 @@ export function makeSummaryLabel(row: Transaction): string {
         case TransactionType.TOKENDELETION:
         case TransactionType.TOKENFEESCHEDULEUPDATE:
         case TransactionType.TOKENPAUSE:
-        case TransactionType.TOKENREJECT:
         case TransactionType.TOKENUNPAUSE:
         case TransactionType.TOKENUPDATE:
         case TransactionType.TOKENUPDATENFTS:


### PR DESCRIPTION
**Description**:

Interpret Entity ID from TOKENREJECT as Account ID instead of Token ID

Before:
<img width="1154" alt="Screenshot 2024-09-20 at 09 25 54" src="https://github.com/user-attachments/assets/4f98bf1d-68b0-42fc-9ecd-9d6149dba9a2">

After:
<img width="1154" alt="Screenshot 2024-09-20 at 09 40 29" src="https://github.com/user-attachments/assets/78b2938e-1cfc-41be-a463-f8f78fc05be7">


**Related issue(s)**:

Fixes #1369 

