### PR TITLE
chore: added limit=1 to ContractResultByTsCache

### DIFF
--- a/src/utils/cache/ContractResultByTsCache.ts
+++ b/src/utils/cache/ContractResultByTsCache.ts
@@ -72,7 +72,8 @@ export class ContractResultByTsCache extends EntityCache<string, ContractResultD
         try {
             const parameters = {
                 timestamp: timestamp,
-                internal: true
+                internal: true,
+                limit: 1
             }
             const response = await axios.get<ContractResultsResponse>("api/v1/contracts/results", {params: parameters})
             const results = response.data.results

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -57,7 +57,7 @@ describe("ContractResult.vue", () => {
 
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/contracts/results"
-        const param1 = {timestamp: timestamp, internal: true}
+        const param1 = {timestamp: timestamp, internal: true, limit: 1}
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
@@ -108,7 +108,7 @@ describe("ContractResult.vue", () => {
 
         const mock = new MockAdapter(axios);
         const matcher1 = "/api/v1/contracts/results"
-        const param1 = {timestamp: timestamp, internal: true}
+        const param1 = {timestamp: timestamp, internal: true, limit: 1}
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_REVERT_CONTRACT_RESULT_DETAILS], "links": {"next": null}
         });
@@ -149,7 +149,7 @@ describe("ContractResult.vue", () => {
 
         const timestamp = SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.timestamp
         const matcher1 = "/api/v1/contracts/results"
-        const param1 = {timestamp: timestamp, internal: true}
+        const param1 = {timestamp: timestamp, internal: true, limit: 1}
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES], "links": {"next": null}
         });

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -176,7 +176,7 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT)
 
 
-        const param3 = {timestamp: timestamp, internal: true}
+        const param3 = {timestamp: timestamp, internal: true, limit: 1}
         const matcher3 = "/api/v1/contracts/results"
         mock.onGet(matcher3, {params: param3}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
@@ -279,7 +279,7 @@ describe("TransactionDetails.vue", () => {
         const matcher2 = "/api/v1/contracts/" + contractId
         mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT)
 
-        const param3 = {timestamp: timestamp, internal: true}
+        const param3 = {timestamp: timestamp, internal: true, limit: 1}
         const matcher3 = "/api/v1/contracts/results"
         mock.onGet(matcher3, {params: param3}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -38,7 +38,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         mock.onGet(matcher0).reply(200, CONTRACT);
 
         const matcher1 = "/api/v1/contracts/results"
-        const param1 = {timestamp: CONTRACT_RESULT.timestamp, internal: true}
+        const param1 = {timestamp: CONTRACT_RESULT.timestamp, internal: true, limit: 1}
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [CONTRACT_RESULT], "links": {"next": null}
         });
@@ -134,7 +134,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         mock.onGet(matcher0).reply(200, CONTRACT);
 
         const matcher1 = "/api/v1/contracts/results"
-        const param1 = {timestamp: CONTRACT_RESULT.timestamp, internal: true}
+        const param1 = {timestamp: CONTRACT_RESULT.timestamp, internal: true, limit: 1}
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [CONTRACT_RESULT], "links": {"next": null}
         });
@@ -227,7 +227,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         const mock = new MockAdapter(axios);
 
         const matcher1 = "/api/v1/contracts/results"
-        const param1 = {timestamp: CONTRACT_RESULT_HTS.timestamp, internal: true}
+        const param1 = {timestamp: CONTRACT_RESULT_HTS.timestamp, internal: true, limit: 1}
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [CONTRACT_RESULT_HTS], "links": {"next": null}
         });

--- a/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
+++ b/tests/unit/utils/cache/ContractResultByTsCache.spec.ts
@@ -41,7 +41,8 @@ describe("ContractResultByTsCache", () => {
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {
             timestamp: timestamp,
-            internal: true
+            internal: true,
+            limit: 1
         }
         mock.onGet(matcher1, {params: param1}).reply(200, {
             results: [SAMPLE_CONTRACT_RESULT_DETAILS], "links": {"next": null}
@@ -80,7 +81,8 @@ describe("ContractResultByTsCache", () => {
         const matcher1 = "/api/v1/contracts/results"
         const param1 = {
             timestamp: timestamp,
-            internal: true
+            internal: true,
+            limit: 1
         }
         mock.onGet(matcher1, {params: param1}).reply(200, SAMPLE_ERROR_RESULTS);
         const ethereumHash = SAMPLE_ERROR_RESULTS.results[0].hash


### PR DESCRIPTION
**Description**:
Changes below add an explicit `limit=1` to in `ContractResultBtCache.load()` and update unit tests accordingly.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
