### PR TITLE
ContractResultsLogsByContractIdCache now returns ContractLog[]

### DIFF
--- a/src/utils/analyzer/ContractResultsLogsAnalyzer.ts
+++ b/src/utils/analyzer/ContractResultsLogsAnalyzer.ts
@@ -18,49 +18,30 @@
  *
  */
 
-import {Ref, WatchStopHandle, computed, ref, watch} from 'vue';
-import {ContractResultsLogResponse} from '@/schemas/HederaSchemas'
+import {computed, Ref} from 'vue';
+import {ContractLog} from '@/schemas/HederaSchemas'
 import {ContractResultsLogsByContractIdCache} from '../cache/ContractResultsLogsByContractIdCache';
+import {EntityLookup} from "@/utils/cache/base/EntityCache";
 
 export class ContractResultsLogsAnalyzer {
     public readonly contractId: Ref<string | null>
-    private readonly watchHandle: Ref<WatchStopHandle | null> = ref(null)
-    private readonly contractResultsLogResponse: Ref<ContractResultsLogResponse | null> = ref(null)
+    public readonly contractResultsLookup: EntityLookup<string, ContractLog[]|null>
 
     //
     // Public
     //
     public constructor(contractId: Ref<string | null>) {
         this.contractId = contractId
+        this.contractResultsLookup = ContractResultsLogsByContractIdCache.instance.makeLookup(this.contractId)
     }
 
     public mount(): void {
-        this.watchHandle.value = watch(this.contractId, this.updateContractResultsLogs, {immediate: true});
+        this.contractResultsLookup.mount()
     }
 
     public unmount(): void {
-        if (this.watchHandle.value !== null) {
-            this.watchHandle.value()
-            this.watchHandle.value = null
-        }
-        this.contractResultsLogResponse.value = null
+        this.contractResultsLookup.unmount()
     }
 
-    public readonly logs = computed(() => this.contractResultsLogResponse.value?.logs ?? undefined)
-    public readonly cursorLinks = computed(() => this.contractResultsLogResponse.value?.links?.next ?? null)
-
-    //
-    // Private
-    //
-    private readonly updateContractResultsLogs = async () => {
-        if (this.contractId.value !== null) {
-            try {
-                this.contractResultsLogResponse.value = await ContractResultsLogsByContractIdCache.instance.lookup(this.contractId.value)
-            } catch {
-                this.contractResultsLogResponse.value = null
-            }
-        } else {
-            this.contractResultsLogResponse.value = null
-        }
-    }
+    public readonly logs = computed(() => this.contractResultsLookup.entity.value ?? undefined)
 }

--- a/src/utils/cache/ContractResultsLogsByContractIdCache.ts
+++ b/src/utils/cache/ContractResultsLogsByContractIdCache.ts
@@ -20,17 +20,17 @@
 
 import axios from 'axios';
 import {EntityCache} from './base/EntityCache';
-import {ContractResultsLogResponse} from '@/schemas/HederaSchemas';
+import {ContractLog} from '@/schemas/HederaSchemas';
 
-export class ContractResultsLogsByContractIdCache extends EntityCache<string, ContractResultsLogResponse | null> {
+export class ContractResultsLogsByContractIdCache extends EntityCache<string, ContractLog[] | null> {
 
     public static readonly instance = new ContractResultsLogsByContractIdCache()
 
     //
     // Cache
     //
-    protected async load(contractId: string): Promise<ContractResultsLogResponse | null> {
-        let result: Promise<ContractResultsLogResponse | null>
+    protected async load(contractId: string): Promise<ContractLog[] | null> {
+        let result: Promise<ContractLog[] | null>
         const params = {
             limit: 100,
             order: "desc",
@@ -38,7 +38,7 @@ export class ContractResultsLogsByContractIdCache extends EntityCache<string, Co
 
         try {
             const response = await axios.get(`api/v1/contracts/${contractId}/results/logs`, {params});
-            result = Promise.resolve(response.data)
+            result = Promise.resolve(response.data.logs)
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status == 404) {
                 result = Promise.resolve(null)


### PR DESCRIPTION
**Description**:
Change below update `ContractResultsLogsByContractIdCache` class: it now returns `ContractLog[]` in place of `ContractResultsLogResponse`. No semantic change.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
