### PR TITLE
feat: display responseCode symbol when call target is a token

### DIFF
--- a/src/utils/analyzer/ContractAnalyzer.ts
+++ b/src/utils/analyzer/ContractAnalyzer.ts
@@ -35,7 +35,7 @@ export class ContractAnalyzer {
     public readonly contractId: Ref<string | null>
     public readonly byteCodeAnalyzer: ByteCodeAnalyzer
     private readonly contractResponse: Ref<ContractResponse | null> = ref(null)
-    private readonly tokenInfo: Ref<TokenInfo|null> = ref(null)
+    public readonly tokenInfo: Ref<TokenInfo|null> = ref(null)
     public readonly systemContractEntry: Ref<SystemContractEntry | null> = ref(null)
     public readonly sourcifyRecord: Ref<SourcifyRecord | null> = ref(null)
     private readonly abi: Ref<ethers.Fragment[] | null> = ref(null)

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -248,7 +248,7 @@ export class FunctionCallAnalyzer {
                     this.functionDecodingFailure.value = null
                     this.is4byteFunctionFragment.value = false
 
-                    // please refer to the ticket below for more information on this logic for redirectForToken(address,bytes) method on HTS System Contract 
+                    // please refer to the ticket below for more information on this logic for redirectForToken(address,bytes) method on HTS System Contract
                     // https://github.com/hashgraph/hedera-mirror-node-explorer/issues/921
                     if (ff !== null && isRedirectForTokenTx(contractId, functionHash)) {
                         this.functionFragment.value = resolveFunctionFragmentForHTSProxyContract(ff, inputArgs)
@@ -378,7 +378,10 @@ export class FunctionCallAnalyzer {
     }
 
     private makeComment(value: unknown, paramType: ethers.ParamType): string | null {
-        if (this.contractAnalyzer.systemContractEntry.value !== null
+        const isSystemContract =
+            this.contractAnalyzer.systemContractEntry.value !== null ||
+            this.contractAnalyzer.tokenInfo.value !== null // Target is a token => IERC20 or IERC721
+        if (isSystemContract
             && paramType.name == "responseCode"
             && typeof value == "bigint") {
             // It's a responseCode from a system contract


### PR DESCRIPTION
**Description**:

Changes below updates `FunctionCallAnalyzer` class to take the case of token target into account.

**Related issue(s)**:

Fixes #1408

**Notes for reviewer**:

User transaction `1727966148.616576069` on `testnet` to see the fix in action.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
