### PR TITLE
ci: new workflow to release helm chart

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -27,11 +27,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Create chart directory
-        run: mkdir -p charts
-        
       - name: Publish helm chart
         uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
         with:
-          target_dir: charts
+          target_dir: chart
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -39,6 +39,6 @@ jobs:
       - name: Publish helm chart
         uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
         with:
-          charts_dir: chart
+          charts_dir: .
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -3,6 +3,7 @@ name: Helm Chart Release
 on:
   workflow_dispatch:
   pull_request:
+  push:
 
 permissions:
   contents: read

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -27,6 +27,15 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: PWD
+        run: pwd
+
+      - name: List directory
+        run: ls -ltr
+
+      - name: list chart directory
+        run: ls -ltr chart
+
       - name: Publish helm chart
         uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
         with:

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Create chart directory
+        run: mkdir -p charts
+        
       - name: Publish helm chart
         uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
         with:

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -39,5 +39,6 @@ jobs:
       - name: Publish helm chart
         uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
         with:
-          target_dir: chart
+          charts_dir: chart
+          target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -15,7 +15,6 @@ defaults:
 jobs:
   chart:
     name: Publish charts
-    needs: image
     runs-on: mirror-node-linux-medium
     permissions:
       contents: write

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -2,6 +2,7 @@ name: Helm Chart Release
 
 on:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,0 +1,33 @@
+name: Helm Chart Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  chart:
+    name: Publish charts
+    needs: image
+    runs-on: mirror-node-linux-medium
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Publish helm chart
+        uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
+        with:
+          target_dir: charts
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -6,7 +6,7 @@ on:
   push:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   pages: write
   id-token: write

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -46,7 +46,12 @@ jobs:
           helm repo update
           helm package chart
 
-      - name: Helm publish
-        run: |
-          export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')         
-          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+      - name: Push Helm chart to OCI compatible registry (Github)
+        uses: bsord/helm-push@4.2.0
+        with:
+          useOCIRegistry: true
+          registry-url:  oci://ghcr.io/${{ github.repository }}
+          username: bsord
+          access-token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          force: true
+          chart-folder: chart

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -2,8 +2,6 @@ name: Helm Chart Release
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
 
 permissions:
   contents: write

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -19,8 +19,6 @@ jobs:
   chart:
     name: Publish charts
     runs-on: mirror-node-linux-medium
-    permissions:
-      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Setup Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
-        if: ${{ inputs.enable-unit-tests && !cancelled() && !failure() }}
         with:
           version: "v3.12.3" #  helm version
 

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -48,4 +48,6 @@ jobs:
       - name: Helm publish
         run: |
           export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')         
-          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY }}
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "owner: $owner"
+          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/$owner/${{ github.event.repository.name }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -27,15 +27,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: PWD
-        run: pwd
-
-      - name: List directory
-        run: ls -ltr
-
-      - name: list chart directory
-        run: ls -ltr chart
-
       - name: Setup Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
@@ -50,17 +41,9 @@ jobs:
 
       - name: Helm package
         run: |
-          export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')
           helm repo add stable https://charts.helm.sh/stable
           helm repo update
           helm package chart
-          
-          # show tgz file content without uncompress
-          tar -tvf hedera-explorer-${CHART_VERSION}.tgz
-
-
-      - name: list tgz files
-        run: ls -ltr *.tgz
 
       - name: Helm publish
         run: |

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -36,15 +36,11 @@ jobs:
       - name: list chart directory
         run: ls -ltr chart
 
-      - name: Setup Kind
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        if: ${{ inputs.enable-unit-tests && !cancelled() && !failure() }}
         with:
-          install_only: true
-          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          version: v0.21.0
-          kubectl_version: v1.28.6
-          verbosity: 3
-          wait: 120s
+          version: "v3.12.3" #  helm version
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -8,7 +8,9 @@ on:
 permissions:
   contents: read
   packages: write
-
+  pages: write
+  id-token: write
+  
 defaults:
   run:
     shell: bash

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 defaults:
   run:

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -36,9 +36,40 @@ jobs:
       - name: list chart directory
         run: ls -ltr chart
 
-      - name: Publish helm chart
-        uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
+      - name: Setup Kind
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          charts_dir: .
-          target_dir: charts
-          token: ${{ secrets.GITHUB_TOKEN }}
+          install_only: true
+          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          version: v0.21.0
+          kubectl_version: v1.28.6
+          verbosity: 3
+          wait: 120s
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Helm package
+        run: |
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo update
+          helm package chart
+          
+          # show tgz file content without uncompress
+          tar -tvf chart*.tgz
+
+
+      - name: list tgz files
+        run: ls -ltr *.tgz
+
+      - name: Helm publish
+        run: |
+          export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')
+          
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          # push to ghcr.io
+          helm push chart*-${CHART_VERSION}.tgz oci://ghcr.io/$owner

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -47,7 +47,7 @@ jobs:
           helm package chart
 
       - name: Push Helm chart to OCI compatible registry (Github)
-        uses: bsord/helm-push@4.1.0
+        uses: bsord/helm-push@v4.1.0
         with:
           useOCIRegistry: true
           registry-url:  oci://ghcr.io/${{ github.repository }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -48,6 +48,4 @@ jobs:
       - name: Helm publish
         run: |
           export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')         
-          owner="${GITHUB_REPOSITORY_OWNER,,}"
-          echo "owner: $owner"
-          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/$owner/${{ github.event.repository.name }}
+          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -47,7 +47,7 @@ jobs:
           helm package chart
 
       - name: Push Helm chart to OCI compatible registry (Github)
-        uses: bsord/helm-push@4.2.0
+        uses: bsord/helm-push@4.1.0
         with:
           useOCIRegistry: true
           registry-url:  oci://ghcr.io/${{ github.repository }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -48,12 +48,7 @@ jobs:
           helm repo update
           helm package chart
 
-      - name: Push Helm chart to OCI compatible registry (Github)
-        uses: bsord/helm-push@v4.1.0
+      - name: Build and Push the Helm Charts to GitHub Container Registry
+        uses: JimCronqvist/action-helm-chart-repo@0.10
         with:
-          useOCIRegistry: true
-          registry-url:  oci://ghcr.io/${{ github.repository }}
-          username: ${{ github.actor }}
-          access-token: ${{ secrets.GITHUB_TOKEN }}
-          force: true
-          chart-folder: chart
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -50,3 +50,10 @@ jobs:
         uses: JimCronqvist/action-helm-chart-repo@0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish helm chart to github pages
+        uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
+        with:
+          charts_dir: .
+          target_dir: charts
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -48,5 +48,4 @@ jobs:
       - name: Helm publish
         run: |
           export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')         
-          owner="${GITHUB_REPOSITORY_OWNER,,}"
-          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/$owner
+          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -52,6 +52,6 @@ jobs:
           useOCIRegistry: true
           registry-url:  oci://ghcr.io/${{ github.repository }}
           username: bsord
-          access-token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          access-token: ${{ secrets.GITHUB_TOKEN }}
           force: true
           chart-folder: chart

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -10,7 +10,7 @@ permissions:
   packages: write
   pages: write
   id-token: write
-  
+
 defaults:
   run:
     shell: bash
@@ -53,7 +53,7 @@ jobs:
         with:
           useOCIRegistry: true
           registry-url:  oci://ghcr.io/${{ github.repository }}
-          username: bsord
+          username: ${{ github.actor }}
           access-token: ${{ secrets.GITHUB_TOKEN }}
           force: true
           chart-folder: chart

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -49,6 +49,6 @@ jobs:
           helm package chart
 
       - name: Build and Push the Helm Charts to GitHub Container Registry
-        uses: JimCronqvist/action-helm-chart-repo@0.10
+        uses: JimCronqvist/action-helm-chart-repo@0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -50,12 +50,13 @@ jobs:
 
       - name: Helm package
         run: |
+          export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')
           helm repo add stable https://charts.helm.sh/stable
           helm repo update
           helm package chart
           
           # show tgz file content without uncompress
-          tar -tvf chart*.tgz
+          tar -tvf hedera-explorer-${CHART_VERSION}.tgz
 
 
       - name: list tgz files
@@ -63,8 +64,6 @@ jobs:
 
       - name: Helm publish
         run: |
-          export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')
-          
+          export CHART_VERSION=$(grep 'version:' ./chart/Chart.yaml | tail -n1 | awk '{ print $2}')         
           owner="${GITHUB_REPOSITORY_OWNER,,}"
-          # push to ghcr.io
-          helm push chart*-${CHART_VERSION}.tgz oci://ghcr.io/$owner
+          helm push hedera-explorer-${CHART_VERSION}.tgz oci://ghcr.io/$owner

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,5 +5,5 @@ home: https://github.com/hashgraph/hedera-mirror-node-explorer
 name: hedera-explorer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node-explorer
-version: 0.2
+version: 0.2.0
 


### PR DESCRIPTION
**Description**:

New CI workflow to publish helm chart to ghcr registry and github pages

**Related issue(s)**:
closes https://github.com/hashgraph/hedera-mirror-node-explorer/issues/877
