### PR TITLE
fix: some search patterns trigger unexpected calls to api/v1/account/{accountAlias}

### DIFF
--- a/src/components/search/SearchController.ts
+++ b/src/components/search/SearchController.ts
@@ -21,7 +21,8 @@
 import {computed, ref, Ref, watch} from "vue";
 import {EntityID} from "@/utils/EntityID";
 import {TransactionID} from "@/utils/TransactionID";
-import {base32ToAlias, hexToByte} from "@/utils/B64Utils";
+import {AccountAlias} from "@/utils/AccountAlias";
+import {hexToByte} from "@/utils/B64Utils";
 import {Timestamp} from "@/utils/Timestamp";
 import {
     AccountSearchAgent,
@@ -193,7 +194,7 @@ export class SearchController {
         const entityID = EntityID.parseWithChecksum(searchedText, true)
         const transactionID = TransactionID.parse(searchedText, true)
         const hexBytes = hexToByte(searchedText)
-        const alias = base32ToAlias(searchedText) != null ? searchedText : null
+        const alias = AccountAlias.parse(searchedText) != null ? searchedText : null
         const timestamp = Timestamp.parse(searchedText)
         const domainName = /\.[a-zA-Z|ℏ]+$/.test(searchedText) ? searchedText : null
         const blockNb = EntityID.parsePositiveInt(searchedText)

--- a/src/utils/AccountAlias.ts
+++ b/src/utils/AccountAlias.ts
@@ -33,7 +33,7 @@ export class AccountAlias {
         if (bytes === null) {
             bytes = hexToByte(a)
         }
-        return bytes !== null ? new AccountAlias(bytes) : null
+        return bytes !== null && bytes.length >= 32 ? new AccountAlias(bytes) : null
     }
 
     public toString(): string {

--- a/tests/unit/search/SearchController.spec.ts
+++ b/tests/unit/search/SearchController.spec.ts
@@ -865,7 +865,6 @@ describe("SearchController.vue", () => {
 
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "api/v1/accounts/" + SAMPLE_TOKEN_NAME,
             "api/v1/tokens/?name=" + SAMPLE_TOKEN_NAME + "&limit=100",
         ])
 


### PR DESCRIPTION
**Description**:

When user types `SAU` is `Search Bar`, current searching logic tries to call `api/v1/accounts/SAU` because `SAU` represents a valid `base32` encoding. Changes below fix this logic by checking the size of the `base32` decoding.

**Related issue(s)**:

Fixes #1419 

**Notes for reviewer**:

See #1419  for testing procedure.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)