### PR TITLE
fix: missing fungible token balances

### DIFF
--- a/src/components/token/TokenCell.vue
+++ b/src/components/token/TokenCell.vue
@@ -48,8 +48,8 @@ import BlobValue from "@/components/values/BlobValue.vue";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {makeTokenName, makeTokenSymbol} from "@/schemas/HederaUtils";
 import TokenAmount from "@/components/values/TokenAmount.vue";
-import {BalanceCache} from "@/utils/cache/BalanceCache";
 import {TokenType} from "@/schemas/HederaSchemas";
+import { TokenRelationshipCache } from "@/utils/cache/TokenRelationshipCache";
 
 export enum TokenCellItem {
   tokenName = "tokenName",
@@ -90,15 +90,15 @@ export default defineComponent({
     onMounted(() => infoLookup.mount())
     onBeforeUnmount(() => infoLookup.unmount())
 
-    const balanceLookup = BalanceCache.instance.makeLookup(accountId)
+    const balanceLookup = TokenRelationshipCache.instance.makeLookup(accountId)
     onMounted(() => balanceLookup.mount())
     onBeforeUnmount(() => balanceLookup.unmount())
 
     const tokenBalance = computed(() => {
       let result
-      if (balanceLookup.entity.value !== null && balanceLookup.entity.value.balances.length >= 1) {
+      if (balanceLookup.entity.value !== null) {
         result = null
-        for (const t of balanceLookup.entity.value.balances[0].tokens) {
+        for (const t of balanceLookup.entity.value) { 
           if (t.token_id === props.tokenId) {
             result = t.balance
             break

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2262,6 +2262,27 @@ export const SAMPLE_TOKEN_ASSOCIATIONS = {
     }
 }
 
+export const SAMPLE_TOKEN_ASSOCIATIONS_2 = {
+    "tokens": [{
+        "automatic_association": false,
+        "balance": 2342647909,
+        "created_timestamp": SAMPLE_TOKEN_ASSOCIATE_TRANSACTION.consensus_timestamp,
+        "freeze_status": "UNFROZEN",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": SAMPLE_ASSOCIATED_TOKEN.token_id
+    }, {
+        "automatic_association": false,
+        "balance": 31669471,
+        "created_timestamp": "1671648712.150557003",
+        "freeze_status": "UNFROZEN",
+        "kyc_status": "NOT_APPLICABLE",
+        "token_id": SAMPLE_ASSOCIATED_TOKEN_2.token_id
+    }],
+    "links": {
+        next: null
+    }
+}
+
 //
 // Account inspired from: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts/0.0.730631
 //

--- a/tests/unit/account/TokensSection.spec.ts
+++ b/tests/unit/account/TokensSection.spec.ts
@@ -26,7 +26,8 @@ import {
     SAMPLE_ASSOCIATED_TOKEN,
     SAMPLE_ASSOCIATED_TOKEN_2,
     SAMPLE_NFTS,
-    SAMPLE_NONFUNGIBLE
+    SAMPLE_NONFUNGIBLE,
+    SAMPLE_TOKEN_ASSOCIATIONS_2
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
@@ -53,29 +54,6 @@ describe("TokensSection.vue", () => {
             SAMPLE_ASSOCIATED_TOKEN_2
         ]
     }
-    const SAMPLE_BALANCES = {
-        "timestamp": "1646728200.821070000",
-        "balances": [
-            {
-                "account": accountId,
-                "balance": 42,
-                "tokens": [
-                    {
-                        "token_id": SAMPLE_ASSOCIATED_TOKEN.token_id,
-                        "balance": 420000
-                    },
-                    {
-                        "token_id": SAMPLE_ASSOCIATED_TOKEN_2.token_id,
-                        "balance": 4200000000
-                    },
-                    {
-                        "token_id": "0.0.34332104",
-                        "balance": 0
-                    }
-                ]
-            }
-        ]
-    }
 
     const mock = new MockAdapter(axios);
 
@@ -93,8 +71,9 @@ describe("TokensSection.vue", () => {
         mock.onGet(matcher4).reply(200, SAMPLE_ASSOCIATED_TOKEN)
         const matcher5 = "/api/v1/tokens/" + SAMPLE_ASSOCIATED_TOKEN_2.token_id
         mock.onGet(matcher5).reply(200, SAMPLE_ASSOCIATED_TOKEN_2)
-        const matcher6 = "/api/v1/balances"
-        mock.onGet(matcher6).reply(200, SAMPLE_BALANCES)
+        const matcher6 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/tokens?limit=100"
+        mock.onGet(matcher6).reply(200, SAMPLE_TOKEN_ASSOCIATIONS_2)
+
     })
 
     afterAll(() => {
@@ -182,9 +161,10 @@ describe("TokensSection.vue", () => {
 
         const associationsTable = tokensSection.get("#fungibleTable")
         expect(associationsTable.find('thead').text()).toBe("Token Name Symbol Balance")
+        console.log(associationsTable.find('tbody').text())
         expect(associationsTable.find('tbody').text()).toBe(
-            "0.0.34332104" + "HSUITE" + "HSuite" + "42.0000" +
-            "0.0.49292859" + "Token SymbolA7" + "TokenA7" + "42.00000000"
+            "0.0.34332104" + "HSUITE" + "HSuite" + "234,264.7909" +
+            "0.0.49292859" + "Token SymbolA7" + "TokenA7" + "0.31669471"
         )
 
         wrapper.unmount()


### PR DESCRIPTION
**Description**:
This PR fixes missing fungible token balances for accounts with large amount of tokens. It replaces the endpoint `api/v1/balances?account.id={id}` (the call returns a max of 50 token balances per account) with  `/api/v1/accounts/{id}/tokens` to retrieve the token balances of an account. 


**Related issue(s)**:

Fixes #1413 

**Notes for reviewer**:
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/eb142507-4eed-4f8e-9222-d13a778535d9">

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
