### PR TITLE
ci: add jobs to publish to gh-pages

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -59,7 +59,7 @@ jobs:
   # publish chart to gh-pages, required for helm install in solo
   prepare-release:
     name: Release / Prepare
-    runs-on: solo-linux-medium
+    runs-on: mirror-node-linux-medium
     outputs:
       version: ${{ steps.tag.outputs.version }}
     steps:
@@ -96,7 +96,7 @@ jobs:
 
   publish-helm-charts:
     name: Publish / Helm Charts
-    runs-on: solo-linux-medium
+    runs-on: mirror-node-linux-medium
     needs:
       - prepare-release
     steps:
@@ -117,7 +117,7 @@ jobs:
 
   create-github-release:
     name: Github / Release
-    runs-on: solo-linux-medium
+    runs-on: mirror-node-linux-medium
     needs:
       - publish-helm-charts
     steps:

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Publish helm chart to github pages
         uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
         with:
-          charts_dir: .
+          charts_dir: chart
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   chart:
-    name: Publish charts
+    name: Publish charts to ghcr.io
     runs-on: mirror-node-linux-medium
     steps:
       - name: Harden Runner
@@ -55,3 +55,116 @@ jobs:
           charts_dir: .
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # publish chart to gh-pages, required for helm install in solo
+  prepare-release:
+    name: Release / Prepare
+    runs-on: solo-linux-medium
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: 18
+
+      - name: Install Semantic Release
+        run: |
+          npm install -g semantic-release@21.0.7 @semantic-release/git@10.0.1 @semantic-release/exec@6.0.3
+          npm install -g conventional-changelog-conventionalcommits@6.1.0 @commitlint/cli@17.6.6 @commitlint/config-conventional@17.6.6
+          npm install -g marked-mangle@1.0.1 marked-gfm-heading-id@3.0.4 semantic-release-conventional-commits@3.0.0
+
+      - name: Calculate Next Version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+        run: npx semantic-release --dry-run
+
+      - name: Extract Version
+        id: tag
+        run: |
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == true && ! -f VERSION ]] && echo -n "0.0.0-latest" > VERSION
+          echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
+
+  publish-helm-charts:
+    name: Publish / Helm Charts
+    runs-on: solo-linux-medium
+    needs:
+      - prepare-release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: "v3.12.3" # helm version
+
+      - name: Publish Helm Charts
+        uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d #v1.7.0
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target_dir: charts
+
+  create-github-release:
+    name: Github / Release
+    runs-on: solo-linux-medium
+    needs:
+      - publish-helm-charts
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+
+      - name: Install GnuPG Tools
+        run: |
+          if ! command -v gpg2 >/dev/null 2>&1; then
+            echo "::group::Updating APT Repository Indices"
+              sudo apt update
+            echo "::endgroup::"
+            echo "::group::Installing GnuPG Tools"
+              sudo apt install -y gnupg2
+            echo "::endgroup::"
+          fi
+
+      - name: Import GPG key
+        id: gpg_key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: false
+
+      - name: Setup Node
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: 18
+
+      - name: Install Semantic Release
+        run: |
+          npm install -g semantic-release@21.0.7 @semantic-release/git@10.0.1 @semantic-release/exec@6.0.3
+          npm install -g conventional-changelog-conventionalcommits@6.1.0 @commitlint/cli@17.6.6 @commitlint/config-conventional@17.6.6
+          npm install -g marked-mangle@1.0.1 marked-gfm-heading-id@3.0.4 semantic-release-conventional-commits@3.0.0
+
+      - name: Publish Semantic Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
+        run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -31,6 +31,9 @@
       "name": "main"
     },
     {
+      "name": "08777-publish-chart-gh-pages"
+    },
+    {
       "name": "release/([0-9]+).([0-9]+)",
       "channel": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x",
       "range": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x"

--- a/.releaserc
+++ b/.releaserc
@@ -21,8 +21,7 @@
       "@semantic-release/git",
       {
         "assets": [
-          "charts/solo-deployment/Chart.yaml",
-          "charts/solo-cluster-setup/Chart.yaml"
+          "chart/Chart.yaml",
         ]
       }
     ]

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,60 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    "@semantic-release/git",
+    "@semantic-release/github"
+  ],
+  "verifyRelease": [
+    [
+      "@semantic-release/exec",
+      { "cmd": "echo ${nextRelease.version} > VERSION" }
+    ]
+  ],
+  "prepare": [
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "charts/solo-deployment/Chart.yaml",
+          "charts/solo-cluster-setup/Chart.yaml"
+        ]
+      }
+    ]
+  ],
+  "branches":[
+    {
+      "name": "main"
+    },
+    {
+      "name": "release/([0-9]+).([0-9]+)",
+      "channel": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x",
+      "range": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x"
+    },
+    {
+      "name": "alpha/*",
+      "prerelease": "alpha",
+      "channel": "alpha"
+    },
+    {
+      "name": "ci/*",
+      "prerelease": "alpha",
+      "channel": "alpha"
+    },
+    {
+      "name": "beta/*",
+      "prerelease": "beta",
+      "channel": "beta"
+    },
+    {
+      "name": "rc/*",
+      "prerelease": "rc",
+      "channel": "rc"
+    }
+  ]
+}


### PR DESCRIPTION
**Description**:

Currently helm install command does not support to install chart from oci registrty,
still need to publish chart to gh-pages, so it can be used by solo with `helm install` command


Fixes #877
