### PR TITLE
fix: token actions activation and table refresh

### DIFF
--- a/src/components/token/TokenActions.vue
+++ b/src/components/token/TokenActions.vue
@@ -156,7 +156,7 @@ export default defineComponent({
       required: true
     }
   },
-  emits: ['rejected'],
+  emits: ['completed'],
   setup(props, context) {
     //
     // States
@@ -378,6 +378,7 @@ export default defineComponent({
           try {
             await walletManager.associateToken(tokenId.value!)
           } finally {
+            context.emit('completed')
             props.analyzer.tokenAssociationDidChange()
             gtagTransaction("associate_token")
           }
@@ -408,6 +409,7 @@ export default defineComponent({
           try {
             await walletManager.dissociateToken(tokenId.value!)
           } finally {
+            context.emit('completed')
             props.analyzer.tokenAssociationDidChange()
             gtagTransaction("dissociate_token")
           }
@@ -457,7 +459,7 @@ export default defineComponent({
             }
           } finally {
             props.analyzer.tokenAssociationDidChange()
-            context.emit('rejected')
+            context.emit('completed')
             gtagTransaction("reject_token")
           }
         }

--- a/src/components/token/TokenActions.vue
+++ b/src/components/token/TokenActions.vue
@@ -409,8 +409,9 @@ export default defineComponent({
           try {
             await walletManager.dissociateToken(tokenId.value!)
           } finally {
-            context.emit('completed')
+            TokenAssociationCache.instance.forgetTokenAssociation(walletManager.accountId.value!, tokenId.value!)
             props.analyzer.tokenAssociationDidChange()
+            context.emit('completed')
             gtagTransaction("dissociate_token")
           }
         }
@@ -458,6 +459,7 @@ export default defineComponent({
               await walletManager.rejectTokens(transaction)
             }
           } finally {
+            TokenAssociationCache.instance.forgetTokenAssociation(walletManager.accountId.value!, tokenId.value!)
             props.analyzer.tokenAssociationDidChange()
             context.emit('completed')
             gtagTransaction("reject_token")

--- a/src/components/token/TokenCell.vue
+++ b/src/components/token/TokenCell.vue
@@ -49,7 +49,7 @@ import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {makeTokenName, makeTokenSymbol} from "@/schemas/HederaUtils";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import {TokenType} from "@/schemas/HederaSchemas";
-import { TokenRelationshipCache } from "@/utils/cache/TokenRelationshipCache";
+import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache";
 
 export enum TokenCellItem {
   tokenName = "tokenName",
@@ -90,27 +90,16 @@ export default defineComponent({
     onMounted(() => infoLookup.mount())
     onBeforeUnmount(() => infoLookup.unmount())
 
-    const balanceLookup = TokenRelationshipCache.instance.makeLookup(accountId)
-    onMounted(() => balanceLookup.mount())
-    onBeforeUnmount(() => balanceLookup.unmount())
+    const associationLookup = TokenAssociationCache.instance.makeTokenAssociationLookup(accountId, tokenId)
+    onMounted(() => associationLookup.mount())
+    onBeforeUnmount(() => associationLookup.unmount())
 
     const tokenBalance = computed(() => {
-      let result
-      if (balanceLookup.entity.value !== null) {
-        result = null
-        for (const t of balanceLookup.entity.value) { 
-          if (t.token_id === props.tokenId) {
-            result = t.balance
-            break
-          }
-        }
-      } else {
-        result = null
-      }
-      return result
+      const associations = associationLookup.entity.value
+      return associations ? associations[0].balance : null
     })
 
-    const propertyValue = computed( () => {
+    const propertyValue = computed(() => {
       let result: string | null
       switch (props.property) {
         case TokenCellItem.tokenName:

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -63,7 +63,7 @@
              class="h-is-property-text is-flex algin-items-center is-relative">
           <TokenActions
               :analyzer="tokenAnalyzer"
-              @rejected="onRejectCompleted"
+              @completed="onActionCompleted"
           />
         </div>
       </template>
@@ -464,7 +464,7 @@ export default defineComponent({
 
     const isWalletConnected = computed(() => walletManager.connected.value)
 
-    const onRejectCompleted = () => {
+    const onActionCompleted = () => {
       if (tokenAnalyzer.isNft.value) {
         nftHolderTableController.refresh()
       } else {
@@ -495,7 +495,7 @@ export default defineComponent({
       nftHolderTableController,
       metadata,
       metadataAnalyzer,
-      onRejectCompleted,
+      onActionCompleted,
     }
   },
 });

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -467,8 +467,8 @@ export default defineComponent({
     const onRejectCompleted = () => {
       if (tokenAnalyzer.isNft.value) {
         nftHolderTableController.refresh()
-      }else {
-        nftHolderTableController.refresh()
+      } else {
+        tokenBalanceTableController.refresh()
       }
     }
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2279,43 +2279,29 @@ export const SAMPLE_ASSOCIATED_TOKEN_2 = {
 // Inspired from https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.642949/tokens
 //
 
-export const SAMPLE_TOKEN_ASSOCIATIONS = {
-    "tokens": [{
-        "automatic_association": false,
-        "balance": 0,
-        "created_timestamp": SAMPLE_TOKEN_ASSOCIATE_TRANSACTION.consensus_timestamp,
-        "freeze_status": "UNFROZEN",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": SAMPLE_ASSOCIATED_TOKEN.token_id
-    }, {
-        "automatic_association": false,
-        "balance": 0,
-        "created_timestamp": "1671648712.150557003",
-        "freeze_status": "UNFROZEN",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": SAMPLE_ASSOCIATED_TOKEN_2.token_id
-    }],
-    "links": {
-        next: null
-    }
+export const SAMPLE_TOKEN_RELATIONSHIP_1 = {
+    "automatic_association": false,
+    "balance": 2342647909,
+    "created_timestamp": SAMPLE_TOKEN_ASSOCIATE_TRANSACTION.consensus_timestamp,
+    "freeze_status": "UNFROZEN",
+    "kyc_status": "NOT_APPLICABLE",
+    "token_id": SAMPLE_ASSOCIATED_TOKEN.token_id
 }
 
-export const SAMPLE_TOKEN_ASSOCIATIONS_2 = {
-    "tokens": [{
-        "automatic_association": false,
-        "balance": 2342647909,
-        "created_timestamp": SAMPLE_TOKEN_ASSOCIATE_TRANSACTION.consensus_timestamp,
-        "freeze_status": "UNFROZEN",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": SAMPLE_ASSOCIATED_TOKEN.token_id
-    }, {
-        "automatic_association": false,
-        "balance": 31669471,
-        "created_timestamp": "1671648712.150557003",
-        "freeze_status": "UNFROZEN",
-        "kyc_status": "NOT_APPLICABLE",
-        "token_id": SAMPLE_ASSOCIATED_TOKEN_2.token_id
-    }],
+export const SAMPLE_TOKEN_RELATIONSHIP_2 = {
+    "automatic_association": false,
+    "balance": 31669471,
+    "created_timestamp": "1671648712.150557003",
+    "freeze_status": "UNFROZEN",
+    "kyc_status": "NOT_APPLICABLE",
+    "token_id": SAMPLE_ASSOCIATED_TOKEN_2.token_id
+}
+
+export const SAMPLE_TOKEN_RELATIONSHIP_RESPONSE = {
+    "tokens": [
+        SAMPLE_TOKEN_RELATIONSHIP_1,
+        SAMPLE_TOKEN_RELATIONSHIP_2
+    ],
     "links": {
         next: null
     }

--- a/tests/unit/account/TokensSection.spec.ts
+++ b/tests/unit/account/TokensSection.spec.ts
@@ -29,7 +29,8 @@ import {
     SAMPLE_NONFUNGIBLE,
     SAMPLE_NONFUNGIBLE_DUDE,
     SAMPLE_PENDING_AIRDROPS,
-    SAMPLE_TOKEN_ASSOCIATIONS_2
+    SAMPLE_TOKEN_RELATIONSHIP_1,
+    SAMPLE_TOKEN_RELATIONSHIP_2
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
@@ -73,8 +74,14 @@ describe("TokensSection.vue", () => {
         mock.onGet(matcher4).reply(200, SAMPLE_ASSOCIATED_TOKEN)
         const matcher5 = "/api/v1/tokens/" + SAMPLE_ASSOCIATED_TOKEN_2.token_id
         mock.onGet(matcher5).reply(200, SAMPLE_ASSOCIATED_TOKEN_2)
-        const matcher6 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/tokens?limit=100"
-        mock.onGet(matcher6).reply(200, SAMPLE_TOKEN_ASSOCIATIONS_2)
+        const token1 = SAMPLE_TOKEN_RELATIONSHIP_1.token_id
+        const response1 = { tokens: [SAMPLE_TOKEN_RELATIONSHIP_1]}
+        const matcher6 = "/api/v1/accounts/" + accountId + "/tokens?token.id=" + token1 + "&limit=1"
+        mock.onGet(matcher6).reply(200, response1)
+        const token2 = SAMPLE_TOKEN_RELATIONSHIP_2.token_id
+        const response2 = { tokens: [SAMPLE_TOKEN_RELATIONSHIP_2]}
+        const matcher7 = "/api/v1/accounts/" + accountId + "/tokens?token.id=" + token2 + "&limit=1"
+        mock.onGet(matcher7).reply(200, response2)
 
         // For Pending Airdrops tab / NFTs sub-tab
         const matcher10 = `/api/v1/accounts/${accountId}/airdrops/pending`

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -53,8 +53,8 @@ import {
     SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS,
     SAMPLE_TOKEN,
     SAMPLE_TOKEN_ASSOCIATE_TRANSACTION,
-    SAMPLE_TOKEN_ASSOCIATIONS,
     SAMPLE_TOKEN_CALL_TRANSACTIONS,
+    SAMPLE_TOKEN_RELATIONSHIP_RESPONSE,
     SAMPLE_TRANSACTION,
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
@@ -786,7 +786,7 @@ describe("TransactionDetails.vue", () => {
             }
         });
         const matcher3 = "/api/v1/accounts/" + transaction.entity_id + "/tokens?limit=100"
-        mock.onGet(matcher3).reply(200, SAMPLE_TOKEN_ASSOCIATIONS);
+        mock.onGet(matcher3).reply(200, SAMPLE_TOKEN_RELATIONSHIP_RESPONSE);
         const matcher4 = "/api/v1/tokens/" + token1.token_id
         mock.onGet(matcher4).reply(200, token1);
         const matcher5 = "/api/v1/tokens/" + token2.token_id


### PR DESCRIPTION
**Description**:

- As a follow-up to #1448, fixes several issues related to Token Actions:
   - activation of REJECT only if connected to Hedera wallet and balance > 0
   - refresh tables after token actions are completed
- Replace use of (soon to be retired) TokenRelationshipCache by TokenAssociationCache

**Notes for reviewer**:

Deployed on staging server.