### PR TITLE
chore: App vue now uses <script setup>

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,14 +45,7 @@ import {useRoute} from "vue-router";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import CookiesDialog from "@/components/CookiesDialog.vue";
 import {AppStorage} from "@/AppStorage";
-
-export const XLARGE_BREAKPOINT = 1450
-export const LARGE_BREAKPOINT = 1280
-export const MEDIUM_BREAKPOINT = 1080
-export const SMALL_BREAKPOINT = 768
-export const FINAL_BREAKPOINT = 640
-
-export const ORUGA_MOBILE_BREAKPOINT = "1080px"
+import {LARGE_BREAKPOINT, MEDIUM_BREAKPOINT, SMALL_BREAKPOINT, XLARGE_BREAKPOINT} from "@/BreakPoints";
 
 export default defineComponent({
   name: 'App',

--- a/src/BreakPoints.ts
+++ b/src/BreakPoints.ts
@@ -1,0 +1,6 @@
+export const XLARGE_BREAKPOINT = 1450
+export const LARGE_BREAKPOINT = 1280
+export const MEDIUM_BREAKPOINT = 1080
+export const SMALL_BREAKPOINT = 768
+export const FINAL_BREAKPOINT = 640
+export const ORUGA_MOBILE_BREAKPOINT = "1080px"

--- a/src/BreakPoints.ts
+++ b/src/BreakPoints.ts
@@ -1,3 +1,23 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 export const XLARGE_BREAKPOINT = 1450
 export const LARGE_BREAKPOINT = 1280
 export const MEDIUM_BREAKPOINT = 1080

--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -94,7 +94,7 @@ import {ComputedRef, defineComponent, onBeforeUnmount, onMounted, PropType, Ref}
 import {Transaction} from "@/schemas/HederaSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import ContractName from "@/components/values/ContractName.vue";

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -115,7 +115,7 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TokenAmount from "@/components/values/TokenAmount.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {AccountTableController} from "@/components/account/AccountTableController";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";

--- a/src/components/account/BalanceTable.vue
+++ b/src/components/account/BalanceTable.vue
@@ -123,7 +123,7 @@
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {TokenBalance, TokenRelationship} from "@/schemas/HederaSchemas";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import {TokenRelationshipsTableController} from "@/components/account/TokenRelationshipsTableController";

--- a/src/components/account/CollectionTable.vue
+++ b/src/components/account/CollectionTable.vue
@@ -80,7 +80,7 @@
 
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {Nft} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import {CollectionTableController} from "@/components/account/CollectionTableController";

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -103,7 +103,7 @@
 
 import {onBeforeUnmount, onMounted, PropType, watch} from 'vue';
 import {Nft, Token, TokenBalance} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -116,7 +116,6 @@
 
 import {onBeforeUnmount, onMounted, PropType, watch} from 'vue';
 import {Nft, Token} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
@@ -125,6 +124,7 @@ import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 import {AppStorage} from "@/AppStorage";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/PendingFungibleAirdropTable.vue
+++ b/src/components/account/PendingFungibleAirdropTable.vue
@@ -111,7 +111,7 @@
 
 import {onBeforeUnmount, onMounted, PropType, watch} from 'vue';
 import {TokenAirdrop} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";

--- a/src/components/account/PendingNftAirdropTable.vue
+++ b/src/components/account/PendingNftAirdropTable.vue
@@ -117,7 +117,7 @@
 
 import {onBeforeUnmount, onMounted, PropType, watch} from 'vue';
 import {TokenAirdrop} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -88,7 +88,7 @@ import {computed, ComputedRef, defineComponent, onBeforeUnmount, onMounted, Prop
 import {Contract} from "@/schemas/HederaSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import ContractName from "@/components/values/ContractName.vue";
 import {VerifiedContractsController} from "@/components/contract/VerifiedContractsController";

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -92,7 +92,7 @@
 
 import {computed, ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {CryptoAllowance} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {HbarAllowanceTableController} from "@/components/allowances/HbarAllowanceTableController";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -97,7 +97,7 @@
 
 import {computed, ComputedRef, defineComponent, inject, PropType, ref, Ref, watch} from 'vue';
 import {NftAllowance} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -101,7 +101,7 @@
 
 import {computed, ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {Nft} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -101,7 +101,7 @@
 import {computed, ComputedRef, defineComponent, inject, PropType, ref, Ref, watch} from 'vue';
 import {TokenAllowance} from "@/schemas/HederaSchemas";
 import {isValidAssociation} from "@/schemas/HederaUtils";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -109,7 +109,7 @@ import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {Block} from '@/schemas/HederaSchemas';
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import {BlockTableController} from "@/components/block/BlockTableController";

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -94,7 +94,7 @@ import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";

--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -117,7 +117,7 @@
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref} from "vue";
 import {ContractAction} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import Property from "@/components/Property.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";

--- a/src/components/contract/ContractActionsTable.vue
+++ b/src/components/contract/ContractActionsTable.vue
@@ -115,7 +115,7 @@
 
 import {computed, defineComponent, inject, PropType} from 'vue';
 import {ContractAction} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import ContractActionDetails from "@/components/contract/ContractActionDetails.vue";

--- a/src/components/contract/ContractResultStates.vue
+++ b/src/components/contract/ContractResultStates.vue
@@ -96,7 +96,7 @@
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref, Ref, watch} from 'vue';
 import DashboardCard from "@/components/DashboardCard.vue";
 import {ContractResultStateChange} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache";
 import ContractResultStateChangeEntry from "@/components/contract/ContractResultStateChangeEntry.vue";
 import {AppStorage} from "@/AppStorage";

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -97,7 +97,7 @@
 
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {ContractResult} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {ContractResultTableController} from "@/components/contract/ContractResultTableController";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -90,7 +90,7 @@ import {Contract} from "@/schemas/HederaSchemas";
 import {routeManager} from "@/router";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {ContractTableController} from "@/components/contract/ContractTableController";
 import ContractName from "@/components/values/ContractName.vue";

--- a/src/components/contract/ContractTransactionTable.vue
+++ b/src/components/contract/ContractTransactionTable.vue
@@ -94,7 +94,7 @@ import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableControllerXL} from "@/components/transaction/TransactionTableControllerXL";
 

--- a/src/components/dashboard/ContractCallTransactionTable.vue
+++ b/src/components/dashboard/ContractCallTransactionTable.vue
@@ -88,7 +88,7 @@ import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";

--- a/src/components/dashboard/CryptoTransactionTable.vue
+++ b/src/components/dashboard/CryptoTransactionTable.vue
@@ -87,7 +87,7 @@ import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
 import {routeManager} from "@/router";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";

--- a/src/components/dashboard/MessageTransactionTable.vue
+++ b/src/components/dashboard/MessageTransactionTable.vue
@@ -86,7 +86,7 @@ import {ComputedRef, defineComponent, PropType, Ref} from 'vue';
 import {Transaction} from "@/schemas/HederaSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import TopicIOL from "@/components/values/link/TopicIOL.vue";

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -140,7 +140,7 @@
 
 import {defineComponent, inject, onBeforeUnmount, onMounted, PropType} from 'vue';
 import {NetworkNode} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import StakeRange from "@/components/node/StakeRange.vue";

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -88,7 +88,7 @@ import {StakingReward} from '@/schemas/HederaSchemas';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import {StakingRewardsTableController} from "@/components/staking/StakingRewardsTableController";

--- a/src/components/token/FixedFeeTable.vue
+++ b/src/components/token/FixedFeeTable.vue
@@ -65,7 +65,7 @@
 import {defineComponent, PropType} from 'vue';
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";

--- a/src/components/token/FractionalFeeTable.vue
+++ b/src/components/token/FractionalFeeTable.vue
@@ -75,7 +75,7 @@ import {defineComponent, PropType} from 'vue';
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {FractionAmount} from "@/schemas/HederaSchemas";
 import StringValue from "@/components/values/StringValue.vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -116,7 +116,7 @@
 
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {Nft} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {NftHolderTableController} from "@/components/token/NftHolderTableController";
 import {routeManager} from "@/router";

--- a/src/components/token/RoyaltyFeeTable.vue
+++ b/src/components/token/RoyaltyFeeTable.vue
@@ -70,7 +70,7 @@
 import {defineComponent, PropType} from 'vue';
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {FractionAmount} from "@/schemas/HederaSchemas";
 import StringValue from "@/components/values/StringValue.vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer";

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -87,7 +87,7 @@ import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {TokenDistribution} from "@/schemas/HederaSchemas";
 import {routeManager} from "@/router";
 import TokenAmount from "@/components/values/TokenAmount.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TokenBalanceTableController} from "@/components/token/TokenBalanceTableController";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";

--- a/src/components/token/TokenCustomFees.vue
+++ b/src/components/token/TokenCustomFees.vue
@@ -90,7 +90,7 @@ import {defineComponent, inject, PropType} from 'vue';
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import DashboardCard from "@/components/DashboardCard.vue";
 import Property from "@/components/Property.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import FixedFeeTable from "@/components/token/FixedFeeTable.vue";
 import FractionalFeeTable from "@/components/token/FractionalFeeTable.vue";
 import RoyaltyFeeTable from "@/components/token/RoyaltyFeeTable.vue";

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -86,7 +86,7 @@
 import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {routeManager} from "@/router";
 import {Token} from "@/schemas/HederaSchemas";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TokenTableController} from "@/components/token/TokenTableController";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -85,7 +85,7 @@
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
 import {Token} from '@/schemas/HederaSchemas';
 import {routeManager} from "@/router";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -85,7 +85,7 @@
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
 import {Token} from '@/schemas/HederaSchemas';
 import {routeManager} from "@/router";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -95,7 +95,7 @@ import {ComputedRef, defineComponent, inject, PropType, Ref} from 'vue';
 import {TopicMessageTableController} from "@/components/topic/TopicMessageTableController";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TopicMessage} from "@/schemas/HederaSchemas";
 import {routeManager} from "@/router";

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -83,7 +83,7 @@ import {Transaction} from "@/schemas/HederaSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";
 import BlobValue from "@/components/values/BlobValue.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import TopicIOL from "@/components/values/link/TopicIOL.vue";

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -94,7 +94,7 @@ import TimestampValue from "@/components/values/TimestampValue.vue"
 import TransactionLabel from "@/components/values/TransactionLabel.vue"
 import {makeTypeLabel} from "@/utils/TransactionTools"
 import {routeManager} from "@/router"
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue"
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue"
 import InnerSenderEVMAddress from "@/components/values/InnerSenderEVMAddress.vue"
 import {NftTransactionTableController} from "./NftTransactionTableController"

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -88,7 +88,7 @@ import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
-import {ORUGA_MOBILE_BREAKPOINT} from '@/App.vue';
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 
 export default defineComponent({

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -105,7 +105,7 @@ import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";
-import {ORUGA_MOBILE_BREAKPOINT} from "@/App.vue";
+import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {TransactionTableControllerXL} from "@/components/transaction/TransactionTableControllerXL";
 import EmptyTable from "@/components/EmptyTable.vue";
 import InnerSenderEVMAddress from "@/components/values/InnerSenderEVMAddress.vue";

--- a/src/pages/MobileMenu.vue
+++ b/src/pages/MobileMenu.vue
@@ -102,7 +102,7 @@
 
 import {defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
 import router, {routeManager} from "@/router";
-import {MEDIUM_BREAKPOINT} from "@/App.vue";
+import {MEDIUM_BREAKPOINT} from "@/BreakPoints";
 import Footer from "@/components/Footer.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 

--- a/src/pages/MobileSearch.vue
+++ b/src/pages/MobileSearch.vue
@@ -48,7 +48,7 @@
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
 import {useRoute} from "vue-router";
 import router from "@/router";
-import {MEDIUM_BREAKPOINT} from "@/App.vue";
+import {MEDIUM_BREAKPOINT} from "@/BreakPoints";
 import SearchBarV2 from "@/components/search/SearchBarV2.vue";
 import Footer from "@/components/Footer.vue";
 


### PR DESCRIPTION
**Description**:

With changes below, `App` view now uses `<script setup>` syntax / layout.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
