### PR TITLE
chore: generalized usage of RouteManager.currentNetwork and currentNetworkEntry

### DIFF
--- a/src/components/account/UpdateAccountDialog.vue
+++ b/src/components/account/UpdateAccountDialog.vue
@@ -299,7 +299,7 @@ import {WalletDriverCancelError, WalletDriverError} from "@/utils/wallet/WalletD
 import {AccountInfo, makeNodeSelectorDescription} from "@/schemas/HederaSchemas";
 import DialogButton from "@/components/dialog/DialogButton.vue";
 import CommitButton from "@/components/dialog/CommitButton.vue";
-import router, {walletManager} from "@/router";
+import {routeManager, walletManager} from "@/router";
 import Dialog from "@/components/dialog/Dialog.vue";
 import {AccountUpdateTransaction} from "@hashgraph/sdk";
 import {inputEntityID} from "@/utils/InputUtils";
@@ -324,7 +324,7 @@ const props = defineProps({
 
 const emit = defineEmits(["updated"])
 
-const network = router.currentRoute.value.params.network as string
+const network = routeManager.currentNetwork.value
 const nr = networkRegistry
 
 const autoRenewPeriodFeedbackMessage = ref<string | null>(null)

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -223,7 +223,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType, ref, watch} from "vue";
-import router, {walletManager} from "@/router";
+import router, {routeManager, walletManager} from "@/router";
 import {EntityID} from "@/utils/EntityID";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
@@ -282,7 +282,7 @@ export default defineComponent({
 
   setup(props, context) {
     const nr = networkRegistry
-    const network = router.currentRoute.value.params.network as string
+    const network = routeManager.currentNetwork.value
 
     const selectedSpender = ref<string | null>(null)
     const normalizedSpender = computed(() => EntityID.normalize(nr.stripChecksum(selectedSpender.value ?? "")))

--- a/src/components/dashboard/HbarMarketDashboard.vue
+++ b/src/components/dashboard/HbarMarketDashboard.vue
@@ -82,8 +82,8 @@
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
 import DashboardItem from "@/components/dashboard/DashboardItem.vue";
-import {NetworkRegistry, networkRegistry} from "@/schemas/NetworkRegistry";
-import router from "@/router";
+import {NetworkRegistry} from "@/schemas/NetworkRegistry";
+import {routeManager} from "@/router";
 import {HederaMetricsLoader} from "@/components/dashboard/metrics/HederaMetricsLoader";
 
 export default defineComponent({
@@ -96,17 +96,9 @@ export default defineComponent({
     const isSmallScreen = inject('isSmallScreen', true)
     const isLargeScreen = inject('isLargeScreen', true)
 
-    const isMainNetwork = computed(() => router.currentRoute.value.params.network == NetworkRegistry.MAIN_NETWORK)
+    const isMainNetwork = computed(() => routeManager.currentNetwork.value == NetworkRegistry.MAIN_NETWORK)
 
-    const currentNetworkDisplayName = computed(() => {
-      let displayName
-      if (Array.isArray(router.currentRoute.value.params.network)) {
-        displayName = networkRegistry.lookup(router.currentRoute.value.params.network[0])?.displayName
-      } else {
-        displayName = networkRegistry.lookup(router.currentRoute.value.params.network)?.displayName
-      }
-      return displayName
-    })
+    const currentNetworkDisplayName = computed(() => routeManager.currentNetworkEntry.value.displayName)
 
     const hbarPriceLabel = 'HBAR PRICE'
     const hbarMarketCapLabel = 'HBAR MARKET CAP'

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -186,7 +186,7 @@ import axios from "axios";
 import {EntityID} from "@/utils/EntityID";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import router from "@/router";
+import {routeManager} from "@/router";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import {isCouncilNode, makeDefaultNodeDescription} from "@/schemas/HederaUtils";
 
@@ -210,7 +210,7 @@ export default defineComponent({
   emits: ["changeStaking", "update:showDialog"],
   setup(props, context) {
     const accountId = computed(() => props.account?.account)
-    const network = router.currentRoute.value.params.network as string
+    const network = routeManager.currentNetwork.value
     const nr = networkRegistry
 
     const showConfirmDialog = ref(false)

--- a/src/components/token/TokenInfoAnalyzer.ts
+++ b/src/components/token/TokenInfoAnalyzer.ts
@@ -22,7 +22,7 @@ import {computed, Ref} from "vue";
 import {makeEthAddressForToken, makeTokenSymbol} from "@/schemas/HederaUtils";
 import {TokenInfo, TokenType} from "@/schemas/HederaSchemas";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import router, {walletManager} from "@/router";
+import {routeManager, walletManager} from "@/router";
 import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache";
 
 export class TokenInfoAnalyzer {
@@ -95,7 +95,7 @@ export class TokenInfoAnalyzer {
     public readonly tokenChecksum = computed(() =>
         this.tokenInfo.value?.token_id ? networkRegistry.computeChecksum(
             this.tokenInfo.value?.token_id,
-            router.currentRoute.value.params.network as string
+            routeManager.currentNetwork.value
         ) : null)
 
     public readonly associationStatus = computed(() => {

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -217,7 +217,7 @@ import Property from "@/components/Property.vue";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {ContractLocParser} from "@/utils/parser/ContractLocParser";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import router, {routeManager} from "@/router";
+import {routeManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import ContractByteCodeSection from "@/components/contract/ContractByteCodeSection.vue";
@@ -310,7 +310,7 @@ export default defineComponent({
     const accountChecksum = computed(() =>
         contractLocParser.contractId.value ? networkRegistry.computeChecksum(
             contractLocParser.contractId.value,
-            router.currentRoute.value.params.network as string
+            routeManager.currentNetwork.value
         ) : null)
 
     //

--- a/src/pages/MobileSearch.vue
+++ b/src/pages/MobileSearch.vue
@@ -46,8 +46,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
-import {useRoute} from "vue-router";
-import router from "@/router";
+import router, {routeManager} from "@/router";
 import {MEDIUM_BREAKPOINT} from "@/BreakPoints";
 import SearchBarV2 from "@/components/search/SearchBarV2.vue";
 import Footer from "@/components/Footer.vue";
@@ -62,13 +61,8 @@ export default defineComponent({
   setup() {
     const isSmallScreen = inject('isSmallScreen', true)
     const isTouchDevice = inject('isTouchDevice', false)
-    const route = useRoute()
-    const network = computed(() => {
-      return route.params.network
-    })
-    const name = computed(() => {
-      return route.query.from
-    })
+    const network = routeManager.currentNetwork
+    const name = routeManager.previousRoute
 
     const selectedNetwork = ref(network.value)
     watch(selectedNetwork, (selection) => {

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -133,7 +133,7 @@ import NotificationBanner from "@/components/NotificationBanner.vue";
 import {EntityID} from "@/utils/EntityID";
 import {TopicMessageTableController} from "@/components/topic/TopicMessageTableController";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import router from "@/router";
+import {routeManager} from "@/router";
 import {TopicByIdCache} from "@/utils/cache/TopicByIdCache";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import Property from "@/components/Property.vue";
@@ -182,7 +182,7 @@ export default defineComponent({
     const topicChecksum = computed(() =>
         normalizedTopicId.value ? networkRegistry.computeChecksum(
             normalizedTopicId.value,
-            router.currentRoute.value.params.network as string
+            routeManager.currentNetwork.value
         ) : null)
 
     const notification = computed(() => {

--- a/src/utils/parser/AccountLocParser.ts
+++ b/src/utils/parser/AccountLocParser.ts
@@ -26,7 +26,7 @@ import {AccountAlias} from "@/utils/AccountAlias";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {AccountBalanceTransactions, Key, TokenBalance} from "@/schemas/HederaSchemas";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import router from "@/router";
+import router, {routeManager} from "@/router";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import {makeEthAddressForAccount} from "@/schemas/HederaUtils";
 import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
@@ -100,7 +100,7 @@ export class AccountLocParser {
     public readonly accountChecksum: ComputedRef<string | null> = computed(() =>
         this.accountId.value ? networkRegistry.computeChecksum(
             this.accountId.value,
-            router.currentRoute.value.params.network as string
+            routeManager.currentNetwork.value
         ) : null)
 
     public readonly balance: ComputedRef<number | null> = computed(() => this.accountInfo.value?.balance?.balance ?? null)

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -30,6 +30,7 @@ import DashboardCard from "@/components/DashboardCard.vue";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
+import {routeManager} from "../../src/router";
 
 /*
     Bookmarks
@@ -71,6 +72,7 @@ describe("App.vue", () => {
             {name: "customnet2", url: "/testurl2", ledgerID: "02", sourcifySetup: null},
             {name: "customnet3", url: "/testurl3", ledgerID: "03", sourcifySetup: null}
         ]);
+        expect(routeManager.currentNetwork.value).toBe("mainnet")
 
         const wrapper = mount(App, {
             global: {
@@ -80,6 +82,8 @@ describe("App.vue", () => {
         });
 
         await flushPromises()
+        expect(routeManager.currentNetwork.value).toBe("customnet1")
+
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
@@ -100,7 +104,7 @@ describe("App.vue", () => {
         expect(cards[2].text()).toMatch(RegExp("^HCS Messages"))
 
         const logos = wrapper.findAll("img")
-        expect(logos.length).toBe(16)
+        expect(logos.length).toBe(14)
         expect(logos[0].attributes('alt')).toBe("")
         expect(logos[1].attributes('alt')).toBe("wallet logo")
         expect(logos[2].attributes('alt')).toBe("wallet logo")
@@ -110,13 +114,11 @@ describe("App.vue", () => {
         expect(logos[6].attributes('alt')).toBe("Modal close icon")
         expect(logos[7].attributes('alt')).toBe("Product Logo")
         expect(logos[8].attributes('alt')).toBe("Modal close icon")
-        expect(logos[9].attributes('alt')).toBe("Trend Up")
-        expect(logos[10].attributes('alt')).toBe("Trend Up")
+        expect(logos[9].attributes('alt')).toBe("Pause")
+        expect(logos[10].attributes('alt')).toBe("Pause")
         expect(logos[11].attributes('alt')).toBe("Pause")
-        expect(logos[12].attributes('alt')).toBe("Pause")
-        expect(logos[13].attributes('alt')).toBe("Pause")
-        expect(logos[14].attributes('alt')).toBe("Built On Hedera")
-        expect(logos[15].attributes('alt')).toBe("Sponsor Logo")
+        expect(logos[12].attributes('alt')).toBe("Built On Hedera")
+        expect(logos[13].attributes('alt')).toBe("Sponsor Logo")
 
         mock.restore()
         wrapper.unmount()

--- a/tests/unit/utils/AccountLocParser.spec.ts
+++ b/tests/unit/utils/AccountLocParser.spec.ts
@@ -35,7 +35,7 @@ describe("AccountLocParser.ts", () => {
 
     const SAMPLE_ACCOUNT_ALIAS_HEX = AccountAlias.parse(SAMPLE_ACCOUNT.alias)!.toHexString()
     const SAMPLE_ACCOUNT_ADDRESS = makeEthAddressForAccount(SAMPLE_ACCOUNT as AccountInfo)
-    const SAMPLE_ACCOUNT_CHECKSUM = "irkir"
+    const SAMPLE_ACCOUNT_CHECKSUM = "zxthk"
 
     //
     // mount + set/unset account loc + unmount

--- a/tests/unit/utils/analyzer/TokenInfoAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/TokenInfoAnalyzer.spec.ts
@@ -107,7 +107,7 @@ describe("TokenInfoAnalyzer.spec.ts", () => {
         expect(analyzer.fractionalFees.value).toStrictEqual(SAMPLE_ASSOCIATED_TOKEN.custom_fees.fractional_fees)
         expect(analyzer.royaltyFees.value).toBeUndefined()
         expect(analyzer.customFees.value).toStrictEqual(SAMPLE_ASSOCIATED_TOKEN.custom_fees)
-        expect(analyzer.tokenChecksum.value).toBe("ehfmb")
+        expect(analyzer.tokenChecksum.value).toBe("vnoku")
         expect(analyzer.associationStatus.value).toBe(TokenAssociationStatus.Unknown)
 
         // 4) Connect wallet => walletManager.accountId becomes not null
@@ -126,7 +126,7 @@ describe("TokenInfoAnalyzer.spec.ts", () => {
         expect(analyzer.fractionalFees.value).toStrictEqual(SAMPLE_ASSOCIATED_TOKEN.custom_fees.fractional_fees)
         expect(analyzer.royaltyFees.value).toBeUndefined()
         expect(analyzer.customFees.value).toStrictEqual(SAMPLE_ASSOCIATED_TOKEN.custom_fees)
-        expect(analyzer.tokenChecksum.value).toBe("ehfmb")
+        expect(analyzer.tokenChecksum.value).toBe("vnoku")
         expect(analyzer.associationStatus.value).toBe(TokenAssociationStatus.Associated)
 
         // 5) Disconnect wallet => walletManager.accountId becomes null
@@ -145,7 +145,7 @@ describe("TokenInfoAnalyzer.spec.ts", () => {
         expect(analyzer.fractionalFees.value).toStrictEqual(SAMPLE_ASSOCIATED_TOKEN.custom_fees.fractional_fees)
         expect(analyzer.royaltyFees.value).toBeUndefined()
         expect(analyzer.customFees.value).toStrictEqual(SAMPLE_ASSOCIATED_TOKEN.custom_fees)
-        expect(analyzer.tokenChecksum.value).toBe("ehfmb")
+        expect(analyzer.tokenChecksum.value).toBe("vnoku")
         expect(analyzer.associationStatus.value).toBe(TokenAssociationStatus.Unknown)
 
         // 6) Unset token info


### PR DESCRIPTION
**Description**:

Changes below make sure that `RouteManager.currentNetwork` and `RouteManager.currentNetworkEntr`y are used in all the places where they should be.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
