### PR TITLE
chore: moved some routines from NetworkManager to HederaUtils

### DIFF
--- a/src/components/account/UpdateAccountDialog.vue
+++ b/src/components/account/UpdateAccountDialog.vue
@@ -293,7 +293,7 @@
 
 import {computed, onBeforeUnmount, onMounted, PropType, ref, watch, WatchStopHandle} from "vue";
 import {DialogController, DialogMode} from "@/components/dialog/DialogController";
-import {isCouncilNode, waitForTransactionRefresh} from "@/schemas/HederaUtils";
+import {extractChecksum, isCouncilNode, stripChecksum, waitForTransactionRefresh} from "@/schemas/HederaUtils";
 import {TransactionID} from "@/utils/TransactionID";
 import {WalletDriverCancelError, WalletDriverError} from "@/utils/wallet/WalletDriverError";
 import {AccountInfo, makeNodeSelectorDescription} from "@/schemas/HederaSchemas";
@@ -585,10 +585,10 @@ const validateAccount = async () => {
   }
 }
 const stakedAccountEntity = computed(() =>
-    EntityID.normalize(nr.stripChecksum(stakedAccount.value ?? ""))
+    EntityID.normalize(stripChecksum(stakedAccount.value ?? ""))
 )
 const stakedAccountChecksum = computed(() =>
-    nr.extractChecksum(stakedAccount.value ?? "")
+    extractChecksum(stakedAccount.value ?? "")
 )
 const isStakedAccountValid = ref<boolean>(false)
 const isStakingValid = computed(() =>

--- a/src/components/allowances/ApproveAllowanceDialog.vue
+++ b/src/components/allowances/ApproveAllowanceDialog.vue
@@ -223,7 +223,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType, ref, watch} from "vue";
-import router, {routeManager, walletManager} from "@/router";
+import {routeManager, walletManager} from "@/router";
 import {EntityID} from "@/utils/EntityID";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
@@ -233,10 +233,11 @@ import {WalletDriverCancelError, WalletDriverError} from "@/utils/wallet/WalletD
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {
+  extractChecksum,
   formatTokenAmount,
   isOwnedSerials,
   isValidAssociation,
-  makeTokenName,
+  makeTokenName, stripChecksum,
   waitForTransactionRefresh
 } from "@/schemas/HederaUtils";
 import {inputAmount, inputEntityID, inputIntList} from "@/utils/InputUtils";
@@ -285,12 +286,12 @@ export default defineComponent({
     const network = routeManager.currentNetwork.value
 
     const selectedSpender = ref<string | null>(null)
-    const normalizedSpender = computed(() => EntityID.normalize(nr.stripChecksum(selectedSpender.value ?? "")))
+    const normalizedSpender = computed(() => EntityID.normalize(stripChecksum(selectedSpender.value ?? "")))
 
     const selectedHbarAmount = ref<string | null>(null)
 
     const selectedToken = ref<string | null>(null)
-    const normalizedToken = computed(() => EntityID.normalize(nr.stripChecksum(selectedToken.value ?? "")))
+    const normalizedToken = computed(() => EntityID.normalize(stripChecksum(selectedToken.value ?? "")))
     const tokenInfoLookup = TokenInfoCache.instance.makeLookup(normalizedToken)
     onMounted(() => tokenInfoLookup.mount())
     onBeforeUnmount(() => tokenInfoLookup.unmount())
@@ -312,7 +313,7 @@ export default defineComponent({
     )
 
     const selectedNft = ref<string | null>(null)
-    const normalizedNFT = computed(() => EntityID.normalize(nr.stripChecksum(selectedNft.value ?? "")))
+    const normalizedNFT = computed(() => EntityID.normalize(stripChecksum(selectedNft.value ?? "")))
     const nftInfoLookup = TokenInfoCache.instance.makeLookup(normalizedNFT)
     onMounted(() => nftInfoLookup.mount())
     onBeforeUnmount(() => nftInfoLookup.unmount())
@@ -465,7 +466,7 @@ export default defineComponent({
 
     const validateSpender = async () => {
       isSpenderValid.value = false
-      const checksum = nr.extractChecksum(selectedSpender.value ?? "")
+      const checksum = extractChecksum(selectedSpender.value ?? "")
       const isValidChecksum = checksum ? nr.isValidChecksum(normalizedSpender.value ?? "", checksum, network) : true
 
       if (normalizedSpender.value === null) {
@@ -499,7 +500,7 @@ export default defineComponent({
     const validateToken = async () => {
       isTokenValid.value = false
 
-      const checksum = nr.extractChecksum(selectedToken.value ?? "")
+      const checksum = extractChecksum(selectedToken.value ?? "")
       const isValidChecksum = checksum ? nr.isValidChecksum(normalizedToken.value ?? "", checksum, network) : true
 
       if (normalizedToken.value === null) {
@@ -535,7 +536,7 @@ export default defineComponent({
     const validateNft = async () => {
       isNftValid.value = false
 
-      const checksum = nr.extractChecksum(selectedNft.value ?? "")
+      const checksum = extractChecksum(selectedNft.value ?? "")
       const isValidChecksum = checksum ? nr.isValidChecksum(normalizedNFT.value ?? "", checksum, network) : true
 
       if (normalizedNFT.value === null) {

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -188,7 +188,7 @@ import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
 import {routeManager} from "@/router";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
-import {isCouncilNode, makeDefaultNodeDescription} from "@/schemas/HederaUtils";
+import {extractChecksum, isCouncilNode, makeDefaultNodeDescription, stripChecksum} from "@/schemas/HederaUtils";
 
 const VALID_ACCOUNT_MESSAGE = "Rewards will now be paid to that account"
 const UNKNOWN_ACCOUNT_MESSAGE = "This account does not exist"
@@ -252,9 +252,9 @@ export default defineComponent({
 
     const selectedAccount = ref<string | null>(null)
     const selectedAccountEntity = computed(
-        () => EntityID.normalize(nr.stripChecksum(selectedAccount.value ?? "")))
+        () => EntityID.normalize(stripChecksum(selectedAccount.value ?? "")))
     const selectedAccountChecksum = computed(
-        () => nr.extractChecksum(selectedAccount.value ?? ""))
+        () => extractChecksum(selectedAccount.value ?? ""))
     const isSelectedAccountValid = ref(false)
     const inputFeedbackMessage = ref<string | null>(null)
 
@@ -325,7 +325,7 @@ export default defineComponent({
 
     const handleConfirmChange = () => {
       const stakedNode = isNodeSelected.value ? selectedNode.value : null
-      const stakedAccount = isAccountSelected.value ? nr.stripChecksum(selectedAccount.value ?? "") : null
+      const stakedAccount = isAccountSelected.value ? stripChecksum(selectedAccount.value ?? "") : null
       const declineReward = declineChoice.value != props.account?.decline_reward ? declineChoice.value : null;
       context.emit("changeStaking", stakedNode, stakedAccount, declineReward)
     }
@@ -352,7 +352,7 @@ export default defineComponent({
             isValidInput = false
             break
           } else {
-            isValidID = EntityID.parse(nr.stripChecksum(value)) !== null
+            isValidID = EntityID.parse(stripChecksum(value)) !== null
           }
         } else if (c === '-') {
           if (!isValidID || isPastDash) {

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -486,3 +486,70 @@ export async function drainContractResultsLogs(r: ContractResultsLogResponse, li
     }
     return result
 }
+
+//
+// From https://github.com/hashgraph/hedera-improvement-proposal/blob/master/assets/hip-15/HIP-15-javascript.html
+//
+// Given a ledger ID and an address like "0.0.123", return a checksum like "vfmkw" . The address must be in no-checksum
+// format, with no extra characters (so not "0.0.00123" or "==0.0.123==" or "0.0.123-vfmkw"). The algorithm is defined
+// by the HIP-15 standard to be:
+//
+// a = a valid no-checksum address string, such as 0.0.123
+// d = int array for the digits of a (using 10 to represent "."), so 0.0.123 is [0,10,0,10,1,2,3]
+// h = unsigned byte array containing the ledger ID followed by 6 zero bytes
+// p3 = 26 * 26 * 26
+// p5 = 26 * 26 * 26 * 26 * 26
+// sd0 = (d[0] + d[2] + d[4] + d[6] + ...) mod 11
+// sd1 = (d[1] + d[3] + d[5] + d[7] + ...) mod 11
+// sd = (...((((d[0] * 31) + d[1]) * 31) + d[2]) * 31 + ... ) * 31 + d[d.length-1]) mod p3
+// sh = (...(((h[0] * 31) + h[1]) * 31) + h[2]) * 31 + ... ) * 31 + h[h.length-1]) mod p5
+// c = (((d.length mod 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh ) mod p5
+// cp = (c * 1000003) mod p5
+// checksum = cp, written as 5 digits in base 26, using a-z
+//
+//in ports to other languages, answer can be a string, digits an int32[] and the rest int32 (or uint32[] and uint32)
+
+export function hip15checksum(ledgerId: string, addr: string) {
+    let answer = "";
+    const d = [];      //digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3] *** FIX ***
+    let sd0 = 0;      //sum of even positions (mod 11)
+    let sd1 = 0;      //sum of odd positions (mod 11)
+    let sd = 0;       //weighted sum of all positions (mod p3)
+    let sh = 0;      //hash of the ledger ID
+    let cp: number;       //the checksum, as a single number
+    const p3 = 26 * 26 * 26;           //3 digits in base 26
+    const p5 = 26 * 26 * 26 * 26 * 26; //5 digits in base 26
+    const ascii_a = "a".charCodeAt(0);  //97  *** FIX ***
+    const m = 1_000_003; //min prime greater than a million. Used for the final permutation.
+    const w = 31; //sum s of digit values weights them by powers of w. Should be coprime to p5.
+
+    let id = ledgerId + "000000000000";
+    const h = []; // *** FIX ***
+    if (id.length % 2 == 1) id = "0" + id;
+    for (let i = 0; i < id.length; i += 2) {  // *** FIX ***
+        h.push(parseInt(id.substr(i, 2), 16));
+    }
+    for (let i = 0; i < addr.length; i++) {
+        d.push(addr[i] == "." ? 10 : parseInt(addr[i], 10));
+    }
+    for (let i = 0; i < d.length; i++) {
+        sd = (w * sd + d[i]) % p3;
+        if (i % 2 == 0) {
+            sd0 = (sd0 + d[i]) % 11;
+        } else {
+            sd1 = (sd1 + d[i]) % 11;
+        }
+    }
+    for (let i = 0; i < h.length; i++) {
+        sh = (w * sh + h[i]) % p5;
+    }
+    const c = ((((addr.length % 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh) % p5;  //the checksum, before the final permutation
+    cp = (c * m) % p5;
+
+    for (let i = 0; i < 5; i++) {
+        answer = String.fromCharCode(ascii_a + (cp % 26)) + answer;
+        cp /= 26;
+    }
+
+    return answer;
+}

--- a/src/schemas/HederaUtils.ts
+++ b/src/schemas/HederaUtils.ts
@@ -553,3 +553,13 @@ export function hip15checksum(ledgerId: string, addr: string) {
 
     return answer;
 }
+
+export function stripChecksum(address: string): string {
+    const dash = address.indexOf('-')
+    return dash != -1 ? address.substring(0, dash) : address
+}
+
+export function extractChecksum(address: string): string | null {
+    const dash = address.indexOf('-')
+    return dash != -1 ? address.substring(dash + 1) : null
+}

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -22,6 +22,7 @@ import {EntityID} from "@/utils/EntityID";
 import axios from "axios";
 import {ref, Ref} from "vue";
 import {EthereumAddress} from "@/utils/EthereumAddress";
+import {hip15checksum} from "@/schemas/HederaUtils";
 
 declare global {
     interface Window {
@@ -235,7 +236,7 @@ export class NetworkRegistry {
 
     public computeChecksum(id: string, network: string): string {
         const ledgerID = this.lookup(network)?.ledgerID
-        return NetworkRegistry.checksum(ledgerID ?? 'FF', id)
+        return hip15checksum(ledgerID ?? 'FF', id)
     }
 
     public stripChecksum(address: string): string {
@@ -281,73 +282,6 @@ export class NetworkRegistry {
         }
 
         return result
-    }
-
-    //
-    // From https://github.com/hashgraph/hedera-improvement-proposal/blob/master/assets/hip-15/HIP-15-javascript.html
-    //
-    // Given a ledger ID and an address like "0.0.123", return a checksum like "vfmkw" . The address must be in no-checksum
-    // format, with no extra characters (so not "0.0.00123" or "==0.0.123==" or "0.0.123-vfmkw"). The algorithm is defined
-    // by the HIP-15 standard to be:
-    //
-    // a = a valid no-checksum address string, such as 0.0.123
-    // d = int array for the digits of a (using 10 to represent "."), so 0.0.123 is [0,10,0,10,1,2,3]
-    // h = unsigned byte array containing the ledger ID followed by 6 zero bytes
-    // p3 = 26 * 26 * 26
-    // p5 = 26 * 26 * 26 * 26 * 26
-    // sd0 = (d[0] + d[2] + d[4] + d[6] + ...) mod 11
-    // sd1 = (d[1] + d[3] + d[5] + d[7] + ...) mod 11
-    // sd = (...((((d[0] * 31) + d[1]) * 31) + d[2]) * 31 + ... ) * 31 + d[d.length-1]) mod p3
-    // sh = (...(((h[0] * 31) + h[1]) * 31) + h[2]) * 31 + ... ) * 31 + h[h.length-1]) mod p5
-    // c = (((d.length mod 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh ) mod p5
-    // cp = (c * 1000003) mod p5
-    // checksum = cp, written as 5 digits in base 26, using a-z
-    //
-    //in ports to other languages, answer can be a string, digits an int32[] and the rest int32 (or uint32[] and uint32)
-
-    private static checksum(ledgerId: string, addr: string) {
-        let answer = "";
-        const d = [];      //digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3] *** FIX ***
-        let sd0 = 0;      //sum of even positions (mod 11)
-        let sd1 = 0;      //sum of odd positions (mod 11)
-        let sd = 0;       //weighted sum of all positions (mod p3)
-        let sh = 0;      //hash of the ledger ID
-        let cp: number;       //the checksum, as a single number
-        const p3 = 26 * 26 * 26;           //3 digits in base 26
-        const p5 = 26 * 26 * 26 * 26 * 26; //5 digits in base 26
-        const ascii_a = "a".charCodeAt(0);  //97  *** FIX ***
-        const m = 1_000_003; //min prime greater than a million. Used for the final permutation.
-        const w = 31; //sum s of digit values weights them by powers of w. Should be coprime to p5.
-
-        let id = ledgerId + "000000000000";
-        const h = []; // *** FIX ***
-        if (id.length % 2 == 1) id = "0" + id;
-        for (let i = 0; i < id.length; i += 2) {  // *** FIX ***
-            h.push(parseInt(id.substr(i, 2), 16));
-        }
-        for (let i = 0; i < addr.length; i++) {
-            d.push(addr[i] == "." ? 10 : parseInt(addr[i], 10));
-        }
-        for (let i = 0; i < d.length; i++) {
-            sd = (w * sd + d[i]) % p3;
-            if (i % 2 == 0) {
-                sd0 = (sd0 + d[i]) % 11;
-            } else {
-                sd1 = (sd1 + d[i]) % 11;
-            }
-        }
-        for (let i = 0; i < h.length; i++) {
-            sh = (w * sh + h[i]) % p5;
-        }
-        const c = ((((addr.length % 5) * 11 + sd0) * 11 + sd1) * p3 + sd + sh) % p5;  //the checksum, before the final permutation
-        cp = (c * m) % p5;
-
-        for (let i = 0; i < 5; i++) {
-            answer = String.fromCharCode(ascii_a + (cp % 26)) + answer;
-            cp /= 26;
-        }
-
-        return answer;
     }
 }
 

--- a/src/schemas/NetworkRegistry.ts
+++ b/src/schemas/NetworkRegistry.ts
@@ -239,16 +239,6 @@ export class NetworkRegistry {
         return hip15checksum(ledgerID ?? 'FF', id)
     }
 
-    public stripChecksum(address: string): string {
-        const dash = address.indexOf('-')
-        return dash != -1 ? address.substring(0, dash) : address
-    }
-
-    public extractChecksum(address: string): string | null {
-        const dash = address.indexOf('-')
-        return dash != -1 ? address.substring(dash + 1) : null
-    }
-
     public makeAddressWithChecksum(address: string, network: string): string | null {
         const entity = EntityID.normalize(address)
         return entity ? (entity + '-' + this.computeChecksum(entity, network)) : null

--- a/src/utils/InputUtils.ts
+++ b/src/utils/InputUtils.ts
@@ -19,7 +19,7 @@
  */
 
 import {EntityID} from "@/utils/EntityID";
-import {networkRegistry} from "@/schemas/NetworkRegistry";
+import {stripChecksum} from "@/schemas/HederaUtils";
 
 export function inputEntityID(event: Event, entityID: string | null): string | null {
     let result: string | null
@@ -37,7 +37,7 @@ export function inputEntityID(event: Event, entityID: string | null): string | n
                 break
             } else {
                 isPreviousDigit = true
-                isValidID = EntityID.parse(networkRegistry.stripChecksum(value),true) !== null
+                isValidID = EntityID.parse(stripChecksum(value),true) !== null
             }
         } else if (c === '.') {
             pastDots++

--- a/src/utils/parser/AccountLocParser.ts
+++ b/src/utils/parser/AccountLocParser.ts
@@ -26,7 +26,7 @@ import {AccountAlias} from "@/utils/AccountAlias";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {AccountBalanceTransactions, Key, TokenBalance} from "@/schemas/HederaSchemas";
 import {networkRegistry} from "@/schemas/NetworkRegistry";
-import router, {routeManager} from "@/router";
+import {routeManager} from "@/router";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import {makeEthAddressForAccount} from "@/schemas/HederaUtils";
 import {base32ToAlias, byteToHex} from "@/utils/B64Utils";


### PR DESCRIPTION
**Description**:

Changes below move `checksum()`, `extractChecksum()` and `stripChecksum()` methods from `NetworkManager` to `HederaUtils` (those methods don't rely on `NetworkManager.this`).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
