### PR TITLE
chore: update account without staking

### DIFF
--- a/networks-config-example.json
+++ b/networks-config-example.json
@@ -55,6 +55,10 @@
     "displayName": "LOCAL NODE",
     "url": "http://127.0.0.1:5551",
     "ledgerID": "FF",
+    "enableWallet": true,
+    "enableStaking": false,
+    "enableExpiry": false,
+    "enableMarket": false,
     "sourcifySetup": {
       "activate": true,
       "repoURL": "http://localhost:10000/contracts/",

--- a/src/components/account/UpdateAccountDialog.vue
+++ b/src/components/account/UpdateAccountDialog.vue
@@ -136,94 +136,96 @@
         <o-switch class="ml-2 h-is-text-size-4" v-model="recSigRequired"/>
       </div>
 
-      <hr class="mt-2 mb-3" style="height: 1px; background: var(--h-theme-background-color);"/>
+      <template v-if="enableStaking">
+        <hr class="mt-2 mb-3" style="height: 1px; background: var(--h-theme-background-color);"/>
 
-      <div class="has-text-weight-light mb-2">
-        Staking
-      </div>
-      <div class="radios h-is-text-size-4">
-        <label class="radio h-radio-button">
-          <input type="radio" name="stakeTarget" :value="StakeChoice.StakeToNode" v-model="stakeChoice"/>
-          To Node
-        </label>
-        <label class="radio h-radio-button ml-5">
-          <input type="radio" name="stakeTarget" :value="StakeChoice.StakeToAccount" v-model="stakeChoice"/>
-          To Account
-        </label>
-        <label class="radio h-radio-button ml-5">
-          <input type="radio" name="stakeTarget" :value="StakeChoice.NotStaking" v-model="stakeChoice"/>
-          Not Staking
-        </label>
-      </div>
-
-      <div class="mb-4"/>
-
-      <template v-if="stakeChoice===StakeChoice.StakeToNode">
-        <div class="has-text-weight-light mb-1">
-          Staked Node ID
+        <div class="has-text-weight-light mb-2">
+          Staking
         </div>
-        <o-select v-model="stakedNode"
-                  class="is-small has-text-white"
-                  style=" height: 38px; border-radius: 2px; border-width: 1px; border-color: grey;
-                    background-color: var(--h-theme-page-background-color);"
-        >
-          <optgroup label="Hedera council nodes">
-            <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
-                    style="background-color: var(--h-theme-page-background-color)"
-                    v-show="isCouncilNode(n)"
-            >
-              {{ makeNodeSelectorDescription(n) }}
-            </option>
-          </optgroup>
-          <optgroup v-if="networkAnalyzer.hasCommunityNode.value" label="Community nodes">
-            <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
-                    style="background-color: var(--h-theme-page-background-color)"
-                    v-show="!isCouncilNode(n)"
-            >
-              {{ makeNodeSelectorDescription(n) }}
-            </option>
-          </optgroup>
-        </o-select>
-
-      </template>
-
-      <template v-if="stakeChoice===StakeChoice.StakeToAccount">
-        <div class="has-text-weight-light mb-1">
-          Staked Account ID
+        <div class="radios h-is-text-size-4">
+          <label class="radio h-radio-button">
+            <input type="radio" name="stakeTarget" :value="StakeChoice.StakeToNode" v-model="stakeChoice"/>
+            To Node
+          </label>
+          <label class="radio h-radio-button ml-5">
+            <input type="radio" name="stakeTarget" :value="StakeChoice.StakeToAccount" v-model="stakeChoice"/>
+            To Account
+          </label>
+          <label class="radio h-radio-button ml-5">
+            <input type="radio" name="stakeTarget" :value="StakeChoice.NotStaking" v-model="stakeChoice"/>
+            Not Staking
+          </label>
         </div>
-        <div class="is-flex is-align-items-center">
-          <input :value="stakedAccount"
-                 class="input input-field is-small has-text-white"
-                 placeholder="Account ID (0.0.1234)"
-                 type="text"
-                 @input="event => onStakedAccountInput(event)"
-          >
-          <div class="icon is-small ml-2">
-            <i v-if="isStakedAccountValid" class="fas fa-check has-text-success"/>
-            <i v-else-if="stakedAccountFeedbackMessage" class="fas fa-xmark has-text-danger"/>
-            <i v-else/>
+
+        <div class="mb-4"/>
+
+        <template v-if="stakeChoice===StakeChoice.StakeToNode">
+          <div class="has-text-weight-light mb-1">
+            Staked Node ID
           </div>
+          <o-select v-model="stakedNode"
+                    class="is-small has-text-white"
+                    style=" height: 38px; border-radius: 2px; border-width: 1px; border-color: grey;
+                    background-color: var(--h-theme-page-background-color);"
+          >
+            <optgroup label="Hedera council nodes">
+              <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
+                      style="background-color: var(--h-theme-page-background-color)"
+                      v-show="isCouncilNode(n)"
+              >
+                {{ makeNodeSelectorDescription(n) }}
+              </option>
+            </optgroup>
+            <optgroup v-if="networkAnalyzer.hasCommunityNode.value" label="Community nodes">
+              <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
+                      style="background-color: var(--h-theme-page-background-color)"
+                      v-show="!isCouncilNode(n)"
+              >
+                {{ makeNodeSelectorDescription(n) }}
+              </option>
+            </optgroup>
+          </o-select>
+
+        </template>
+
+        <template v-if="stakeChoice===StakeChoice.StakeToAccount">
+          <div class="has-text-weight-light mb-1">
+            Staked Account ID
+          </div>
+          <div class="is-flex is-align-items-center">
+            <input :value="stakedAccount"
+                   class="input input-field is-small has-text-white"
+                   placeholder="Account ID (0.0.1234)"
+                   type="text"
+                   @input="event => onStakedAccountInput(event)"
+            >
+            <div class="icon is-small ml-2">
+              <i v-if="isStakedAccountValid" class="fas fa-check has-text-success"/>
+              <i v-else-if="stakedAccountFeedbackMessage" class="fas fa-xmark has-text-danger"/>
+              <i v-else/>
+            </div>
+          </div>
+        </template>
+
+        <template v-if="stakeChoice===StakeChoice.NotStaking">
+          <div class="is-invisible mb-1">
+            Filler
+          </div>
+          <div class="input-field is-invisible" style="width: 560px">
+            Filler
+          </div>
+        </template>
+
+        <div class="mb-4"/>
+
+        <div class="is-flex is-align-items-center is-justify-content-space-between"
+             :class="{'is-invisible':stakeChoice !== StakeChoice.StakeToNode}">
+          <div class="is-flex has-text-weight-light mb-1">
+            Decline Rewards
+          </div>
+          <o-switch class="ml-2 h-is-text-size-4" v-model="declineRewards"/>
         </div>
       </template>
-
-      <template v-if="stakeChoice===StakeChoice.NotStaking">
-        <div class="is-invisible mb-1">
-          Filler
-        </div>
-        <div class="input-field is-invisible" style="width: 560px">
-          Filler
-        </div>
-      </template>
-
-      <div class="mb-4"/>
-
-      <div class="is-flex is-align-items-center is-justify-content-space-between"
-           :class="{'is-invisible':stakeChoice !== StakeChoice.StakeToNode}">
-        <div class="is-flex has-text-weight-light mb-1">
-          Decline Rewards
-        </div>
-        <o-switch class="ml-2 h-is-text-size-4" v-model="declineRewards"/>
-      </div>
 
       <div class="mb-4"/>
 
@@ -324,9 +326,9 @@ const props = defineProps({
 
 const emit = defineEmits(["updated"])
 
+const enableStaking = routeManager.enableStaking
 const network = routeManager.currentNetwork.value
 const nr = NetworkConfig.inject()
-
 const autoRenewPeriodFeedbackMessage = ref<string | null>(null)
 const maxAutoAssociationsFeedbackMessage = ref<string | null>(null)
 const stakedAccountFeedbackMessage = ref<string | null>(null)

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -3236,7 +3236,7 @@ export const SAMPLE_NETWORK_NODES = {
             "memo": "0.0.3",
             "node_id": 0,
             "node_account_id": "0.0.3",
-            "node_cert_hash": "0xffd6ada74a3a34a9",
+            "node_cert_hash": "0xa171e3ba83476747aeb2e2ac4d0e115caaab918203b0dfe1cdeab443438fc289abc8ba8a6aff83db5f1b334046da88c8",
             "public_key": "0x308201a2300d0609",
             "reward_rate_start": 2740,
             "service_endpoints": [
@@ -3278,7 +3278,7 @@ export const SAMPLE_NETWORK_NODES = {
             "memo": "0.0.4",
             "node_id": 1,
             "node_account_id": "0.0.4",
-            "node_cert_hash": "0xffd6ada74a3a34a9",
+            "node_cert_hash": "0x7409dec2e494b627ee49c69b294be1ceaebca3fdcaf36789e88fc7d5b0eef5561f52b82d35191a39c2fbed6027267166",
             "public_key": "0x308201a2300d0609",
             "reward_rate_start": 5479,
             "service_endpoints": [
@@ -3307,7 +3307,7 @@ export const SAMPLE_NETWORK_NODES = {
             "memo": "0.0.5",
             "node_id": 2,
             "node_account_id": "0.0.5",
-            "node_cert_hash": "0xffd6ada74a3a34a9",
+            "node_cert_hash": "0x9b1416584a4a380bb86a6c7d7207d8aeddbc3b63ea305998255bce8351ba4b5dca52c9282a54a6bed60de63ce03aaa24",
             "public_key": "0x308201a2300d0609",
             "reward_rate_start": 8219,
             "service_endpoints": [

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -24,18 +24,7 @@ import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import router from "@/router";
 import axios from "axios";
-import AccountDetails from "@/pages/AccountDetails.vue";
-import {
-    SAMPLE_ACCOUNT,
-    SAMPLE_ACCOUNT_BALANCES,
-    SAMPLE_ACCOUNT_DUDE,
-    SAMPLE_NETWORK_NODES,
-    SAMPLE_NETWORK_STAKE,
-    SAMPLE_NONFUNGIBLE,
-    SAMPLE_TOKEN,
-    SAMPLE_TOKEN_DUDE,
-    SAMPLE_TRANSACTIONS
-} from "../Mocks";
+import {SAMPLE_NETWORK_NODES, SAMPLE_NETWORK_STAKE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
@@ -102,7 +91,7 @@ describe("NodeDetails.vue", () => {
         expect(wrapper.get("#fileValue").text()).toBe("0.0.102")
         expect(wrapper.get("#rangeFromValue").text()).toBe("4:10:06.0411 PMJun 6, 2022, UTC")
         expect(wrapper.get("#rangeToValue").text()).toBe("None")
-        expect(wrapper.get("#nodeCertHashValue").text()).toBe("d317 df77 a69d 6bbe 1add adf8 6bCopy")
+        expect(wrapper.get("#nodeCertHashValue").text()).toBe("d316 b5ef 57b7 6daf 37e3 bebb e3b6 9e6f 67b6 69ce 1dd1 ed75 e5c6 9a69 bf75 f36d 376f 475f 7b57 1d79 a6f8 e37e 37f1 f736 f3d6 9b73 c6da f1ae 9a7d ff37 75be 5fd5 bdf7 e34e 3a75 af3c 73Copy")
         expect(wrapper.get("#serviceEndpointsValue").text()).toBe("3.211.248.172:502113.211.248.172:5021235.231.208.148:035.231.208.148:5021135.231.208.148:50212")
 
         expect(wrapper.get("#yearlyRate").text()).toBe("Last Period Reward Rate1%APPROX ANNUAL EQUIVALENT")
@@ -121,136 +110,52 @@ describe("NodeDetails.vue", () => {
         await flushPromises()
     });
 
-    it("Should update when account id changes", async () => {
+    it("should update when node id changes", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios);
 
-        const account1 = SAMPLE_ACCOUNT
-        let matcher1 = "/api/v1/accounts/" + account1.account
-        mock.onGet(matcher1).reply(200, account1);
+        let node = 0
+        const matcher1 = "api/v1/network/nodes"
+        mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
 
-        const matcher2 = "/api/v1/transactions"
-        mock.onGet(matcher2).reply(200, SAMPLE_TRANSACTIONS);
+        const matcher2 = "api/v1/network/stake"
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
 
-        const token1 = SAMPLE_TOKEN
-        let matcher3 = "/api/v1/tokens/" + token1.token_id
-        mock.onGet(matcher3).reply(200, token1);
-
-        const nft = SAMPLE_NONFUNGIBLE
-        const matcher4 = "/api/v1/tokens/" + nft.token_id
-        mock.onGet(matcher4).reply(200, nft);
-
-        const matcher5 = "/api/v1/balances"
-        mock.onGet(matcher5).reply(200, SAMPLE_ACCOUNT_BALANCES);
-
-        let matcher8 = "/api/v1/accounts/" + account1.account + "/rewards"
-        mock.onGet(matcher8).reply(200, {rewards: []})
-
-        let matcher9 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/crypto"
-        mock.onGet(matcher9).reply(200, {rewards: []})
-
-        let matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/tokens"
-        mock.onGet(matcher10).reply(200, {rewards: []})
-
-        let matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/allowances/nfts"
-        mock.onGet(matcher11).reply(200, {nfts: []})
-
-        let matcher12 = "api/v1/tokens"
-        mock.onGet(matcher12).reply(200, { tokens: [] });
-
-        let matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/nfts"
-        mock.onGet(matcher13).reply(200, { nfts: [] });
-
-        const wrapper = mount(AccountDetails, {
+        const wrapper = mount(NodeDetails, {
             global: {
                 plugins: [router, Oruga]
             },
             props: {
-                accountId: SAMPLE_ACCOUNT.account ?? undefined
-            },
+                nodeId: node.toString()
+            }
         });
+
         await flushPromises()
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch("AccountAccount ID:" + SAMPLE_ACCOUNT.account)
-        expect(wrapper.get("#keyValue").text()).toBe(
-            "aa2f 7b3e 759f 4531 ec2e 7941 afa4 49e6 a6e6 10ef b52a dae8 9e9c d8e9 d40d dcbf" +
-            "Copy" +
-            "ED25519")
+        expect(wrapper.text()).toMatch(RegExp("^Node " + node))
+        expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.3")
+        expect(wrapper.get("#descriptionValue").text()).toBe("Hosted by Hedera | East Coast, USA")
+        expect(wrapper.get("#nodeCertHashValue").text()).toBe("d316 b5ef 57b7 6daf 37e3 bebb e3b6 9e6f 67b6 69ce 1dd1 ed75 e5c6 9a69 bf75 f36d 376f 475f 7b57 1d79 a6f8 e37e 37f1 f736 f3d6 9b73 c6da f1ae 9a7d ff37 75be 5fd5 bdf7 e34e 3a75 af3c 73Copy")
 
-        const account2 = SAMPLE_ACCOUNT_DUDE
-        matcher1 = "/api/v1/accounts/" + account2.account
-        mock.onGet(matcher1).reply(200, account2);
-
-        matcher9 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/crypto"
-        mock.onGet(matcher9).reply(200, {rewards: []})
-
-        matcher10 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/tokens"
-        mock.onGet(matcher10).reply(200, {rewards: []})
-
-        matcher11 = "/api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/allowances/nfts"
-        mock.onGet(matcher11).reply(200, {nfts: []})
-
-        matcher12 = "api/v1/tokens"
-        mock.onGet(matcher12).reply(200, { tokens: [] });
-
-        matcher13 = "api/v1/accounts/" + SAMPLE_ACCOUNT_DUDE.account + "/nfts"
-        mock.onGet(matcher13).reply(200, { nfts: [] });
-
-        const token2 = SAMPLE_TOKEN_DUDE
-        matcher3 = "/api/v1/tokens/" + token2.token_id
-        mock.onGet(matcher3).reply(200, token2);
-
-        matcher8 = "/api/v1/accounts/" + account2.account + "/rewards"
-        mock.onGet(matcher8).reply(200, {rewards: []})
-
+        node = 1
         await wrapper.setProps({
-            accountId: SAMPLE_ACCOUNT_DUDE.account ?? undefined
+            nodeId: node.toString()
         })
         await flushPromises()
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toMatch("AccountAccount ID:" + SAMPLE_ACCOUNT_DUDE.account)
-        expect(wrapper.get("#keyValue").text()).toBe(
-            "38f1 ea46 0e95 d97e ea13 aefa c760 eaf9 9015 4b80 a360 8ab0 1d4a 2649 44d6 8746" +
-            "Copy" +
-            "ED25519")
-        expect(wrapper.get("#memoValue").text()).toBe("Account Dude Memo in clear")
-        expect(wrapper.find("#aliasValue").exists()).toBe(false)
-        expect(wrapper.get("#expiresAtValue").text()).toBe("3:33:21.4109 AMApr 11, 2022, UTC")
-        expect(wrapper.get("#autoRenewPeriodValue").text()).toBe("77d 3h 40min")
-        expect(wrapper.get("#maxAutoAssociationValue").text()).toBe("Unlimited Auto Associations")
-        expect(wrapper.get("#receiverSigRequiredValue").text()).toBe("true")
+        expect(wrapper.text()).toMatch(RegExp("^Node " + node))
+        expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.4")
+        expect(wrapper.get("#descriptionValue").text()).toBe("Hosted by Hedera | East Coast, USA")
+        expect(wrapper.get("#nodeCertHashValue").text()).toBe("d31e f8d3 d75e 7367 b8f7 86fa dbb7 9ee3 d73a f5bd bde1 b7b5 71e6 9e6d c6b7 7dd7 1a7f 7ebb f3d7 bcf1 f73b 7796 f479 e7f9 e7ad 5fe7 66fc d9dd f9d7 dd5a dfd7 367d b79d eb4d bbdb aef5 ebCopy")
 
         mock.restore()
         wrapper.unmount()
         await flushPromises()
     });
 
-    it("Should detect invalid account ID", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
-
-        const invalidAccountId = "0.0.0.1000"
-        const wrapper = mount(AccountDetails, {
-            global: {
-                plugins: [router, Oruga]
-            },
-            props: {
-                accountId: invalidAccountId
-            },
-        });
-        await flushPromises()
-        // console.log(wrapper.html())
-        // console.log(wrapper.text())
-
-        expect(wrapper.get("#notificationBanner").text()).toBe("Invalid account ID, address or alias: " + invalidAccountId)
-
-        wrapper.unmount()
-        await flushPromises()
-    });
 });


### PR DESCRIPTION
**Description**:

- follow-up to PR #1485: disable editing properties related to staking when the current network configuration does not have enableStaking = true.
- (unrelated:) fix NodeDetails unit test (abusively copy-pasted from AccountDetails unit test)
