### PR TITLE
chore: cache the token metadata

### DIFF
--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -19,13 +19,13 @@
  */
 
 import {computed, ref, Ref, watch, WatchStopHandle} from "vue";
-import {TopicMessagesResponse} from "@/schemas/MirrorNodeSchemas";
 import {EntityID} from "@/utils/EntityID";
 import axios from "axios";
 import {Timestamp} from "@/utils/Timestamp";
 import {TopicMessageCache} from "@/utils/cache/TopicMessageCache";
 import {CID} from "multiformats";
 import {AssetCache} from "@/utils/cache/AssetCache.ts";
+import {LastTopicMessageByIdCache} from "@/utils/cache/LastTopicMessageByIdCache.ts";
 
 export interface NftAttribute {
     trait_type: string
@@ -295,12 +295,11 @@ export class TokenMetadataAnalyzer {
     private async readMetadataFromTopic(id: string): Promise<any> {
         // console.log(`readMetadataFromTopic: ${id}`)
         let result: any
-        const url = "api/v1/topics/" + id + "/messages?limit=1&order=desc"
         try {
-            const response = await axios.get<TopicMessagesResponse>(url)
+            const topicMessage = await LastTopicMessageByIdCache.instance.lookup(id)
             this.loadSuccessRef.value = true
-            if (response.data.messages && response.data.messages.length >= 0) {
-                result = JSON.parse(Buffer.from(response.data.messages[0].message, 'base64').toString())
+            if (topicMessage !== null) {
+                result = JSON.parse(Buffer.from(topicMessage.message, 'base64').toString())
             } else {
                 result = null
             }

--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -25,6 +25,7 @@ import axios from "axios";
 import {Timestamp} from "@/utils/Timestamp";
 import {TopicMessageCache} from "@/utils/cache/TopicMessageCache";
 import {CID} from "multiformats";
+import {AssetCache} from "@/utils/cache/AssetCache.ts";
 
 export interface NftAttribute {
     trait_type: string
@@ -46,7 +47,6 @@ export interface NftFile {
 export class TokenMetadataAnalyzer {
 
     private watchHandle: WatchStopHandle | null = null
-    private privateAxios = axios.create({timeout: 10000});
     private metadataContentRef = ref<any>(null)
 
     //
@@ -235,6 +235,8 @@ export class TokenMetadataAnalyzer {
     private async metadataDidChange(value: string | null): Promise<void> {
         const content = this.metadataContentRef
         const metadata = this.metadata
+        this.loadSuccessRef.value = false
+        this.loadErrorRef.value = false
 
         try {
             metadata.value = Buffer.from(value ?? '', 'base64').toString()
@@ -276,9 +278,8 @@ export class TokenMetadataAnalyzer {
         // console.log(`readMetadataFromUrl: ${url}`)
         let result: any
         try {
-            const response = await this.privateAxios.get(url)
+            result = await AssetCache.instance.lookup(url) as any
             this.loadSuccessRef.value = true
-            result = response.data ?? null
         } catch (reason) {
             console.warn(`Failed to read metadata from URL ${url} - error: ${reason}`)
             if (axios.isAxiosError(reason)) {
@@ -296,7 +297,7 @@ export class TokenMetadataAnalyzer {
         let result: any
         const url = "api/v1/topics/" + id + "/messages?limit=1&order=desc"
         try {
-            const response = await this.privateAxios.get<TopicMessagesResponse>(url)
+            const response = await axios.get<TopicMessagesResponse>(url)
             this.loadSuccessRef.value = true
             if (response.data.messages && response.data.messages.length >= 0) {
                 result = JSON.parse(Buffer.from(response.data.messages[0].message, 'base64').toString())

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -503,8 +503,8 @@ export interface Topic {
 // ---------------------------------------------------------------------------------------------------------------------
 
 export interface TopicMessagesResponse {
-    messages: Array<TopicMessage> | undefined
-    links: Links | undefined
+    messages: Array<TopicMessage>
+    links: Links
 }
 
 export interface TopicMessage {

--- a/src/utils/cache/AssetCache.ts
+++ b/src/utils/cache/AssetCache.ts
@@ -25,12 +25,15 @@ export class AssetCache extends EntityCache<string, unknown> {
 
     public static readonly instance = new AssetCache()
 
+    private static readonly AXIOS_TIMEOUT = 10000 // 10 sec. to leave reasonable time when querying IPFS asset
+    // private privateAxios = axios.create({timeout: AssetCache.AXIOS_TIMEOUT});
+
     //
     // Cache
     //
 
     protected async load(url: string): Promise<unknown> {
-        const response = await axios.get<unknown>(url)
+        const response = await axios.get<unknown>(url, {timeout: AssetCache.AXIOS_TIMEOUT})
         return Promise.resolve(response.data)
     }
 

--- a/src/utils/cache/LastTopicMessageByIdCache.ts
+++ b/src/utils/cache/LastTopicMessageByIdCache.ts
@@ -1,0 +1,53 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import {TopicMessage, TopicMessagesResponse} from "@/schemas/MirrorNodeSchemas";
+import axios from "axios";
+
+export class LastTopicMessageByIdCache extends EntityCache<string, TopicMessage | null> {
+
+    public static readonly instance = new LastTopicMessageByIdCache()
+
+    //
+    // Cache
+    //
+
+    protected async load(topicId: string): Promise<TopicMessage | null> {
+        let result: Promise<TopicMessage | null>
+        try {
+            const url = `api/v1/topics/${topicId}/messages?limit=1&order=desc`
+            const response = await axios.get<TopicMessagesResponse>(url)
+            if (response.data.messages.length >= 1) {
+                result = Promise.resolve(response.data.messages[0])
+            } else {
+                result = Promise.resolve(null)
+            }
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status == 404) {
+                result = Promise.resolve(null)
+            } else {
+                throw error
+            }
+        }
+        return result
+    }
+
+}


### PR DESCRIPTION
**Description**:

With these changes we make sure the various token metadata assets retrieved are cached. This includes:
- metadata obtained either directly from a HTTPS URL or from a CID (or URI) resolving into an URL
- metadata obtained from (the last message of) a Topic on the Hiero network (`LastTopicMessageByIdCache` is introduced to this end)
Note: We assume the caching of images is taken care of by the browser.

**Related issue(s)**:

No related issue but this is somehow a pre-requisite to the enhancement for #1396

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
