### PR TITLE
chore: refactor ipfs config and metadata retrieval

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,7 +31,7 @@ The following configuration parameters can be set in `core-config.json`:
 | `estimatorNotice`              | `string` | No estimator notice is displayed                                                  |                            |
 | `walletChooserDisclaimerPopup` | `string` | No wallet chooser disclaimer popup is displayed                                   |                            |
 | `googleTagID`                  | `string` | Google Tag is disabled                                                            |                            |
-| `ipfsGatewayUrlPrefix`         | `string` | Gateway `https://gateway.pinata.cloud/ipfs/` is used                              |                            |
+| `ipfsGatewayURL`               | `string` | Gateway `https://gateway.pinata.cloud/ipfs/` is used                              |                            |
 | `cryptoName`                   | `string` | `HBAR` is displayed                                                               |                            |
 | `cryptoSymbol`                 | `string` | `<span style="color: darkgrey">ℏ</span>` is displayed                             |                            |
 
@@ -100,8 +100,8 @@ This provides the global site tag ID to be used by Google Analytics. When specif
 dialog asking the user to agree to the use of cookies before proceeding with the application. The google tag ID will
 be actually used only if the user has agreed.
 
-### `ipfsGatewayUrlPrefix`
-This provides the URL prefix of the public IPFS gateway to use to resolve the IPFS URLs used in the token metadata.
+### `ipfsGatewayURL`
+This provides the URL of the public IPFS gateway to use to resolve the IPFS URIs (or CIDs) used in the token metadata.
 By default the Pinata public IPFS gateway is used.
 
 ### `cryptoName`

--- a/public/core-config.json
+++ b/public/core-config.json
@@ -13,7 +13,7 @@
   "estimatorNotice": null,
   "walletChooserDisclaimerPopup": null,
   "googleTagID": null,
-  "ipfsGatewayUrlPrefix": null,
+  "ipfsGatewayURL": null,
   "cryptoName": null,
   "cryptoSymbol": null
 }

--- a/src/components/token/NftCell.vue
+++ b/src/components/token/NftCell.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     onMounted(() => nftLookup.mount())
     onBeforeUnmount(() => nftLookup.unmount())
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayUrlPrefix
+    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
     const metadata = computed(() => nftLookup.entity.value?.metadata ?? '')
     const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix)
     onMounted(() => metadataAnalyzer.mount())

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -195,10 +195,10 @@ export default defineComponent({
       return result
     })
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayUrlPrefix
+    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
 
     const ipfsAddress = computed(() => {
-      if (decodedValue.value.startsWith("ipfs://") && decodedValue.value.length > 7) {
+      if (ipfsGatewayPrefix && decodedValue.value.startsWith("ipfs://") && decodedValue.value.length > 7) {
         return `${ipfsGatewayPrefix}${decodedValue.value.substring(7)}`
       }
       return null

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -25,21 +25,11 @@
 <template>
   <div class="should-wrap">
 
-    <template v-if="blobValue">
+    <template v-if="decodedValue">
 
-      <template v-if="isURL">
-        <span v-if="noAnchor">{{ blobValue }}</span>
-        <a v-else :href="blobValue">{{ blobValue }}</a>
-      </template>
-
-      <template v-else-if="decodedURL">
-        <span v-if="noAnchor">{{ decodedURL }}</span>
-        <a v-else :href="decodedURL.toString()">{{ decodedURL }}</a>
-      </template>
-
-      <template v-else-if="ipfsAddress">
+      <template v-if="decodedURL">
         <span v-if="noAnchor">{{ decodedValue }}</span>
-        <a v-else :href="ipfsAddress">{{ decodedValue }}</a>
+        <a v-else :href="decodedURL">{{ decodedValue }}</a>
       </template>
 
       <template v-else-if="jsonValue && isNaN(jsonValue)">
@@ -86,6 +76,7 @@
 import {computed, defineComponent, inject, PropType, ref} from "vue";
 import {initialLoadingKey} from "@/AppKeys";
 import {CoreConfig} from "@/config/CoreConfig";
+import {blob2URL} from "@/utils/URLUtils.ts";
 
 export default defineComponent({
   name: "BlobValue",
@@ -122,31 +113,9 @@ export default defineComponent({
     const windowWidth = inject('windowWidth', 1280)
     const initialLoading = inject(initialLoadingKey, ref(false))
 
-    const isURL = computed(() => {
-      let result: boolean
-      if (props.blobValue) {
-        try {
-          const url = new URL(props.blobValue)
-          result = url.protocol == "http:" || url.protocol == "https:"
-        } catch {
-          result = false
-        }
-      } else {
-        result = false
-      }
-      return result
-    })
+    const ipfsGateway = CoreConfig.inject().ipfsGatewayURL
 
-    const decodedURL = computed(() => {
-      if (decodedValue.value.startsWith("http://") || decodedValue.value.startsWith("https://")) {
-        try {
-          return new URL(decodedValue.value)
-        } catch {
-          return null
-        }
-      }
-      return null
-    })
+    const decodedURL = computed(() => blob2URL(decodedValue.value, ipfsGateway))
 
     const jsonValue = computed(() => {
       let result
@@ -165,7 +134,7 @@ export default defineComponent({
     const b64EncodingFound = computed(() => b64DecodedValue.value !== null)
 
     const b64DecodedValue = computed(() => {
-      let result: string|null
+      let result: string | null
       const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
       if (props.blobValue && props.base64 && base64regex.test(props.blobValue)) {
         try {
@@ -195,24 +164,13 @@ export default defineComponent({
       return result
     })
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
-
-    const ipfsAddress = computed(() => {
-      if (ipfsGatewayPrefix && decodedValue.value.startsWith("ipfs://") && decodedValue.value.length > 7) {
-        return `${ipfsGatewayPrefix}${decodedValue.value.substring(7)}`
-      }
-      return null
-    })
-
     return {
       isMediumScreen,
       windowWidth,
-      isURL,
       jsonValue,
       b64EncodingFound,
       decodedValue,
       initialLoading,
-      ipfsAddress,
       decodedURL
     }
   }

--- a/src/config/CoreConfig.ts
+++ b/src/config/CoreConfig.ts
@@ -98,8 +98,8 @@ export class CoreConfig {
         // Global site tag ID for Google Analytics
         public readonly googleTagID: string|null,
 
-        // The URL prefix of the IPFS gateway
-        public readonly ipfsGatewayUrlPrefix: string,
+        // The URL of the IPFS gateway
+        public readonly ipfsGatewayURL: string|null,
 
         // The HTML content used as crypto unit symbol
         public readonly cryptoName: string,
@@ -126,7 +126,7 @@ export class CoreConfig {
             fetchString(obj, "estimatorNotice"),
             fetchString(obj, "walletChooserDisclaimerPopup"),
             fetchString(obj, "googleTagID"),
-            fetchURL(obj, "ipfsGatewayUrlPrefix") ?? "https://gateway.pinata.cloud/ipfs/",
+            fetchURL(obj, "ipfsGatewayURL") ?? "https://gateway.pinata.cloud/ipfs/",
             fetchString(obj, "cryptoName") ?? "HBAR",
             fetchString(obj, "cryptoSymbol")
         )

--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -268,7 +268,7 @@ export default defineComponent({
     onMounted(() => nftLookup.mount())
     onBeforeUnmount(() => nftLookup.unmount())
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayUrlPrefix
+    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
     const metadata = computed(() => nftLookup.entity.value?.metadata ?? '')
     const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix)
     onMounted(() => metadataAnalyzer.mount())

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -421,7 +421,7 @@ export default defineComponent({
     onMounted(() => tokenAnalyzer.mount())
     onBeforeUnmount(() => tokenAnalyzer.unmount())
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayUrlPrefix
+    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
     const metadata = computed(() => tokenLookup.entity.value?.metadata ?? '')
     const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix)
     onMounted(() => metadataAnalyzer.mount())

--- a/src/utils/URLUtils.ts
+++ b/src/utils/URLUtils.ts
@@ -1,0 +1,86 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {EntityID} from "@/utils/EntityID";
+import {CID} from "multiformats";
+
+export function blob2URL(blob: string | null, ipfsGateway: string | null): string | null {
+
+    let result: string | null
+
+    if (blob !== null) {
+        if (isSecureURL(blob)) {
+            result = blob
+        } else if (ipfsGateway && blob.startsWith('ipfs://') && blob.length > 7) {
+            result = `${ipfsGateway}${blob.substring(7)}`
+        } else if (ipfsGateway && isIPFSHash(blob)) {
+            result = `${ipfsGateway}${blob}`
+        } else {
+            result = null
+        }
+    } else {
+        result = null
+    }
+    return result
+}
+
+export function blob2Topic(blob: string | null): string | null {
+    let result: string | null
+    let id: string
+
+    if (blob !== null) {
+        if (blob.startsWith('hcs://') && blob.length > 6) {
+            const i = blob.lastIndexOf('/');
+            id = blob.substring(i + 1);
+        } else {
+            id = blob
+        }
+        if (EntityID.parse(id) !== null) {
+            result = id
+        } else {
+            result = null
+        }
+    } else {
+        result = null
+    }
+    return result
+}
+
+export function isSecureURL(blob: string): boolean {
+    let isValid: boolean
+    try {
+        const url = new URL(blob)
+        isValid = url.protocol == "https:"
+    } catch {
+        isValid = false
+    }
+    return isValid
+}
+
+export function isIPFSHash(blob: string): boolean {
+    let isValid: boolean
+    try {
+        CID.parse(blob)
+        isValid = true
+    } catch {
+        isValid = false
+    }
+    return isValid
+}

--- a/tests/unit/values/BlobValue.spec.ts
+++ b/tests/unit/values/BlobValue.spec.ts
@@ -237,15 +237,14 @@ describe("BlobValue.vue", () => {
         expect(wrapper.find("a").attributes("href")).toBe(BLOB_URL)
 
         const encodedUrl = btoa(BLOB_URL)
-        const resultingUrl = (new URL(BLOB_URL)).toString()
 
         await wrapper.setProps({
             blobValue: encodedUrl,
             base64: true
         })
 
-        expect(wrapper.find("a").text()).toBe(resultingUrl)
-        expect(wrapper.find("a").attributes("href")).toBe(resultingUrl)
+        expect(wrapper.find("a").text()).toBe(BLOB_URL)
+        expect(wrapper.find("a").attributes("href")).toBe(BLOB_URL)
 
         wrapper.unmount()
         await flushPromises()
@@ -266,7 +265,7 @@ describe("BlobValue.vue", () => {
         const wrapper = mount(BlobValue, {
             global: {
                 plugins: [router],
-                provide: { [coreConfigKey]: CoreConfig.FALLBACK }
+                provide: {[coreConfigKey]: CoreConfig.FALLBACK}
             },
             props: {
                 blobValue: encodedUrl,


### PR DESCRIPTION
**Description**:

- rename `CoreConfig.ipfsGatewayUrlPrefix` to `CoreConfig.ipfsGatewayURL` 
- Although the implementation now checks for `CoreConfig.ipfsGatewayURL = null`, the default value for this parameter remains `https://gateway.pinata.cloud/ipfs/` for the time being.
- refactor `TokenMetadataAnalyzer` such that logic to retrieve assets from attributes values is a bit more modular and shared.
- refactor BlobValue to reuse some of the above.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
