### PR TITLE
feat: support NFT metadata stored on Arweave

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -32,7 +32,7 @@ The following configuration parameters can be set in `core-config.json`:
 | `walletChooserDisclaimerPopup` | `string` | No wallet chooser disclaimer popup is displayed                                   |                            |
 | `googleTagID`                  | `string` | Google Tag is disabled                                                            |                            |
 | `ipfsGatewayURL`               | `string` | Gateway `https://gateway.pinata.cloud/ipfs/` is used                              |                            |
-| `arweaveServerURL`             | `string` | No server is configured                                                           |                            |
+| `arweaveServerURL`             | `string` | The `https://arweave.net/` URL is used                                            |                            |
 | `cryptoName`                   | `string` | `HBAR` is displayed                                                               |                            |
 | `cryptoSymbol`                 | `string` | `<span style="color: darkgrey">ℏ</span>` is displayed                             |                            |
 
@@ -107,7 +107,7 @@ By default the Pinata public IPFS gateway is used.
 
 ### `arweaveServerURL`
 This provides the URL of the Arweave server used to resolve to use to resolve the Arweave URIs (or CIDs) found in the token metadata.
-By default no server is configured -- i.e. these URIs/CIDs are not resolved.
+By default the `https://arweave.net/` URL is used.
 
 ### `cryptoName`
 This provides the name of the crypto, as a replacement of the default name which is 'HBAR'.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -32,6 +32,7 @@ The following configuration parameters can be set in `core-config.json`:
 | `walletChooserDisclaimerPopup` | `string` | No wallet chooser disclaimer popup is displayed                                   |                            |
 | `googleTagID`                  | `string` | Google Tag is disabled                                                            |                            |
 | `ipfsGatewayURL`               | `string` | Gateway `https://gateway.pinata.cloud/ipfs/` is used                              |                            |
+| `arweaveServerURL`             | `string` | No server is configured                                                           |                            |
 | `cryptoName`                   | `string` | `HBAR` is displayed                                                               |                            |
 | `cryptoSymbol`                 | `string` | `<span style="color: darkgrey">ℏ</span>` is displayed                             |                            |
 
@@ -101,8 +102,12 @@ dialog asking the user to agree to the use of cookies before proceeding with the
 be actually used only if the user has agreed.
 
 ### `ipfsGatewayURL`
-This provides the URL of the public IPFS gateway to use to resolve the IPFS URIs (or CIDs) used in the token metadata.
+This provides the URL of the public IPFS gateway to use to resolve the IPFS URIs (or CIDs) found in the token metadata.
 By default the Pinata public IPFS gateway is used.
+
+### `arweaveServerURL`
+This provides the URL of the Arweave server used to resolve to use to resolve the Arweave URIs (or CIDs) found in the token metadata.
+By default no server is configured -- i.e. these URIs/CIDs are not resolved.
 
 ### `cryptoName`
 This provides the name of the crypto, as a replacement of the default name which is 'HBAR'.

--- a/public/core-config.json
+++ b/public/core-config.json
@@ -14,6 +14,7 @@
   "walletChooserDisclaimerPopup": null,
   "googleTagID": null,
   "ipfsGatewayURL": null,
+  "arweaveServerURL": null,
   "cryptoName": null,
   "cryptoSymbol": null
 }

--- a/src/components/MediaContent.vue
+++ b/src/components/MediaContent.vue
@@ -64,7 +64,7 @@
           class="media-content"
           :style="contentStyle"
           :autoplay="auto"
-          :controls="!auto"
+          :controls="!auto && size >= 100"
           loop
           @error="onLoadError"
           @loadeddata="onLoadSuccess"

--- a/src/components/token/NftCell.vue
+++ b/src/components/token/NftCell.vue
@@ -91,9 +91,12 @@ export default defineComponent({
     onMounted(() => nftLookup.mount())
     onBeforeUnmount(() => nftLookup.unmount())
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
+    const coreConfig = CoreConfig.inject()
+    const ipfsGatewayPrefix = coreConfig.ipfsGatewayURL
+    const arweaveServerURL = coreConfig.arweaveServerURL
+
     const metadata = computed(() => nftLookup.entity.value?.metadata ?? '')
-    const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix)
+    const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix, arweaveServerURL)
     onMounted(() => metadataAnalyzer.mount())
     onBeforeUnmount(() => metadataAnalyzer.unmount())
 

--- a/src/components/token/NftPreview.vue
+++ b/src/components/token/NftPreview.vue
@@ -28,7 +28,7 @@
       :url="url"
       :type="type"
       :size="size"
-      :auto="true"
+      :auto="auto"
       :no-anchor="noAnchor"
       @on-load-error="onLoadError"
   >

--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -54,10 +54,12 @@ export class TokenMetadataAnalyzer {
 
     public readonly rawMetadata: Ref<string>
     public readonly ipfsGatewayPrefix: string | null
+    public readonly arweaveServer: string | null
 
-    public constructor(rawMetadata: Ref<string>, ipfsGatewayPrefix: string | null) {
+    public constructor(rawMetadata: Ref<string>, ipfsGatewayPrefix: string | null, arweaveServer: string | null) {
         this.rawMetadata = rawMetadata
         this.ipfsGatewayPrefix = ipfsGatewayPrefix
+        this.arweaveServer = arweaveServer
     }
 
     public mount(): void {
@@ -153,7 +155,7 @@ export class TokenMetadataAnalyzer {
         if (Array.isArray(files)) {
             for (const file of files) {
                 if (file.uri && file.type) { // both required by HIP-412
-                    const url = blob2URL(file.uri, this.ipfsGatewayPrefix) ?? file.uri
+                    const url = blob2URL(file.uri, this.ipfsGatewayPrefix, this.arweaveServer) ?? file.uri
                     result.push({
                         uri: file.uri,
                         url: url,
@@ -190,7 +192,7 @@ export class TokenMetadataAnalyzer {
     public imageUrl = computed<string | null>(
         () => {
             const uri = this.getProperty('image') ?? this.getProperty(('picture'))
-            return blob2URL(uri, this.ipfsGatewayPrefix) ?? uri
+            return blob2URL(uri, this.ipfsGatewayPrefix, this.arweaveServer) ?? uri
         })
 
     //
@@ -234,7 +236,7 @@ export class TokenMetadataAnalyzer {
         }
 
         if (metadata.value !== null) {
-            const url = blob2URL(metadata.value, this.ipfsGatewayPrefix)
+            const url = blob2URL(metadata.value, this.ipfsGatewayPrefix, this.arweaveServer)
             if (url !== null) {
                 content.value = await this.readMetadataFromUrl(url)
             } else {

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -113,9 +113,11 @@ export default defineComponent({
     const windowWidth = inject('windowWidth', 1280)
     const initialLoading = inject(initialLoadingKey, ref(false))
 
-    const ipfsGateway = CoreConfig.inject().ipfsGatewayURL
+    const coreConfig = CoreConfig.inject()
+    const ipfsGateway = coreConfig.ipfsGatewayURL
+    const arweaveServer = coreConfig.arweaveServerURL
 
-    const decodedURL = computed(() => blob2URL(decodedValue.value, ipfsGateway))
+    const decodedURL = computed(() => blob2URL(decodedValue.value, ipfsGateway, arweaveServer))
 
     const jsonValue = computed(() => {
       let result

--- a/src/config/CoreConfig.ts
+++ b/src/config/CoreConfig.ts
@@ -101,6 +101,9 @@ export class CoreConfig {
         // The URL of the IPFS gateway
         public readonly ipfsGatewayURL: string|null,
 
+        // The URL of the Arweave server
+        public readonly arweaveServerURL: string|null,
+
         // The HTML content used as crypto unit symbol
         public readonly cryptoName: string,
 
@@ -127,6 +130,7 @@ export class CoreConfig {
             fetchString(obj, "walletChooserDisclaimerPopup"),
             fetchString(obj, "googleTagID"),
             fetchURL(obj, "ipfsGatewayURL") ?? "https://gateway.pinata.cloud/ipfs/",
+            fetchURL(obj, "arweaveServerURL"),
             fetchString(obj, "cryptoName") ?? "HBAR",
             fetchString(obj, "cryptoSymbol")
         )

--- a/src/config/CoreConfig.ts
+++ b/src/config/CoreConfig.ts
@@ -130,7 +130,7 @@ export class CoreConfig {
             fetchString(obj, "walletChooserDisclaimerPopup"),
             fetchString(obj, "googleTagID"),
             fetchURL(obj, "ipfsGatewayURL") ?? "https://gateway.pinata.cloud/ipfs/",
-            fetchURL(obj, "arweaveServerURL"),
+            fetchURL(obj, "arweaveServerURL") ?? "https://arweave.net/",
             fetchString(obj, "cryptoName") ?? "HBAR",
             fetchString(obj, "cryptoSymbol")
         )

--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -268,9 +268,12 @@ export default defineComponent({
     onMounted(() => nftLookup.mount())
     onBeforeUnmount(() => nftLookup.unmount())
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
+    const coreConfig = CoreConfig.inject()
+    const ipfsGatewayPrefix = coreConfig.ipfsGatewayURL
+    const arweaveServerURL = coreConfig.arweaveServerURL
+
     const metadata = computed(() => nftLookup.entity.value?.metadata ?? '')
-    const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix)
+    const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix, arweaveServerURL)
     onMounted(() => metadataAnalyzer.mount())
     onBeforeUnmount(() => metadataAnalyzer.unmount())
 

--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -52,7 +52,7 @@
             :type="type"
             :url="imageUrl"
             :size="isSmallScreen ? 450 : 300"
-            :auto="true"
+            :auto="false"
         />
       </template>
       <template #mediaDescription>

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -421,9 +421,12 @@ export default defineComponent({
     onMounted(() => tokenAnalyzer.mount())
     onBeforeUnmount(() => tokenAnalyzer.unmount())
 
-    const ipfsGatewayPrefix = CoreConfig.inject().ipfsGatewayURL
+    const coreConfig = CoreConfig.inject()
+    const ipfsGatewayPrefix = coreConfig.ipfsGatewayURL
+    const arweaveServerURL = coreConfig.arweaveServerURL
+
     const metadata = computed(() => tokenLookup.entity.value?.metadata ?? '')
-    const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix)
+    const metadataAnalyzer = new TokenMetadataAnalyzer(metadata, ipfsGatewayPrefix, arweaveServerURL)
     onMounted(() => metadataAnalyzer.mount())
     onBeforeUnmount(() => metadataAnalyzer.unmount())
 

--- a/src/utils/URLUtils.ts
+++ b/src/utils/URLUtils.ts
@@ -21,8 +21,7 @@
 import {EntityID} from "@/utils/EntityID";
 import {CID} from "multiformats";
 
-export function blob2URL(blob: string | null, ipfsGateway: string | null): string | null {
-
+export function blob2URL(blob: string | null, ipfsGateway: string | null, arweaveServer: string | null): string | null {
     let result: string | null
 
     if (blob !== null) {
@@ -32,6 +31,10 @@ export function blob2URL(blob: string | null, ipfsGateway: string | null): strin
             result = `${ipfsGateway}${blob.substring(7)}`
         } else if (ipfsGateway && isIPFSHash(blob)) {
             result = `${ipfsGateway}${blob}`
+        } else if (arweaveServer && blob.startsWith('ar://') && blob.length > 5) {
+            result = `${arweaveServer}${blob.substring(5)}`
+        } else if (arweaveServer && isArweaveHash(blob)) {
+            result = `${arweaveServer}${blob}`
         } else {
             result = null
         }
@@ -83,4 +86,9 @@ export function isIPFSHash(blob: string): boolean {
         isValid = false
     }
     return isValid
+}
+
+export function isArweaveHash(hash: string): boolean {
+    const re: RegExp = /^[a-zA-Z0-9_\-]{43}$/
+    return re.test(hash)
 }

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -568,8 +568,7 @@ export const SAMPLE_PENDING_AIRDROPS = {
 }
 
 export const IPFS_GATEWAY_PREFIX = 'https://gateway.pinata.cloud/ipfs/'
-
-export const CID_METADATA = "UW1QSjhnbTFIOFY3Ym9SR1JiV3ZyWloxSkMyeXFzajNoYkJKeUJhTFBnSG5ROA=="
+export const IPFS_CID_METADATA = "UW1QSjhnbTFIOFY3Ym9SR1JiV3ZyWloxSkMyeXFzajNoYkJKeUJhTFBnSG5ROA=="
 export const IPFS_METADATA = "aXBmczovL1FtUEo4Z20xSDhWN2JvUkdSYld2clpaMUpDMnlxc2ozaGJCSnlCYUxQZ0huUTg="
 export const IPFS_METADATA_CONTENT_URL = IPFS_GATEWAY_PREFIX + "QmPJ8gm1H8V7boRGRbWvrZZ1JC2yqsj3hbBJyBaLPgHnQ8"
 export const IPFS_IMAGE_URL = IPFS_GATEWAY_PREFIX + "QmXhGcYgJPgVmdDzkUuiK1RVy6fW7NVaJLLxir2iKLKRZU/0292-Shrak.png"
@@ -603,6 +602,32 @@ export const IPFS_METADATA_CONTENT = {
         }
     ]
 }
+
+export const AR_SERVER_PREFIX = 'https://arweave.net/'
+export const AR_CID_METADATA = "YWNjcXdsZFNPWkw4NElHY3JuUFRJdDZGZ05RVE9sc1N5RVhTNC11OGtrNA"
+export const AR_METADATA = "YXI6Ly9hY2Nxd2xkU09aTDg0SUdjcm5QVEl0NkZnTlFUT2xzU3lFWFM0LXU4a2s0"
+export const AR_METADATA_CONTENT_URL = AR_SERVER_PREFIX + "accqwldSOZL84IGcrnPTIt6FgNQTOlsSyEXS4-u8kk4"
+export const AR_IMAGE_URL = AR_SERVER_PREFIX + "3g1__QpZyBOlMUNUEE6YiBcoh0kdoDpimPFzpS8w_O4"
+export const AR_METADATA_CONTENT = {
+    "name": "DaVinciGraph BRONZE #2",
+    "description": "DaVinciGraph Utility BRONZE NFT",
+    "creator": "DaVinciGraph",
+    "CID": "3g1__QpZyBOlMUNUEE6YiBcoh0kdoDpimPFzpS8w_O4",
+    "image": "ar://3g1__QpZyBOlMUNUEE6YiBcoh0kdoDpimPFzpS8w_O4",
+    "type": "image/png",
+    "format": "DaVinciGraph",
+    "attributes": [
+        {
+            "trait_type": "Color",
+            "value": "Bronze"
+        },
+        {
+            "trait_type": "Number",
+            "value": "2"
+        }
+    ]
+}
+
 export const NON_STD_METADATA_CONTENT = {
     "custom": "Non standard metadata",
     "picture": "ipfs://QmXhGcYgJPgVmdDzkUuiK1RVy6fW7NVaJLLxir2iKLKRZU/0292-Shrak.png"


### PR DESCRIPTION
**Description**:

Add support for NFT metadata and related assets stored on Airwaves -- i.e. identified either by an URI of type `ar://` or by a 43-byte CID.

Also fix autoplay of video content -- current implementation never auto-plays videos.

**Related issue(s)**:

Fixes #1396 

**Notes for reviewer**:

Example of such NFT: 
<img width="1418" alt="Screenshot 2024-11-25 at 19 00 39" src="https://github.com/user-attachments/assets/a8ef7dea-ef66-4171-85a1-2d49330f203f">


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
