### PR TITLE
feat: Contract Details / Contract Bytecode / ABI tab now exposes error message available in api/v1/contracts/call response

### DIFF
--- a/src/components/values/abi/ContractCallBuilder.ts
+++ b/src/components/values/abi/ContractCallBuilder.ts
@@ -21,7 +21,7 @@
 import {computed, ref, watch} from "vue";
 import {ethers} from "ethers";
 import {AppStorage} from "@/AppStorage";
-import {ContractCallRequest, ContractCallResponse} from "@/schemas/MirrorNodeSchemas";
+import {ContractCallRequest, ContractCallResponse, extractMessageFromErrorBody} from "@/schemas/MirrorNodeSchemas";
 import {walletManager} from "@/router";
 import axios from "axios";
 import {ABIController} from "@/components/contract/ABIController";
@@ -90,7 +90,11 @@ export class ContractCallBuilder {
         const lastValue = this.lastValue.value
         const lastError = this.lastError.value
         if (lastError !== null) {
-            result = lastError?.toString() ?? "Undefined error"
+            if (axios.isAxiosError(lastError) && lastError.status == 400) {
+                result = extractMessageFromErrorBody(lastError.response?.data) ?? lastError.toString()
+            } else {
+                result = lastError?.toString() ?? "Undefined error"
+            }
         } else if (lastValue !== null) {
             try {
                 result = JSON.stringify(lastValue.length == 1 ? lastValue[0] : lastValue)

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -24,6 +24,7 @@
 
 import {EntityID} from "@/utils/EntityID";
 import {makeDefaultNodeDescription} from "@/schemas/MirrorNodeUtils.ts";
+import {fetchJSArray, fetchJSObject, fetchJSString} from "@/utils/JSUtils.ts";
 
 export interface AccountsResponse {
     accounts: AccountInfo[] | undefined
@@ -854,6 +855,29 @@ export interface StakingReward {
     account_id: string | null
     amount: number
     timestamp: string
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+//                                                      Error
+// ---------------------------------------------------------------------------------------------------------------------
+
+export interface ErrorBody {
+    _status: {
+        messages: [
+            {
+                data: string|null|undefined     // Error message in hexadecimal - pattern: ^0x[0-9a-fA-F]+$
+                detail: string|null|undefined   // Detailed error message
+                message: string|undefined       // Error message
+            }
+        ] | undefined
+    } | undefined
+}
+
+export function extractMessageFromErrorBody(body: unknown): string|null {
+    const _status = fetchJSObject(body, "_status")
+    const messages = fetchJSArray(_status, "messages")
+    const message0 = messages !== null && messages.length >= 1 ? messages[0] : null
+    return message0 !== null ? fetchJSString(message0, "message") : null
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/utils/JSUtils.ts
+++ b/src/utils/JSUtils.ts
@@ -1,0 +1,44 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export function fetchJSValue(obj: unknown, attributeName: string): unknown|null {
+    let result: unknown|null
+    if (typeof obj === 'object' && attributeName in obj) {
+        result = obj[attributeName]
+    } else {
+        result = null
+    }
+    return result
+}
+
+export function fetchJSObject(obj: unknown, attributeName: string): object|null {
+    const v = fetchJSValue(obj, attributeName)
+    return typeof v == "object" && v !== null ? v : null
+}
+
+export function fetchJSArray(obj: unknown, attributeName: string): unknown[]|null {
+    const v = fetchJSValue(obj, attributeName)
+    return Array.isArray(v) ? v : null
+}
+
+export function fetchJSString(obj: unknown, attributeName: string): string|null {
+    const v = fetchJSValue(obj, attributeName)
+    return typeof v == "string" ? v : null
+}

--- a/src/utils/JSUtils.ts
+++ b/src/utils/JSUtils.ts
@@ -20,8 +20,8 @@
 
 export function fetchJSValue(obj: unknown, attributeName: string): unknown|null {
     let result: unknown|null
-    if (typeof obj === 'object' && attributeName in obj) {
-        result = obj[attributeName]
+    if (typeof obj === 'object' && obj !== null && attributeName in obj) {
+        result = obj[attributeName as keyof typeof obj]
     } else {
         result = null
     }


### PR DESCRIPTION
**Description**:

Changes below extract message available in error response returned by api/v1/contracts/call.

**Related issue(s)**:

Fixes #1531 

**Notes for reviewer**:

See call to name() in contract [0.0.5198819](https://hashscan.io/testnet/contract/0.0.5198819?ps=1) on testnet.

With changes below, ABI looks like this:

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/1ec2a9fe-cb9d-4a92-8591-3c0b0bc505e9">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
