### PR TITLE
feat: contract detail page now displays EVM version for verified contract

### DIFF
--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -74,6 +74,12 @@
           <StringValue :string-value="solcVersion ?? undefined"/>
         </template>
       </Property>
+      <Property v-if="isVerified" id="contractName" :full-width="true">
+        <template v-slot:name>EVM Version</template>
+        <template v-slot:value>
+          <StringValue :string-value="evmVersion"/>
+        </template>
+      </Property>
       <template  v-if="logicContractId">
         <Property id="logicContract" :full-width="true">
           <template v-slot:name>Proxying to Logic Contract</template>
@@ -221,6 +227,8 @@ const isFullMatch = computed(() => props.contractAnalyzer.fullMatch.value)
 
 const contractName = computed(
     () => isVerified.value ? props.contractAnalyzer.contractName.value : null)
+
+const evmVersion = props.contractAnalyzer.evmVersion
 
 // True when the verification is ENABLED by configuration and the current verification STATUS is known, which
 // enables to decide which option to present to the user

--- a/src/utils/analyzer/ContractAnalyzer.ts
+++ b/src/utils/analyzer/ContractAnalyzer.ts
@@ -108,6 +108,16 @@ export class ContractAnalyzer {
         return result
     })
 
+    public readonly evmVersion: ComputedRef<string | null> = computed(() => {
+        let result: string | null
+        if (this.metadata.value !== null) {
+            result = this.metadata.value.settings.evmVersion ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
+
     public readonly interface: ComputedRef<ethers.Interface | null> = computed(() => {
         let result: ethers.Interface | null
         if (this.abi.value !== null) {

--- a/tests/unit/utils/ContractAnalyzer.spec.ts
+++ b/tests/unit/utils/ContractAnalyzer.spec.ts
@@ -48,6 +48,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 2) mount
         contractAnalyzer.mount()
@@ -59,6 +60,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 3) setup
         contractId.value = SAMPLE_CONTRACT.contract_id
@@ -70,6 +72,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBe(SAMPLE_CONTRACT.runtime_bytecode)
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 4) unmount
         contractAnalyzer.unmount()
@@ -81,6 +84,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
     })
 
@@ -106,6 +110,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 2) mount
         contractAnalyzer.mount()
@@ -117,6 +122,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 3) setup
         contractId.value = SAMPLE_CONTRACT.contract_id
@@ -128,6 +134,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBe(SAMPLE_CONTRACT.runtime_bytecode)
         expect(contractAnalyzer.fullMatch.value).toBeTruthy()
         expect(contractAnalyzer.sourcifyURL.value).toBe(contractURL)
+        expect(contractAnalyzer.evmVersion.value).toBe("london")
 
         // 4) unmount
         contractAnalyzer.unmount()
@@ -139,6 +146,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
     })
 
@@ -163,6 +171,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 2) mount
         contractAnalyzer.mount()
@@ -174,6 +183,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 3) setup
         contractId.value = SAMPLE_TOKEN.token_id
@@ -185,6 +195,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 4) unmount
         contractAnalyzer.unmount()
@@ -196,6 +207,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
 
     })
@@ -221,6 +233,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 2) mount
         contractAnalyzer.mount()
@@ -232,6 +245,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 3) setup
         contractId.value = SAMPLE_TOKEN_WITH_KEYS.token_id
@@ -243,6 +257,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
         // 4) unmount
         contractAnalyzer.unmount()
@@ -254,6 +269,7 @@ describe("ContractAnalyzer.spec.ts", () => {
         expect(contractAnalyzer.byteCode.value).toBeNull()
         expect(contractAnalyzer.fullMatch.value).toBeNull()
         expect(contractAnalyzer.sourcifyURL.value).toBeNull()
+        expect(contractAnalyzer.evmVersion.value).toBeNull()
 
 
     })


### PR DESCRIPTION
**Description**:

With changes below, `Contract Details` page now displays EVM version when contract is verified.
ContractAnalyzer unit test is also updated.

<img width="633" alt="image" src="https://github.com/user-attachments/assets/3423b0cc-e7a0-41a0-91f4-c72c966db01c">


**Related issue(s)**:

Fixes #1538 

**Notes for reviewer**:

On testnet, contract [0.0.5204343](https://hashscan.io/previewnet/contract/0.0.5204343) has `EVM version` `shanghai`.
On previewnet, contract  [0.0.12287](https://hashscan.io/previewnet/contract/0.0.12287) has `EVM version` `cancun`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
