### PR TITLE
chore: renaming (Hedera, Hashgraph, Swirlds) -> Hiero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # hashgraph/hedera-mirror-node-explorer
 
-Visual Explorer for the Hedera Hashgraph DLT.
+Visual Explorer for the Hiero DLT.
 
 ## Project setup
 
@@ -62,7 +62,7 @@ Details for these configuration files can be found in [CONFIGURATION.md](https:/
 # Build the Docker image locally
 npm run docker:build
 
-# Copy and adjust configuration of Hedera networks as needed
+# Copy and adjust configuration of Hiero networks as needed
 cp networks-config-http-example.json networks-config.json
 
 # Start the Docker container
@@ -78,22 +78,20 @@ npm run docker:stop
 
 ## Run in Kubernetes
 
-To run in [Kubernetes](https://kubernetes.io) the hedera-explorer [Helm](https://helm.sh) chart can be used. First,
+To run in [Kubernetes](https://kubernetes.io) the hiero-explorer [Helm](https://helm.sh) chart can be used. First,
 obtain access to a Kubernetes cluster running version 1.23 or greater. [Minikube](https://minikube.sigs.k8s.io/docs/)
 can be used for a local Kubernetes cluster.
 
 ```shell
-helm upgrade --install hedera-explorer chart/
+helm upgrade --install hiero-explorer chart/
 ```
 
 ### Configure custom networks 
 
 Core configuration and network configuration need to be provided to the Explorer in the `values.yaml` file 
-(see [CONFIGURATION.md](https://github.com/hashgraph/hedera-mirror-node-explorer/blob/main/CONFIGURATION.md) for 
-details on configuration parameters).
+(see [CONFIGURATION.md](https://github.com/hashgraph/hedera-mirror-node-explorer/blob/main/CONFIGURATION.md) for details on configuration parameters).
 
-If the network configuration is empty, by default the Explorer will support MAINNET, PREVIEWNET and TESTNET. But a 
-custom list of network can be provided, to either extend or completely replace the list of networks supported.
+The network configuration needs to provide at least the description on one supported networks.
 
 An example:
 ```

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 23.8.0
 description: Hedera Mirror Node Explorer for the Hedera Hashgraph DLT
 home: https://github.com/hashgraph/hedera-mirror-node-explorer
-name: hedera-explorer
+name: hiero-explorer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node-explorer
 version: 0.2.1

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -2,19 +2,19 @@ Get the application URL by running these commands:
 
 {{- if contains "NodePort" .Values.service.type }}
 
-  export NODE_PORT=$(kubectl get -n {{ include "hedera-explorer.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hedera-explorer.fullname" . }})
-  export NODE_IP=$(kubectl get nodes -n {{ include "hedera-explorer.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get -n {{ include "hiero-explorer.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hiero-explorer.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -n {{ include "hiero-explorer.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   open http://${NODE_IP}:${NODE_PORT}
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
-  export SERVICE_IP=$(kubectl get svc -n {{ include "hedera-explorer.namespace" . }} {{ include "hedera-explorer.fullname" . }} -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}")
+  export SERVICE_IP=$(kubectl get svc -n {{ include "hiero-explorer.namespace" . }} {{ include "hiero-explorer.fullname" . }} -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}")
   open http://${SERVICE_IP}:{{ .Values.service.port }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-  export POD_NAME=$(kubectl get pods -n {{ include "hedera-explorer.namespace" . }} -l "app.kubernetes.io/name={{ include "hedera-explorer.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods -n {{ include "hiero-explorer.namespace" . }} -l "app.kubernetes.io/name={{ include "hiero-explorer.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   open http://127.0.0.1:8080
-  kubectl -n {{ include "hedera-explorer.namespace" . }} port-forward $POD_NAME 8080:8080
+  kubectl -n {{ include "hiero-explorer.namespace" . }} port-forward $POD_NAME 8080:8080
 
 {{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "hedera-explorer.chart" -}}
+{{- define "hiero-explorer.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -12,7 +12,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "hedera-explorer.fullname" -}}
+{{- define "hiero-explorer.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -28,12 +28,12 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Common labels
 */}}
-{{- define "hedera-explorer.labels" -}}
-{{ include "hedera-explorer.selectorLabels" . }}
+{{- define "hiero-explorer.labels" -}}
+{{ include "hiero-explorer.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: hedera-explorer
+app.kubernetes.io/part-of: hiero-explorer
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-helm.sh/chart: {{ include "hedera-explorer.chart" . }}
+helm.sh/chart: {{ include "hiero-explorer.chart" . }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels }}
 {{- end }}
@@ -42,32 +42,32 @@ helm.sh/chart: {{ include "hedera-explorer.chart" . }}
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "hedera-explorer.name" -}}
+{{- define "hiero-explorer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Namespace
 */}}
-{{- define "hedera-explorer.namespace" -}}
+{{- define "hiero-explorer.namespace" -}}
 {{- default .Release.Namespace .Values.global.namespaceOverride -}}
 {{- end -}}
 
 {{/*
 Selector labels
 */}}
-{{- define "hedera-explorer.selectorLabels" -}}
-app.kubernetes.io/component: hedera-explorer
-app.kubernetes.io/name: {{ include "hedera-explorer.name" . }}
+{{- define "hiero-explorer.selectorLabels" -}}
+app.kubernetes.io/component: hiero-explorer
+app.kubernetes.io/name: {{ include "hiero-explorer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "hedera-explorer.serviceAccountName" -}}
+{{- define "hiero-explorer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-{{- default (include "hedera-explorer.fullname" .) .Values.serviceAccount.name -}}
+{{- default (include "hiero-explorer.fullname" .) .Values.serviceAccount.name -}}
 {{- else -}}
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}

--- a/chart/templates/cert-manager/certificate-requests.yaml
+++ b/chart/templates/cert-manager/certificate-requests.yaml
@@ -2,14 +2,14 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ca-secret-hedera-explorer
+  name: ca-secret-hiero-explorer
   namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
 spec:
   isCA: false
   commonName: {{ index $.Values "ingress" "hosts" 0 "host" }}
   dnsNames:
     - {{ index $.Values "ingress" "hosts" 0 "host" }}
-  secretName: ca-secret-hedera-explorer
+  secretName: ca-secret-hiero-explorer
   privateKey:
     algorithm: RSA
     size: 3072

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "hedera-explorer.fullname" . }}-config
+  name: {{ include "hiero-explorer.fullname" . }}-config
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 data:
   nginx.conf: |
     worker_processes  1;

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -2,21 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
-  name: {{ include "hedera-explorer.fullname" . }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
+  name: {{ include "hiero-explorer.fullname" . }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
-    matchLabels: {{ include "hedera-explorer.selectorLabels" . | nindent 6 }}
+    matchLabels: {{ include "hiero-explorer.selectorLabels" . | nindent 6 }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   template:
     metadata:
       annotations: {{- tpl (.Values.podAnnotations | toYaml) $ | nindent 8 }}
-      labels: {{ include "hedera-explorer.selectorLabels" . | nindent 8 }}
+      labels: {{ include "hiero-explorer.selectorLabels" . | nindent 8 }}
     spec:
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
       containers:
@@ -52,7 +52,7 @@ spec:
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       priorityClassName: {{ .Values.priorityClassName }}
       securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ include "hedera-explorer.serviceAccountName" . }}
+      serviceAccountName: {{ include "hiero-explorer.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- with .Values.volumes }}

--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -2,9 +2,9 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
-  name: {{ include "hedera-explorer.fullname" . }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
+  name: {{ include "hiero-explorer.fullname" . }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 spec:
   behavior: {{ toYaml .Values.autoscaling.behavior | nindent 4 }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
@@ -13,5 +13,5 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "hedera-explorer.fullname" . }}
+    name: {{ include "hiero-explorer.fullname" . }}
 {{- end -}}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "hedera-explorer.fullname" $ -}}
+{{- $fullName := include "hiero-explorer.fullname" $ -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -9,9 +9,9 @@ metadata:
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}
   {{- end }}
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
   name: {{ $fullName }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 spec:
   {{- with (coalesce .Values.ingressClassName .Values.ingress.className) }}
   ingressClassName: {{ . }}

--- a/chart/templates/poddisruptionbudget.yaml
+++ b/chart/templates/poddisruptionbudget.yaml
@@ -2,9 +2,9 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
-  name: {{ include "hedera-explorer.fullname" . }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
+  name: {{ include "hiero-explorer.fullname" . }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 spec:
   {{- with .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ . }}
@@ -13,5 +13,5 @@ spec:
   minAvailable: {{ . }}
   {{- end }}
   selector:
-    matchLabels: {{ include "hedera-explorer.selectorLabels" . | nindent 6 }}
+    matchLabels: {{ include "hiero-explorer.selectorLabels" . | nindent 6 }}
 {{- end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
-  name: {{ include "hedera-explorer.fullname" . }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
+  name: {{ include "hiero-explorer.fullname" . }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
-  selector: {{ include "hedera-explorer.selectorLabels" . | nindent 4 }}
+  selector: {{ include "hiero-explorer.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels: {{ include "hedera-explorer.labels" . | nindent 4 }}
-  name: {{ include "hedera-explorer.serviceAccountName" . }}
-  namespace: {{ include "hedera-explorer.namespace" . }}
+  labels: {{ include "hiero-explorer.labels" . | nindent 4 }}
+  name: {{ include "hiero-explorer.serviceAccountName" . }}
+  namespace: {{ include "hiero-explorer.namespace" . }}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,7 +32,7 @@ affinity:
           topologyKey: kubernetes.io/hostname
           labelSelector:
             matchLabels:
-              app.kubernetes.io/component: hedera-explorer
+              app.kubernetes.io/component: hiero-explorer
 
 annotations: {}
 
@@ -169,7 +169,7 @@ volumeMounts:
   nginx-config:
     mountPath: /etc/nginx/nginx.conf
     subPath: nginx.conf
-  hedera-explorer-config:
+  hiero-explorer-config:
     mountPath: /app/networks-config.json
     subPath: networks-config.json
 
@@ -179,10 +179,10 @@ volumes:
     emptyDir: {}
   nginx-config:
     configMap:
-      name: '{{ include "hedera-explorer.fullname" . }}-config'
-  hedera-explorer-config:
+      name: '{{ include "hiero-explorer.fullname" . }}-config'
+  hiero-explorer-config:
     configMap:
-      name: '{{ include "hedera-explorer.fullname" . }}-config'
+      name: '{{ include "hiero-explorer.fullname" . }}-config'
 
 # Add custom reverse proxy configuration.
 # It is a key-value map where key is the path and value being a URL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   explorer:
-    container_name:  hedera-explorer
+    container_name:  hiero-explorer
     image: "gcr.io/hedera-registry/hedera-mirror-node-explorer:latest"
     env_file: ./.env.docker
     restart: "always"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hedera-explorer",
+  "name": "hiero-explorer",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hedera-explorer",
+      "name": "hiero-explorer",
       "version": "0.1.0",
       "dependencies": {
         "@bladelabs/blade-web3.js": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hedera-explorer",
+  "name": "hiero-explorer",
   "version": "0.1.0",
   "type": "module",
   "private": true,

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "hedera-explorer",
-    "short_name": "hedera-explorer",
+    "name": "hiero-explorer",
+    "short_name": "hiero-explorer",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
**Description**:

- These changes rename (hopefully) most of the remaining occurrences of (Hedera, Hashgraph, Swirlds) to Hiero.
- Notable exceptions, perhaps not exhaustive:
     - copyright notices in all source files, to be addressed later
     - paths for files, repositories, etc...  to be addressed later
     - CookiesDialog.vue component, which will be taken care of in a separate PR.

**Related issue(s)**:

Related to #1430 