### PR TITLE
chore: add configuration for cookies acceptance dialog

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,6 +31,7 @@ The following configuration parameters can be set in `core-config.json`:
 | `estimatorNotice`              | `string` | No estimator notice is displayed                                                  |                            |
 | `walletChooserDisclaimerPopup` | `string` | No wallet chooser disclaimer popup is displayed                                   |                            |
 | `googleTagID`                  | `string` | Google Tag is disabled                                                            |                            |
+| `cookiesDialogContent`         | `string` | No cookies acceptation dialog (hence Google Tag is disabled)                      |                            |
 | `ipfsGatewayURL`               | `string` | Gateway `https://gateway.pinata.cloud/ipfs/` is used                              |                            |
 | `arweaveServerURL`             | `string` | The `https://arweave.net/` URL is used                                            |                            |
 | `cryptoName`                   | `string` | `HBAR` is displayed                                                               |                            |
@@ -97,9 +98,13 @@ This provides the HTML content of the disclaimer popup dialog displayed by the C
 If not specified, this pop-up dialog is not shown.
 
 ### `googleTagID`
-This provides the global site tag ID to be used by Google Analytics. When specified, it will trigger the display of a
-dialog asking the user to agree to the use of cookies before proceeding with the application. The google tag ID will
-be actually used only if the user has agreed.
+This provides the global site tag ID to be used by Google Analytics. If this parameter is specified, and if the user
+has agreed to the use of cookies, the google tag ID will be used.
+
+### `cookiesDialogContent`
+This provides the HTML content to be used in the cookies acceptation dialog. If this parameter is specified, it will 
+trigger the display of a dialog asking the user to agree to the use of cookies before proceeding with the application.
+By default, this dialog won't be shown (which also means that the google tag ID will not be used).
 
 ### `ipfsGatewayURL`
 This provides the URL of the public IPFS gateway to use to resolve the IPFS URIs (or CIDs) found in the token metadata.

--- a/public/core-config.json
+++ b/public/core-config.json
@@ -13,6 +13,7 @@
   "estimatorNotice": null,
   "walletChooserDisclaimerPopup": null,
   "googleTagID": null,
+  "cookiesDialogContent": null,
   "ipfsGatewayURL": null,
   "arweaveServerURL": null,
   "cryptoName": null,

--- a/src/App.vue
+++ b/src/App.vue
@@ -117,8 +117,9 @@ provide(networkConfigKey, props.networkConfig)
 const showCookiesDialog = ref(false)
 
 const acceptCookies = ref<boolean | null>(null)
-watch(acceptCookies, (value) => {
-  if (value != null && value && props.coreConfig.googleTagID !== null) {
+watch(acceptCookies, (accept) => {
+  const googleTagID = props.coreConfig.googleTagID
+  if (accept && googleTagID && googleTagID.length > 0) {
     insertGoogleTag(props.coreConfig.googleTagID)
   }
 })
@@ -130,10 +131,11 @@ provide(explanationKey, AxiosMonitor.instance.explanation)
 provide(suggestionKey, AxiosMonitor.instance.suggestion)
 
 onBeforeMount(() => {
-  const tagId = props.coreConfig.googleTagID
-  if (tagId != undefined && tagId.length > 0) {
+  const cookiesDialogContent = props.coreConfig.cookiesDialogContent
+
+  if (cookiesDialogContent && cookiesDialogContent.length > 0) {
     acceptCookies.value = AppStorage.getAcceptCookiePolicy()
-    showCookiesDialog.value = (acceptCookies.value == null)
+    showCookiesDialog.value = (acceptCookies.value == null && props.coreConfig.cookiesDialogContent != null)
   } else {
     acceptCookies.value = null
     showCookiesDialog.value = false

--- a/src/components/CookiesDialog.vue
+++ b/src/components/CookiesDialog.vue
@@ -23,21 +23,15 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <ModalDialog :icon-class="iconClass" :show-dialog="showDialog" :show-close-icon="false">
+  <ModalDialog :icon-class="props.iconClass" :show-dialog="props.showDialog" :show-close-icon="false">
     <template v-slot:dialogMessage>
       <span>Accept Cookies</span>
     </template>
     <template v-slot:dialogDetails>
-      <span class="mr-1">We use cookies to deliver the best experience on our website and to analyze traffic.
-        By continuing to use this site, you consent to our cookie policy.
-        Review our</span>
-      <a class="mr-1" href="https://swirldslabs.com/privacy-policy/">Privacy Policy</a>
-      <span>to understand how Swirlds Labs collects and uses information.</span>
-      <div class="is-flex is-justify-content-space-between is-align-items-baseline mt-4">
-        <div class="is-flex is-justify-content-flex-end">
-          <button class="button is-white is-small" @click="handleChooseReject">REJECT</button>
-          <button class="button is-info is-small ml-4" @click="handleChooseAccept">ACCEPT</button>
-        </div>
+      <div v-html="cookiesDialogContent"/>
+      <div class="is-flex is-justify-content-flex-end is-align-items-baseline mt-4">
+        <button class="button is-white is-small" @click="handleChooseReject">REJECT</button>
+        <button class="button is-info is-small ml-4" @click="handleChooseAccept">ACCEPT</button>
       </div>
     </template>
   </ModalDialog>
@@ -47,36 +41,32 @@
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script lang="ts">
+<script setup lang="ts">
 
-import {defineComponent} from "vue";
 import ModalDialog from "@/components/ModalDialog.vue";
+import {CoreConfig} from "@/config/CoreConfig.ts";
 
-export default defineComponent({
-  name: "CookiesDialog",
-  components: {ModalDialog},
-  props: {
-    showDialog: {
-      type: Boolean,
-      default: false
-    },
-    iconClass: String
+const props = defineProps({
+  showDialog: {
+    type: Boolean,
+    default: false
   },
-  setup(props, context) {
-    const handleChooseAccept = () => {
-      context.emit('update:showDialog', false)
-      context.emit('onChooseAccept')
-    }
-    const handleChooseReject = () => {
-      context.emit('update:showDialog', false)
-      context.emit('onChooseReject')
-    }
-    return {
-      handleChooseAccept,
-      handleChooseReject,
-    }
-  }
-});
+  iconClass: String
+})
+
+const emit = defineEmits(["update:showDialog", "onChooseAccept", "onChooseReject"],)
+
+const coreConfig = CoreConfig.inject()
+const cookiesDialogContent = coreConfig.cookiesDialogContent
+
+const handleChooseAccept = () => {
+  emit('update:showDialog', false)
+  emit('onChooseAccept')
+}
+const handleChooseReject = () => {
+  emit('update:showDialog', false)
+  emit('onChooseReject')
+}
 
 </script>
 

--- a/src/config/CoreConfig.ts
+++ b/src/config/CoreConfig.ts
@@ -98,6 +98,9 @@ export class CoreConfig {
         // Global site tag ID for Google Analytics
         public readonly googleTagID: string|null,
 
+        // The HTML content of the cookie acceptation dialog
+        public readonly cookiesDialogContent: string|null,
+
         // The URL of the IPFS gateway
         public readonly ipfsGatewayURL: string|null,
 
@@ -129,6 +132,7 @@ export class CoreConfig {
             fetchString(obj, "estimatorNotice"),
             fetchString(obj, "walletChooserDisclaimerPopup"),
             fetchString(obj, "googleTagID"),
+            fetchString(obj, "cookiesDialogContent"),
             fetchURL(obj, "ipfsGatewayURL") ?? "https://gateway.pinata.cloud/ipfs/",
             fetchURL(obj, "arweaveServerURL") ?? "https://arweave.net/",
             fetchString(obj, "cryptoName") ?? "HBAR",


### PR DESCRIPTION
**Description**:

The changes below introduce a new `CoreConfig.cookiesDialogContent` configuration parameter to control the content and appearance of the cookies dialog. 

Note that if not set, the value of the `googleTagID` parameter is ignored.

On the other hand, if `cookiesDialogContent` is set, and `googleTagID` is not, the dialog will be show but will have no other effect (for the time being). This will allow us to use cookies for other features if needed later.

**Related issue(s)**:

Related to #1430 
