### PR TITLE
Add support for core-config.json

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -43,14 +43,14 @@ data:
         }
 
         {{- if .Values.proxyPass }}
-          
+
           {{- range $path, $backend := .Values.proxyPass }}
           location {{ $path }} {
             proxy_pass {{ tpl $backend $ }};
           }
           {{- end }}
 
-     
+
         {{- end }}
 
         error_page   500 502 503 504  /50x.html;
@@ -60,3 +60,4 @@ data:
       }
     }
   networks-config.json: {{ .Values.config | toJson }}
+  core-config.json: {{ index .Values "core-config" | toJson }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -190,7 +190,7 @@ volumes:
     configMap:
       name: '{{ include "hiero-explorer.fullname" . }}-config'
 
-# Add cusom reverse proxy configuration.
+# Add custom reverse proxy configuration.
 # It is a key-value map where key is the path and value being a URL.
 # Primary use case is to allow access to mirror node api via hedera explorer url
 # Note that templating is allowed in the values

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -172,6 +172,9 @@ volumeMounts:
   hiero-explorer-config:
     mountPath: /app/networks-config.json
     subPath: networks-config.json
+  hiero-core-config:
+    mountPath: /app/core-config.json
+    subPath: core-config.json
 
 # Volume mounts to add to the container. The key is the volume name and the value is the volume definition. Evaluated as a template.
 volumes:
@@ -183,8 +186,11 @@ volumes:
   hiero-explorer-config:
     configMap:
       name: '{{ include "hiero-explorer.fullname" . }}-config'
+  hiero-core-config:
+    configMap:
+      name: '{{ include "hiero-explorer.fullname" . }}-config'
 
-# Add custom reverse proxy configuration.
+# Add cusom reverse proxy configuration.
 # It is a key-value map where key is the path and value being a URL.
 # Primary use case is to allow access to mirror node api via hedera explorer url
 # Note that templating is allowed in the values
@@ -213,3 +219,25 @@ config: |
       "ledgerID": "02"
     }
   ]
+core-config: |
+  {
+    "productName": null,
+    "productLogoURL": null,
+    "documentTitlePrefix": null,
+    "productDescription": null,
+    "metaDescription": null,
+    "metaURL": null,
+    "builtOnLogoURL": null,
+    "builtOnURL": null,
+    "sponsorLogoURL": null,
+    "sponsorURL": null,
+    "termsOfUseURL": null,
+    "estimatorNotice": null,
+    "walletChooserDisclaimerPopup": null,
+    "googleTagID": null,
+    "cookiesDialogContent": null,
+    "ipfsGatewayURL": null,
+    "arweaveServerURL": null,
+    "cryptoName": null,
+    "cryptoSymbol": null
+  }


### PR DESCRIPTION
This PR adds support for core.config.json within the mirror node explorer helm chart. 

The default values used were copied from https://github.com/hashgraph/hedera-mirror-node-explorer/blob/main/public/core-config.json