### PR TITLE
chore: fix install-branding.sh.

### DIFF
--- a/src/assets/branding/install-branding.sh
+++ b/src/assets/branding/install-branding.sh
@@ -7,8 +7,8 @@ cp ./src/assets/styles/brand-theme.scss ./src/assets/branding/
 # Install possible assets customization
 BRANDING_DIR="${BRANDING_LOCATION:-./branding}"
 cp ${BRANDING_DIR}/assets/* ./src/assets/branding/ 2>/dev/null | :
-cp -R ${BRANDING_DIR}/public/* ./public 2>/dev/null | :
-cp -R ${BRANDING_DIR}/public/.* ./public 2>/dev/null | :
+cp ${BRANDING_DIR}/public/* ./public/ 2>/dev/null | :
+cp -R ${BRANDING_DIR}/public/.well-known ./public/ 2>/dev/null | :
 cp ${BRANDING_DIR}/.env ./ 2>/dev/null | :
 cp ${BRANDING_DIR}/index.html ./ 2>/dev/null | :
 


### PR DESCRIPTION
**Description**:

Fix install-branding.sh, which was broken in PR #1543. Its execution left the repository in a complete mess.