### PR TITLE
chore: bump appVersion from 23.8.0 to 24.11.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 23.8.0
+appVersion: 24.11.0
 description: Hedera Mirror Node Explorer for the Hedera Hashgraph DLT
 home: https://github.com/hashgraph/hedera-mirror-node-explorer
 name: hiero-explorer


### PR DESCRIPTION
Align appVersion on last release of docker image, in Helm chart.