### PR TITLE
feat: remove "Key Alias" from account view

### DIFF
--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -266,13 +266,6 @@
           </template>
         </EditableProperty>
 
-        <Property v-if="account?.alias" id="alias" :class="{'mb-0':account?.alias}">
-          <template v-slot:name>Key Alias</template>
-          <template v-slot:value>
-            <AliasValue :alias-value="account?.alias"/>
-          </template>
-        </Property>
-
         <Property id="ethereumNonce">
           <template v-slot:name>Ethereum Nonce</template>
           <template v-slot:value>

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -131,7 +131,6 @@ describe("AccountDetails.vue", () => {
             "ED25519")
 
         expect(wrapper.get("#memoValue").text()).toBe("None")
-        expect(wrapper.get("#aliasValue").text()).toBe(ALIAS_HEX + 'Copy')
         expect(wrapper.get("#createTransactionValue").text()).toBe(TransactionID.normalizeForDisplay(SAMPLE_TRANSACTION.transaction_id))
 
         expect(wrapper.get("#expiresAtValue").text()).toBe("None")


### PR DESCRIPTION
**Description**:

Changes below remove the `Key Alias` field from `Account Details` page and adapt unit tests.

<img width="1238" alt="image" src="https://github.com/user-attachments/assets/9b3ba4fb-2494-4598-a3c6-ee034b21974b">

**Related issue(s)**:

Fixes #1550 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
