### PR TITLE
chore: temporarily disable KNS test in SearchBar.cy.ts.

### DIFF
--- a/tests/e2e/specs/SearchBar.cy.ts
+++ b/tests/e2e/specs/SearchBar.cy.ts
@@ -252,7 +252,7 @@ describe('Search Bar', () => {
         clickTestBody(searchAccount, '/mainnet/account/' + searchAccount, 'Account ID:', true)
     })
 
-    it('should find account with kns name', () => {
+    it.skip('should find account with kns name', () => {
         const searchName = "kabuto.hh"
         const searchAccount = "0.0.1001"
         testBody(searchAccount, '/mainnet/account/' + searchAccount, 'Account ID:', true, searchName)


### PR DESCRIPTION
**Description**:

Change below temporarily disable e2e test related to KNS in SearchBar.cy.ts.
This test regularly fails because on KNS deployment issue and pollutes PR review checks.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
