### PR TITLE
feat: label account 0.0.801 as the node reward account 

### DIFF
--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -159,6 +159,8 @@ export function makeOperatorDescription(accountId: string, nodes: NetworkNode[],
         result = "Hedera fee collection account"
     } else if (accountId === "0.0.800") {
         result = isFee ? "Staking reward account fee" : "Staking reward account"
+    } else if (accountId === "0.0.801") {
+        result = isFee ? "Node reward account fee" : "Node reward account"
     } else {
         const node = lookupNodeByAccountId(accountId, nodes)
         result = node !== null

--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -154,10 +154,10 @@ export class EntityID {
             result = compareNumber(this.realm, that.realm)
         }
         if (result == 0) {
-            if ((this.num < 100 || this.num === 800) && (that.num >= 100 && that.num !== 800)) {
+            if ((this.num < 100 || this.num === 800 || this.num === 801) && (that.num >= 100 && that.num !== 800 && that.num !== 801)) {
                 // We put this.num at the end
                 result = +1
-            } else if ((that.num < 100 || that.num === 800) && (this.num >= 100 && this.num != 800)) {
+            } else if ((that.num < 100 || that.num === 800 || that.num === 801) && (this.num >= 100 && this.num != 800 && this.num != 801)) {
                 // We put that.num at the end
                 result = -1
             } else {

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -252,6 +252,111 @@ describe("HbarTransferLayout.vue", () => {
         expect(cd1.payload).toBe(true)
     })
 
+    test("Single source, destinations including 800 and 801", async () => {
+
+        const transaction = {
+            "charged_tx_fee": 34394,
+            "transfers": [
+                {
+                    "account": "0.0.5",
+                    "amount": 1394
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 26400
+                },
+                {
+                    "account": "0.0.800",
+                    "amount": 3300
+                },
+                {
+                    "account": "0.0.801",
+                    "amount": 3300
+                },
+                {
+                    "account": "0.0.3229",
+                    "amount": -34395
+                },
+                {
+                    "account": "0.0.3230",
+                    "amount": 1
+                }
+            ]
+        } as Transaction
+
+        //
+        // FULL
+        //
+
+        const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
+
+        expect(fullLayout.transaction).toBe(transaction)
+        expect(fullLayout.destinationAmount).toBe(34395)
+        expect(fullLayout.rowCount).toBe(5)
+        expect(fullLayout.sources.length).toBe(1)
+        expect(fullLayout.destinations.length).toBe(5)
+
+        const s0 = fullLayout.sources[0]
+        expect(s0.transfer.account).toBe("0.0.3229")
+        expect(s0.transfer.amount).toBe(-34395)
+        expect(s0.description).toBe(null)
+        expect(s0.payload).toBe(true)
+
+        const d0 = fullLayout.destinations[0]
+        expect(d0.transfer.account).toBe("0.0.3230")
+        expect(d0.transfer.amount).toBe(+1)
+        expect(d0.description).toBe("Transfer")
+        expect(d0.payload).toBe(true)
+
+        const d1 = fullLayout.destinations[1]
+        expect(d1.transfer.account).toBe("0.0.5")
+        expect(d1.transfer.amount).toBe(+1394)
+        expect(d1.description).toBe("Node fee (Hedera)")
+        expect(d1.payload).toBe(false)
+
+        const d2 = fullLayout.destinations[2]
+        expect(d2.transfer.account).toBe("0.0.98")
+        expect(d2.transfer.amount).toBe(+26400)
+        expect(d2.description).toBe("Hedera fee collection account")
+        expect(d2.payload).toBe(false)
+
+        const d3 = fullLayout.destinations[3]
+        expect(d3.transfer.account).toBe("0.0.800")
+        expect(d3.transfer.amount).toBe(+3300)
+        expect(d3.description).toBe("Staking reward account fee")
+        expect(d3.payload).toBe(false)
+
+        const d4 = fullLayout.destinations[4]
+        expect(d4.transfer.account).toBe("0.0.801")
+        expect(d4.transfer.amount).toBe(+3300)
+        expect(d4.description).toBe("Node reward account fee")
+        expect(d4.payload).toBe(false)
+
+        //
+        // COMPACT
+        //
+
+        const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
+
+        expect(compactLayout.transaction).toBe(transaction)
+        expect(compactLayout.destinationAmount).toBe(1)
+        expect(compactLayout.rowCount).toBe(1)
+        expect(compactLayout.sources.length).toBe(1)
+        expect(compactLayout.destinations.length).toBe(1)
+
+        const cs0 = compactLayout.sources[0]
+        expect(cs0.transfer.account).toBe("0.0.3229")
+        expect(cs0.transfer.amount).toBe(-34395)
+        expect(cs0.description).toBe(null)
+        expect(cs0.payload).toBe(true)
+
+        const cd0 = fullLayout.destinations[0]
+        expect(cd0.transfer.account).toBe("0.0.3230")
+        expect(cd0.transfer.amount).toBe(+1)
+        expect(cd0.description).toBe("Transfer")
+        expect(cd0.payload).toBe(true)
+    })
+
 
     //
     // Multiple sources


### PR DESCRIPTION
**Description**:

With these trivial changes:
- account 801 is identified as `Node reward account` in the transfer graphs
- transfers to 801 are treated as fees similar to the transfers to 800

**Related issue(s)**:

Fixes #1562 

**Notes for reviewer**:

Before:
<img width="803" alt="Screenshot 2024-12-13 at 10 08 31" src="https://github.com/user-attachments/assets/bc416ec8-01a8-4bc5-ad07-60ca3b8678c9" />

After:
<img width="803" alt="Screenshot 2024-12-13 at 10 08 08" src="https://github.com/user-attachments/assets/15c809e0-38fc-4a7e-9040-22e89d523668" />
