### PR TITLE
fix: wrong hbar values assigned to Gas Limit, Gas Used, and Gas Consumed

### DIFF
--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -28,7 +28,7 @@
 
     <DashboardCard class="h-card" collapsible-key="contractResult">
       <template v-slot:title>
-        <span v-if="topLevel" class="h-is-primary-title">
+        <span v-if="props.topLevel" class="h-is-primary-title">
           Contract Result for {{ contractResult?.contract_id }} at {{ contractResult?.timestamp }}
         </span>
         <span v-else class="h-is-secondary-title">Contract Result</span>
@@ -135,12 +135,12 @@
 
     </DashboardCard>
 
-    <ContractResultTrace v-if="isParent" :transaction-id-or-hash="contractResult?.hash ?? undefined"
+    <ContractResultTrace v-if="props.isParent" :transaction-id-or-hash="contractResult?.hash ?? undefined"
                          :analyzer="analyzer"/>
 
     <ContractResultStates :state-changes="contractResult?.state_changes" :time-stamp="contractResult?.timestamp"/>
 
-    <ContractResultLogs :logs="contractResult?.logs" :block-number="blockNumber" :transaction-hash="transactionHash"/>
+    <ContractResultLogs :logs="contractResult?.logs" :block-number="props.blockNumber" :transaction-hash="props.transactionHash"/>
 
   </template>
 
@@ -150,9 +150,9 @@
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script lang="ts">
+<script setup lang="ts">
 
-import {computed, defineComponent, inject, onBeforeUnmount, onMounted} from 'vue';
+import {computed, inject, onBeforeUnmount, onMounted} from 'vue';
 import DashboardCard from "@/components/DashboardCard.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import StringValue from "@/components/values/StringValue.vue";
@@ -169,87 +169,54 @@ import FunctionError from "@/components/values/FunctionError.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import GasAmount from "@/components/values/GasAmount.vue";
 
-export default defineComponent({
-
-  name: 'ContractResult',
-
-  components: {
-    GasAmount,
-    HexaValue,
-    FunctionError,
-    FunctionResult,
-    FunctionInput,
-    ContractResultLogs,
-    EVMAddress,
-    ContractResultStates,
-    ContractResultTrace,
-    PlainAmount,
-    Property,
-    HbarAmount,
-    DashboardCard,
-    StringValue
+const props = defineProps({
+  timestamp: {
+    type: String,
   },
-
-  props: {
-    timestamp: {
-      type: String,
-    },
-    topLevel: {
-      type: Boolean,
-      default: false
-    },
-    isParent: {
-      type: Boolean,
-      default: false
-    },
-    blockNumber: {
-      type: Number
-    },
-    transactionHash: {
-      type: String
-    }
+  topLevel: {
+    type: Boolean,
+    default: false
   },
-
-  setup(props) {
-    const isSmallScreen = inject('isSmallScreen', true)
-    const isMediumScreen = inject('isMediumScreen', true)
-    const isTouchDevice = inject('isTouchDevice', false)
-
-    const contractResultAnalyzer = new ContractResultAnalyzer(computed(() => props.timestamp ?? null))
-    onMounted(() => contractResultAnalyzer.mount())
-    onBeforeUnmount(() => contractResultAnalyzer.unmount())
-
-    const displayedPrice = computed(() => {
-      let result: number | null
-      if (contractResultAnalyzer.contractType.value === 'Pre-Eip1559') {
-        result = contractResultAnalyzer.gasPrice.value
-      } else if (contractResultAnalyzer.contractType.value === 'Post-Eip1559') {
-        result = contractResultAnalyzer.maxFeePerGas.value
-      } else {
-        result = contractResultAnalyzer.gasPrice.value
-      }
-      return result
-    })
-
-    return {
-      isSmallScreen,
-      isMediumScreen,
-      isTouchDevice,
-      displayedPrice,
-      fromId: contractResultAnalyzer.fromId,
-      toId: contractResultAnalyzer.toId,
-      gasPrice: contractResultAnalyzer.gasPrice,
-      maxFeePerGas: contractResultAnalyzer.maxFeePerGas,
-      maxPriorityFeePerGas: contractResultAnalyzer.maxPriorityFeePerGas,
-      contractResult: contractResultAnalyzer.contractResult,
-      analyzer: contractResultAnalyzer.functionCallAnalyzer,
-      functionHash: contractResultAnalyzer.functionCallAnalyzer.functionHash,
-      signature: contractResultAnalyzer.functionCallAnalyzer.signature,
-      contractType: contractResultAnalyzer.contractType,
-      ethereumNonce: contractResultAnalyzer.ethereumNonce,
-    }
+  isParent: {
+    type: Boolean,
+    default: false
   },
-});
+  blockNumber: {
+    type: Number
+  },
+  transactionHash: {
+    type: String
+  }
+})
+
+const isSmallScreen = inject('isSmallScreen', true)
+const isMediumScreen = inject('isMediumScreen', true)
+
+const contractResultAnalyzer = new ContractResultAnalyzer(computed(() => props.timestamp ?? null))
+onMounted(() => contractResultAnalyzer.mount())
+onBeforeUnmount(() => contractResultAnalyzer.unmount())
+
+const displayedPrice = computed(() => {
+  let result: number | null
+  if (contractResultAnalyzer.contractType.value === 'Pre-Eip1559') {
+    result = contractResultAnalyzer.gasPrice.value
+  } else if (contractResultAnalyzer.contractType.value === 'Post-Eip1559') {
+    result = contractResultAnalyzer.maxFeePerGas.value
+  } else {
+    result = contractResultAnalyzer.gasPrice.value
+  }
+  return result
+})
+
+const fromId = contractResultAnalyzer.fromId
+const toId = contractResultAnalyzer.toId
+const gasPrice = contractResultAnalyzer.gasPrice
+const maxFeePerGas = contractResultAnalyzer.maxFeePerGas
+const maxPriorityFeePerGas = contractResultAnalyzer.maxPriorityFeePerGas
+const contractResult = contractResultAnalyzer.contractResult
+const analyzer = contractResultAnalyzer.functionCallAnalyzer
+const contractType = contractResultAnalyzer.contractType
+const ethereumNonce = contractResultAnalyzer.ethereumNonce
 
 </script>
 

--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -172,6 +172,7 @@ import HexaValue from "@/components/values/HexaValue.vue";
 import GasAmount from "@/components/values/GasAmount.vue";
 import {NetworkFeesCache} from "@/utils/cache/NetworkFeesCache.ts";
 import {TransactionType} from "@/schemas/MirrorNodeSchemas.ts";
+import {lookupTransactionType} from "@/schemas/MirrorNodeUtils.ts";
 
 const props = defineProps({
   timestamp: {
@@ -215,7 +216,7 @@ const gasPrice = computed(() => {
   console.log(`contractResultAnalyzer.gasPrice.value: ${result}`)
 
   if (!result && timestamp.value !== null) {
-    result = NetworkFeesCache.lookupTransactionType(feeLookup, props.transactionType)
+    result = lookupTransactionType(feeLookup.entity.value, props.transactionType)
   }
   result = result ?? contractResultAnalyzer.gasPrice.value
   return result

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -256,7 +256,9 @@
       <ContractResult :timestamp="transaction?.consensus_timestamp"
                       :is-parent="transaction?.parent_consensus_timestamp === null"
                       :block-number="blockNumber ?? undefined"
-                      :transaction-hash="formattedHash ?? undefined"/>
+                      :transaction-hash="formattedHash ?? undefined"
+                      :transaction-type="transaction?.name ?? undefined"
+      />
 
       <MirrorLink :network="network" entityUrl="transactions" :loc="transactionId!"/>
 

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -815,6 +815,16 @@ export interface NetworkStake {
                                               // this value is used to compute the HIP-782 balance ratio
 }
 
+export interface NetworkFeesResponse {
+    fees: NetworkFee[],
+    timestamp: string
+}
+
+export interface NetworkFee {
+    gas: number,              // gas cost in tinybars
+    transaction_type: string
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 //                                                      Block
 // ---------------------------------------------------------------------------------------------------------------------
@@ -865,15 +875,15 @@ export interface ErrorBody {
     _status: {
         messages: [
             {
-                data: string|null|undefined     // Error message in hexadecimal - pattern: ^0x[0-9a-fA-F]+$
-                detail: string|null|undefined   // Detailed error message
-                message: string|undefined       // Error message
+                data: string | null | undefined     // Error message in hexadecimal - pattern: ^0x[0-9a-fA-F]+$
+                detail: string | null | undefined   // Detailed error message
+                message: string | undefined       // Error message
             }
         ] | undefined
     } | undefined
 }
 
-export function extractMessageFromErrorBody(body: unknown): string|null {
+export function extractMessageFromErrorBody(body: unknown): string | null {
     const _status = fetchJSObject(body, "_status")
     const messages = fetchJSArray(_status, "messages")
     const message0 = messages !== null && messages.length >= 1 ? messages[0] : null

--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -27,6 +27,7 @@ import {
     ContractResultsResponse,
     HTS_PRECOMPILE_CONTRACT_ID,
     KeyType,
+    NetworkFeesResponse,
     NetworkNode,
     Nft,
     Nfts,
@@ -40,6 +41,7 @@ import {
     Transaction,
     TransactionByIdResponse,
     TransactionResponse,
+    TransactionType,
     Transfer,
 } from "@/schemas/MirrorNodeSchemas";
 import {ethers} from "ethers";
@@ -236,6 +238,31 @@ export function makeAnnualizedRate(rewardInTinyBar: number): string {
         maximumFractionDigits: 3
     })
     return formatter.format(makeRewardRate(rewardInTinyBar) * 365);
+}
+
+export function lookupTransactionType(feesResponse: NetworkFeesResponse | null, txType: TransactionType): number | null {
+    let result: number | null = null
+    let type: string
+    switch (txType) {
+        case TransactionType.CONTRACTCREATEINSTANCE:
+            type = "ContractCreate"
+            break
+        case TransactionType.CONTRACTCALL:
+            type = "ContractCall"
+            break
+        case TransactionType.ETHEREUMTRANSACTION:
+        default:
+            type = "EthereumTransaction"
+            break
+    }
+    const networkFees = feesResponse?.fees ?? []
+    for (const fee of networkFees) {
+        if (fee.transaction_type === type) {
+            result = fee.gas
+            break
+        }
+    }
+    return result
 }
 
 export function isCouncilNode(node: NetworkNode): boolean {

--- a/src/utils/cache/NetworkFeesCache.ts
+++ b/src/utils/cache/NetworkFeesCache.ts
@@ -19,37 +19,12 @@
  */
 
 import axios from "axios";
-import {EntityCache, EntityLookup} from "@/utils/cache/base/EntityCache";
-import {NetworkFeesResponse, TransactionType} from "@/schemas/MirrorNodeSchemas";
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import {NetworkFeesResponse} from "@/schemas/MirrorNodeSchemas";
 
 export class NetworkFeesCache extends EntityCache<string, NetworkFeesResponse> {
 
     public static readonly instance = new NetworkFeesCache()
-
-    public static lookupTransactionType(lookup: EntityLookup<string, NetworkFeesResponse>, txType: TransactionType): number | null {
-        let result: number | null = null
-        let type: string
-        switch (txType) {
-            case TransactionType.CONTRACTCREATEINSTANCE:
-                type = "ContractCreate"
-                break
-            case TransactionType.CONTRACTCALL:
-                type = "ContractCall"
-                break
-            case TransactionType.ETHEREUMTRANSACTION:
-            default:
-                type = "EthereumTransaction"
-                break
-        }
-        const networkFees = lookup.entity.value?.fees ?? []
-        for (const fee of networkFees) {
-            if (fee.transaction_type === type) {
-                result = fee.gas
-                break
-            }
-        }
-        return result
-    }
 
     //
     // Cache

--- a/src/utils/cache/NetworkFeesCache.ts
+++ b/src/utils/cache/NetworkFeesCache.ts
@@ -1,0 +1,42 @@
+/*-
+ *
+ * Hedera Mirror Node Explorer
+ *
+ * Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import axios from "axios";
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import {NetworkFeesResponse} from "@/schemas/MirrorNodeSchemas";
+
+export class NetworkFeesCache extends EntityCache<string, NetworkFeesResponse> {
+
+    public static readonly instance = new NetworkFeesCache()
+
+    //
+    // Cache
+    //
+
+    protected async load(timestamp: string): Promise<NetworkFeesResponse> {
+        const parameters = timestamp != "0" ? {timestamp: timestamp} : {}
+        const result = await axios.get<NetworkFeesResponse>(
+            'api/v1/network/fees',
+            {params: parameters}
+        )
+        return Promise.resolve(result.data)
+    }
+
+}

--- a/src/utils/cache/NetworkFeesCache.ts
+++ b/src/utils/cache/NetworkFeesCache.ts
@@ -19,12 +19,37 @@
  */
 
 import axios from "axios";
-import {EntityCache} from "@/utils/cache/base/EntityCache";
-import {NetworkFeesResponse} from "@/schemas/MirrorNodeSchemas";
+import {EntityCache, EntityLookup} from "@/utils/cache/base/EntityCache";
+import {NetworkFeesResponse, TransactionType} from "@/schemas/MirrorNodeSchemas";
 
 export class NetworkFeesCache extends EntityCache<string, NetworkFeesResponse> {
 
     public static readonly instance = new NetworkFeesCache()
+
+    public static lookupTransactionType(lookup: EntityLookup<string, NetworkFeesResponse>, txType: TransactionType): number | null {
+        let result: number | null = null
+        let type: string
+        switch (txType) {
+            case TransactionType.CONTRACTCREATEINSTANCE:
+                type = "ContractCreate"
+                break
+            case TransactionType.CONTRACTCALL:
+                type = "ContractCall"
+                break
+            case TransactionType.ETHEREUMTRANSACTION:
+            default:
+                type = "EthereumTransaction"
+                break
+        }
+        const networkFees = lookup.entity.value?.fees ?? []
+        for (const fee of networkFees) {
+            if (fee.transaction_type === type) {
+                result = fee.gas
+                break
+            }
+        }
+        return result
+    }
 
     //
     // Cache


### PR DESCRIPTION
**Description**:

With the changes below:
- we use script setup syntax in ContractResult and do a tiny bit of refactoring
- we always display the Gas Price in the Contract Result and get its value from `/api/v1/network/fees` at the corresponding timestamp. 

[See detailed analysis of the issue in #1559]

**Related issue(s)**:

Fixes #1559 

**Notes for reviewer**:

Before: 
<img width="496" alt="394906549-1d32f539-08eb-4abe-8776-d63e5fa40f1f" src="https://github.com/user-attachments/assets/d308d414-bb63-4242-bdd0-d59b7b76a2e2" />

After:
<img width="544" alt="Screenshot 2024-12-13 at 18 15 41" src="https://github.com/user-attachments/assets/559fcc66-05d2-484a-9d4f-a2749edf960d" />

