### PR TITLE
fix: block-chain-bg.png does not show up in top navigation bar.

### DIFF
--- a/src/components/page/PageFrame.vue
+++ b/src/components/page/PageFrame.vue
@@ -77,7 +77,7 @@ const isTouchDevice = inject('isTouchDevice', false)
 section.section.is-top-section {
   padding-top: 0;
   padding-bottom: 0;
-  background-image: url("assets/block-chain-bg.png");
+  background-image: url("@/assets/block-chain-bg.png");
   background-repeat: no-repeat;
   background-size: 104px
 }


### PR DESCRIPTION
**Description**:

Trivial. Fix erroneous path for `block-chain-bg.png` in `PageFrame.vue`

**Notes for reviewer**:

<img width="462" alt="Screenshot 2024-12-18 at 11 59 36" src="https://github.com/user-attachments/assets/604e696c-407e-4f80-8b27-327c17e52f12" />

