### PR TITLE
fix: Add the `ingress` in values as it is required

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -49,6 +49,20 @@ image:
   repository: hedera-registry/hedera-mirror-node-explorer
   tag: ""  # Defaults to the chart's app version
 
+ingress:
+  annotations: {}
+  className: ""
+  enabled: false
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 labels: {}
 
 livenessProbe:


### PR DESCRIPTION
**Description**:

Add the `ingress` in values as it is required

This PR modifies
* adds back the `ingress` value in the values file

**Related issue**: https://github.com/hashgraph/hedera-mirror-node-explorer/issues/1570