### PR TITLE
chore: re-implement hex utils using etherjs library

### DIFF
--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -21,6 +21,7 @@
 
 import base32Decode from "base32-decode";
 import base32Encode from "base32-encode";
+import {ethers} from "ethers";
 
 //
 // https://developer.mozilla.org/en-US/docs/Glossary/Base64
@@ -114,13 +115,7 @@ function uint6ToB64(nUint6: number) {
 //
 
 export function byteToHex(bytes: Uint8Array): string {
-    let result = ""
-    for (let i = 0; i < bytes.length; i += 1) {
-        const b = bytes[i]
-        const h = ('0' + b.toString(16)).slice(-2)
-        result += h
-    }
-    return result
+    return ethers.hexlify(bytes).slice(2)
 }
 
 export function paddedBytes(bytes: Uint8Array, length: number): Uint8Array {
@@ -130,28 +125,12 @@ export function paddedBytes(bytes: Uint8Array, length: number): Uint8Array {
     return result
 }
 
-const HEXSET = "0123456789ABCDEF"
-
 export function hexToByte(hex: string): Uint8Array | null {
     let result: Uint8Array | null
-    if (hex.length % 2 == 0) {
-        const startIndex = hex.startsWith("0x") ? 1 : 0
-        const bytes = Array<number>()
-        let ok = true
-        for (let i = startIndex, endIndex = hex.length / 2; i < endIndex && ok; i += 1) {
-            const b1 = hex[2 * i].toUpperCase()
-            const b0 = hex[2 * i + 1].toUpperCase()
-            const okB1 = HEXSET.indexOf(b1) != -1
-            const okB0 = HEXSET.indexOf(b0) != -1
-            if (okB0 && okB1) {
-                const b = Number.parseInt(b1 + b0, 16)
-                bytes.push(b)
-            } else {
-                ok = false
-            }
-        }
-        result = ok ? new Uint8Array(bytes) : null
-    } else {
+    try {
+        hex = hex.startsWith("0x") ? hex : "0x" + hex
+        result = ethers.getBytes(hex)
+    } catch {
         result = null
     }
     return result

--- a/src/utils/parser/AccountLocParser.ts
+++ b/src/utils/parser/AccountLocParser.ts
@@ -29,7 +29,7 @@ import {NetworkConfig} from "@/config/NetworkConfig";
 import {routeManager} from "@/router";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import {makeEthAddressForAccount} from "@/schemas/MirrorNodeUtils.ts";
-import {base32ToAlias, byteToHex} from "@/utils/B64Utils";
+import {base32ToAlias} from "@/utils/B64Utils";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {AccountByAliasCache} from "@/utils/cache/AccountByAliasCache";
 
@@ -146,12 +146,6 @@ export class AccountLocParser {
 
     public readonly ethereumAddress = computed(() => {
         return this.accountInfo.value !== null ? makeEthAddressForAccount(this.accountInfo.value) : null
-    })
-
-    public readonly aliasByteString = computed(() => {
-        const alias32 = this.accountInfo.value?.alias
-        const aliasBytes = alias32 ? base32ToAlias(alias32) : null
-        return aliasBytes !== null ? byteToHex(aliasBytes) : null
     })
 
     public readonly errorNotification: ComputedRef<string | null> = computed(() => {

--- a/tests/unit/utils/AccountLocParser.spec.ts
+++ b/tests/unit/utils/AccountLocParser.spec.ts
@@ -68,7 +68,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -89,7 +88,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -109,7 +107,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(SAMPLE_ACCOUNT.account)
@@ -127,7 +124,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBe(SAMPLE_ACCOUNT_ADDRESS)
-        expect(parser.aliasByteString.value).toBe(SAMPLE_ACCOUNT_ALIAS_HEX)
         expect(parser.errorNotification.value).toBeNull()
 
         // 3) Unsets
@@ -148,7 +144,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -169,7 +164,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -205,7 +199,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -225,7 +218,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(SAMPLE_ACCOUNT.account)
@@ -243,7 +235,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Mounts parser
@@ -264,7 +255,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBe(SAMPLE_ACCOUNT_ADDRESS)
-        expect(parser.aliasByteString.value).toBe(SAMPLE_ACCOUNT_ALIAS_HEX)
         expect(parser.errorNotification.value).toBeNull()
 
         // 3) Unmounts parser
@@ -285,7 +275,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // Unsets
@@ -306,7 +295,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -342,7 +330,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -363,7 +350,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account address
@@ -383,7 +369,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(SAMPLE_ACCOUNT_ADDRESS)
@@ -401,7 +386,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBe(SAMPLE_ACCOUNT_ADDRESS)
-        expect(parser.aliasByteString.value).toBe(SAMPLE_ACCOUNT_ALIAS_HEX)
         expect(parser.errorNotification.value).toBeNull()
 
         // 3) Unsets
@@ -422,7 +406,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -443,7 +426,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -479,7 +461,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -500,7 +481,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account alias
@@ -520,7 +500,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(SAMPLE_ACCOUNT.alias)
@@ -538,7 +517,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBe(SAMPLE_ACCOUNT_ADDRESS)
-        expect(parser.aliasByteString.value).toBe(SAMPLE_ACCOUNT_ALIAS_HEX)
         expect(parser.errorNotification.value).toBeNull()
 
         accountLoc.value = null
@@ -558,7 +536,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -579,7 +556,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -615,7 +591,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -636,7 +611,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account alias in hex form
@@ -656,7 +630,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(SAMPLE_ACCOUNT_ALIAS_HEX)
@@ -674,7 +647,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBe(SAMPLE_ACCOUNT_ADDRESS)
-        expect(parser.aliasByteString.value).toBe(SAMPLE_ACCOUNT_ALIAS_HEX)
         expect(parser.errorNotification.value).toBeNull()
 
         accountLoc.value = null
@@ -694,7 +666,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -715,7 +686,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -752,7 +722,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -773,7 +742,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -793,7 +761,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(UNKNOWN_ACCOUNT_ID)
@@ -811,7 +778,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBe("Account with ID 0.0.42 was not found")
 
         // 3) Unsets
@@ -832,7 +798,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -853,7 +818,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -890,7 +854,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -911,7 +874,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -931,7 +893,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(UNKNOWN_ACCOUNT_ADDRESS)
@@ -949,7 +910,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBe("Own this account? Activate it by transferring any amount of ℏ or tokens to 0x00…070809.")
 
         // 3) Unsets
@@ -970,7 +930,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -991,7 +950,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -1028,7 +986,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -1049,7 +1006,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -1069,7 +1025,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(UNKNOWN_ACCOUNT_ALIAS)
@@ -1087,7 +1042,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBe("Account with alias CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ was not found")
 
         // 3) Unsets
@@ -1108,7 +1062,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -1129,7 +1082,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -1166,7 +1118,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -1187,7 +1138,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -1207,7 +1157,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
         await flushPromises()
         expect(parser.accountLoc.value).toBe(UNKNOWN_ACCOUNT_ALIAS)
@@ -1225,7 +1174,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBe("Account with alias CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ was not found")
 
         // 3) Unsets
@@ -1246,7 +1194,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -1267,7 +1214,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()
@@ -1305,7 +1251,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 1) Mounts parser
@@ -1326,7 +1271,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 2) Sets with account id
@@ -1346,7 +1290,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBe("Invalid account ID, address or alias: dummy loc")
         await flushPromises()
         expect(parser.accountLoc.value).toBe(DUMMY_LOC)
@@ -1364,7 +1307,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBe("Invalid account ID, address or alias: dummy loc")
 
         // 3) Unsets
@@ -1385,7 +1327,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         // 4) Unmounts parser
@@ -1406,7 +1347,6 @@ describe("AccountLocParser.ts", () => {
         expect(parser.accountDescription.value).toBeNull()
         expect(parser.nodeId.value).toBeNull()
         expect(parser.ethereumAddress.value).toBeNull()
-        expect(parser.aliasByteString.value).toBeNull()
         expect(parser.errorNotification.value).toBeNull()
 
         mock.restore()


### PR DESCRIPTION
**Description**:

Changes below re-implement `byteToHex()` and `hexToByte()` routines using `etherjs` library.
They also remove unused `AccountParser.aliasByteString()`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
