### PR TITLE
chore: move network selector from TopNavBar to separate view NetworkSelector.

### DIFF
--- a/src/components/page/NetworkSelector.vue
+++ b/src/components/page/NetworkSelector.vue
@@ -1,0 +1,67 @@
+<!--
+  -
+  - Hedera Mirror Node Explorer
+  -
+  - Copyright (C) 2021 - 2024 Hedera Hashgraph, LLC
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -      http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -
+  -->
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <o-field>
+    <o-select v-model="selectedNetwork" class="h-is-navbar-item">
+      <option v-for="network in networkEntries" :key="network.name" :value="network.name">
+        {{ network.displayName }}
+      </option>
+    </o-select>
+  </o-field>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script setup lang="ts">
+
+import {ref, watch} from "vue";
+import {routeManager} from "@/router.ts";
+import {NetworkConfig} from "@/config/NetworkConfig.ts";
+
+const networkEntries = NetworkConfig.inject().entries
+
+const selectedNetwork = ref(routeManager.currentNetwork.value)
+watch(routeManager.currentNetwork, (newNetwork) => {
+  selectedNetwork.value = newNetwork // Checked : does not trigger any watch when value is unchanged
+})
+watch(selectedNetwork, (newNetwork) => {
+  if (newNetwork !== routeManager.currentNetwork.value) {
+    routeManager.routeToMainDashboard(newNetwork)
+  }
+})
+
+
+</script>
+
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      STYLE                                                      -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+</style>

--- a/src/components/page/TopNavBar.vue
+++ b/src/components/page/TopNavBar.vue
@@ -105,13 +105,7 @@
         </div>
 
         <div v-if="nbNetworks > 1" id="drop-down-menu">
-          <o-field>
-            <o-select v-model="selectedNetwork" class="h-is-navbar-item">
-              <option v-for="network in networkEntries" :key="network.name" :value="network.name">
-                {{ network.displayName }}
-              </option>
-            </o-select>
-          </o-field>
+          <NetworkSelector/>
         </div>
 
         <div v-if="enableWallet" id="connect-button">
@@ -133,16 +127,15 @@
 import {routeManager} from "@/router";
 import SearchBarV2 from "@/components/search/SearchBarV2.vue";
 import AxiosStatus from "@/components/AxiosStatus.vue";
-import {NetworkConfig} from "@/config/NetworkConfig";
-import {computed, inject, ref, watch} from "vue";
+import {computed, inject} from "vue";
 import ConnectWalletButton from "@/components/wallet/ConnectWalletButton.vue";
 import {CoreConfig} from "@/config/CoreConfig";
 import NavMenuItem from "@/components/page/NavMenuItem.vue";
 import {TabId} from "@/utils/RouteManager.ts";
+import NetworkSelector from "@/components/page/NetworkSelector.vue";
 
 const isMediumScreen = inject('isMediumScreen', true)
 const coreConfig = CoreConfig.inject()
-const networkConfig = NetworkConfig.inject()
 
 const enableStaking = routeManager.enableStaking
 const productLogoURL = coreConfig.productLogoURL
@@ -160,24 +153,9 @@ const searchBarClass = computed(() => {
   return result
 })
 
-//
-// Public (selectedNetwork)
-//
-
-const selectedNetwork = ref(routeManager.currentNetwork.value)
-watch(routeManager.currentNetwork, (newNetwork) => {
-  selectedNetwork.value = newNetwork // Checked : does not trigger any watch when value is unchanged
-})
-watch(selectedNetwork, (newNetwork) => {
-  if (newNetwork !== routeManager.currentNetwork.value) {
-    routeManager.routeToMainDashboard(newNetwork)
-  }
-})
-
 const name = routeManager.currentRoute
 const enableWallet = routeManager.enableWallet
 const nbNetworks = routeManager.nbNetworks
-const networkEntries = networkConfig.entries
 
 </script>
 


### PR DESCRIPTION
**Description**:

Change below add a new `NetworkSelector` view and move the network selector template/script from `TopNavBar` to it.

**Related issue(s)**:

Fixes #1577 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
