### PR TITLE
ci: update the formatting workflow to use the correct runner group

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: solo-linux-medium
+    runs-on: mirror-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c95a14d0e5bab51a9f56296a4eb0e416910cd350 # v2.10.3


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the `flow-pull-request-formatting.yaml` workflow to use the correct runner group

### Related Issues

- Closes #1604 