### PR TITLE
chore: remove mention of council nodes

### DIFF
--- a/src/components/account/UpdateAccountDialog.vue
+++ b/src/components/account/UpdateAccountDialog.vue
@@ -168,22 +168,11 @@
                     style=" height: 38px; border-radius: 2px; border-width: 1px; border-color: grey;
                     background-color: var(--h-theme-page-background-color);"
           >
-            <optgroup label="Hedera council nodes">
-              <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
-                      style="background-color: var(--h-theme-page-background-color)"
-                      v-show="isCouncilNode(n)"
-              >
-                {{ makeNodeSelectorDescription(n) }}
-              </option>
-            </optgroup>
-            <optgroup v-if="networkAnalyzer.hasCommunityNode.value" label="Community nodes">
-              <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
-                      style="background-color: var(--h-theme-page-background-color)"
-                      v-show="!isCouncilNode(n)"
-              >
-                {{ makeNodeSelectorDescription(n) }}
-              </option>
-            </optgroup>
+            <option v-for="n in networkAnalyzer.nodes.value" :key="n.node_id" :value="n.node_id"
+                    style="background-color: var(--h-theme-page-background-color)"
+            >
+              {{ makeNodeSelectorDescription(n) }}
+            </option>
           </o-select>
 
         </template>
@@ -295,7 +284,7 @@
 
 import {computed, onBeforeUnmount, onMounted, PropType, ref, watch, WatchStopHandle} from "vue";
 import {DialogController, DialogMode} from "@/components/dialog/DialogController";
-import {extractChecksum, isCouncilNode, stripChecksum, waitForTransactionRefresh} from "@/schemas/MirrorNodeUtils.ts";
+import {extractChecksum, stripChecksum, waitForTransactionRefresh} from "@/schemas/MirrorNodeUtils.ts";
 import {TransactionID} from "@/utils/TransactionID";
 import {WalletClientError, WalletClientRejectError} from "@/utils/wallet/client/WalletClient";
 import {AccountInfo, makeNodeSelectorDescription} from "@/schemas/MirrorNodeSchemas";

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -35,13 +35,6 @@
         @cell-click="handleClick"
     >
 
-      <o-table-column v-slot="props" field="nature" label="">
-        <span class="icon has-text-info regular-node-column" style="font-size: 16px">
-          <i v-if="isCouncilNode(props.row)" class="fas fa-building"></i>
-          <i v-else class="fas fa-users"></i>
-        </span>
-      </o-table-column>
-
       <o-table-column v-slot="props" field="node_id" label="Node">
         <div class="is-numeric regular-node-column">
           {{ props.row.node_id }}

--- a/src/components/staking/RewardsCalculator.vue
+++ b/src/components/staking/RewardsCalculator.vue
@@ -37,20 +37,11 @@
             <p v-else class="h-is-text-size-3 mb-1">Choose a node to stake to</p>
             <o-field style="width: 100%">
               <o-select v-model="selectedNodeId" class="h-is-text-size-1" style="border-radius: 4px" :icon="nodeIcon">
-                <optgroup label="Hedera council nodes">
-                  <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
-                          style="background-color: var(--h-theme-box-background-color)"
-                          v-show="isCouncilNode(n)">
-                    {{ makeNodeSelectorDescription(n) }}
-                  </option>
-                </optgroup>
-                <optgroup v-if="hasCommunityNode" label="Community nodes">
-                  <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
-                          style="background-color: var(--h-theme-box-background-color)"
-                          v-show="!isCouncilNode(n)">
-                    {{ makeNodeSelectorDescription(n) }}
-                  </option>
-                </optgroup>
+                <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
+                        style="background-color: var(--h-theme-box-background-color)"
+                >
+                  {{ makeNodeSelectorDescription(n) }}
+                </option>
               </o-select>
             </o-field>
           </div>

--- a/src/components/staking/StakingDialog.vue
+++ b/src/components/staking/StakingDialog.vue
@@ -88,20 +88,11 @@
                   <o-select v-model="selectedNode" :class="{'has-text-grey': !isNodeSelected}"
                             class="h-is-text-size-1" style="border-radius: 4px" @focus="stakeChoice='node'"
                             :icon="selectedNodeIcon">
-                    <optgroup label="Hedera council nodes">
-                      <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
-                              style="background-color: var(--h-theme-box-background-color)"
-                              v-show="isCouncilNode(n)">
-                        {{ makeNodeSelectorDescription(n) }}
-                      </option>
-                    </optgroup>
-                    <optgroup v-if="hasCommunityNode" label="Community nodes">
-                      <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
-                              style="background-color: var(--h-theme-box-background-color)"
-                              v-show="!isCouncilNode(n)">
-                        {{ makeNodeSelectorDescription(n) }}
-                      </option>
-                    </optgroup>
+                    <option v-for="n in nodes" :key="n.node_id" :value="n.node_id"
+                            style="background-color: var(--h-theme-box-background-color)"
+                    >
+                      {{ makeNodeSelectorDescription(n) }}
+                    </option>
                   </o-select>
                 </o-field>
               </div>
@@ -175,7 +166,8 @@
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType, ref, watch} from "vue";
 import {
   AccountBalanceTransactions,
-  AccountsResponse, makeNodeSelectorDescription,
+  AccountsResponse,
+  makeNodeSelectorDescription,
   makeShortNodeDescription,
   NetworkNode
 } from "@/schemas/MirrorNodeSchemas";

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -33,14 +33,6 @@
             <span class="h-is-primary-title mr-2">Node </span>
             <span class="h-is-secondary-text is-numeric mr-3">{{ nodeIdNb }}</span>
           </div>
-          <div v-if="isCouncilNode">
-            <span class="icon has-text-info mr-2"><i class="fas fa-building"></i></span>
-            <span class="h-is-tertiary-text has-text-grey">Hedera Council Node</span>
-          </div>
-          <div v-else>
-            <span class="icon has-text-info mr-2"><i class="fas fa-users"></i></span>
-            <span class="h-is-tertiary-text has-text-grey">Community Node</span>
-          </div>
         </template>
 
         <template v-slot:content>

--- a/tests/e2e/specs/NodeNavigation.cy.ts
+++ b/tests/e2e/specs/NodeNavigation.cy.ts
@@ -34,7 +34,7 @@ describe('Node Navigation', () => {
             .should('have.length', 7)
             .eq(0)
             .find('td')
-            .eq(1)
+            .eq(0)
             .click()
             .then(($id) => {
                 // cy.log('Selected node Id: ' + $id.text())


### PR DESCRIPTION
**Description**:

Remove all mentions of node nature (council vs. community node) in the UI:
  - subtitle in Node details
  - option groups in Node selector
  - icon in Node table

**Notes for reviewer**:

<img width="924" alt="Screenshot 2025-02-18 at 10 25 37" src="https://github.com/user-attachments/assets/7e4b0b67-edba-4f84-8db1-e226dd12460f" />
<img width="701" alt="Screenshot 2025-02-18 at 10 26 08" src="https://github.com/user-attachments/assets/93c72881-329c-4a39-b603-dd11d1024d81" />
<img width="755" alt="Screenshot 2025-02-18 at 10 29 27" src="https://github.com/user-attachments/assets/d09cad5d-f2e5-46d4-8fae-db9c13f75715" />
