### PR TITLE
fix: auto refresh stops and restarts immediately when clicking on Pause in Transactions table

### DIFF
--- a/src/utils/table/RowBuffer.ts
+++ b/src/utils/table/RowBuffer.ts
@@ -256,106 +256,91 @@ export class RowBuffer<R, K> {
     // Private (xxxLoad)
     //
 
-    private headLoad(key: K, rowCount: number, current: R[] = []): Promise<R[] | null> {
-        let result: Promise<R[] | null>
+    private async headLoad(key: K, rowCount: number, current: R[] = []): Promise<R[] | null> {
+        let result: R[]|null
 
         if (rowCount >= 1) {
-
-            const cb = (r: R[] | null): Promise<R[] | null> => {
-                let result: Promise<R[] | null>
-                if (r !== null) {
-                    current = r.reverse().concat(current)
-                    if (r.length < limitedCount) {
-                        result = Promise.resolve(current)
-                    } else {
-                        const headKey = this.tableController.keyFor(r[0])
-                        result = this.headLoad(headKey, remainingCount, current)
-                    }
-                } else {
-                    result = Promise.resolve(current)
-                }
-                return result
-            }
 
             const limitedCount = Math.min(this.tableController.maxLimit, rowCount)
             const remainingCount = rowCount - limitedCount
-            result = this.tableController.load(key, KeyOperator.gt, SortOrder.ASC, limitedCount).then(cb)
+            const r = await this.tableController.load(key, KeyOperator.gt, SortOrder.ASC, limitedCount)
+            if (r !== null) {
+                current = r.reverse().concat(current)
+                if (r.length < limitedCount) {
+                    result = current
+                } else {
+                    const headKey = this.tableController.keyFor(r[0])
+                    result = await this.headLoad(headKey, remainingCount, current)
+                }
+            } else {
+                result = current
+            }
 
         } else {
 
-            result = Promise.resolve(current)
+            result = current
 
         }
 
-        return result
+        return Promise.resolve(result)
     }
 
-    private tailLoad(key: K | null, rowCount: number, lte: boolean, current: R[] = []): Promise<R[] | null> {
-        let result: Promise<R[] | null>
+    private async tailLoad(key: K | null, rowCount: number, lte: boolean, current: R[] = []): Promise<R[] | null> {
+        let result: R[]|null
 
         if (rowCount >= 1) {
-
-            const cb = (r: R[] | null): Promise<R[] | null> => {
-                let result: Promise<R[] | null>
-                if (r !== null) {
-                    current = current.concat(r)
-                    if (r.length < limitedCount) {
-                        result = Promise.resolve(current)
-                    } else {
-                        const tailRow = r[r.length - 1]
-                        const tailKey = this.tableController.keyFor(tailRow)
-                        result = this.tailLoad(tailKey, remainingCount, false, current)
-                    }
-                } else {
-                    result = Promise.resolve(null)
-                }
-                return result
-            }
 
             const limitedCount = Math.min(this.tableController.maxLimit, rowCount)
             const remainingCount = rowCount - limitedCount
             const operator = lte ? KeyOperator.lte : KeyOperator.lt
-            result = this.tableController.load(key, operator, SortOrder.DESC, limitedCount).then(cb)
+            const r = await this.tableController.load(key, operator, SortOrder.DESC, limitedCount)
+            if (r !== null) {
+                current = current.concat(r)
+                if (r.length < limitedCount) {
+                    result = current
+                } else {
+                    const tailRow = r[r.length - 1]
+                    const tailKey = this.tableController.keyFor(tailRow)
+                    result = await this.tailLoad(tailKey, remainingCount, false, current)
+                }
+            } else {
+                result = null
+            }
 
         } else {
-            result = Promise.resolve(current)
+            result = current
         }
 
-        return result
+        return Promise.resolve(result)
     }
 
-    private lastLoad(key: K, rowCount: number, current: R[] = []): Promise<R[] | null> {
-        let result: Promise<R[] | null>
+    private async lastLoad(key: K, rowCount: number, current: R[] = []): Promise<R[] | null> {
+        let result: R[]|null
 
         if (rowCount >= 1) {
 
-            const cb = (r: R[] | null): Promise<R[] | null> => {
-                let result: Promise<R[] | null>
-                if (r !== null) {
-                    current = this.concatOrReplace(r, current)
-                    if (r.length < limitedCount) {
-                        result = Promise.resolve(current)
-                    } else {
-                        const key = this.tableController.keyFor(r[0])
-                        result = this.headLoad(key, remainingCount, current)
-                    }
-                } else {
-                    result = Promise.resolve(current)
-                }
-                return result
-            }
-
             const limitedCount = Math.min(this.tableController.maxLimit, rowCount)
             const remainingCount = rowCount - limitedCount
-            result = this.tableController.load(key, KeyOperator.gte, SortOrder.DESC, limitedCount).then(cb)
+            const r = await this.tableController.load(key, KeyOperator.gte, SortOrder.DESC, limitedCount)
+            if (r !== null) {
+                current = this.concatOrReplace(r, current)
+                if (r.length < limitedCount) {
+                    result = current
+                } else {
+                    const key = this.tableController.keyFor(r[0])
+                    result = await this.headLoad(key, remainingCount, current)
+                }
+            } else {
+                result = current
+            }
 
         } else {
 
-            result = Promise.resolve(current)
+            result = current
 
         }
 
-        return result
+        return Promise.resolve(result)
     }
 
     private concatOrReplace(newRows: R[], currentRows: R[]): R[] {

--- a/src/utils/table/TableController.ts
+++ b/src/utils/table/TableController.ts
@@ -332,8 +332,10 @@ export abstract class TableController<R, K> implements PlayPauseController {
         await this.bufferDidChange()
         if (this.refreshCountRef.value < this.maxAutoUpdateCount) {
             this.timeoutID = window.setTimeout(() => {
-                this.refreshCountRef.value += 1
-                this.refreshBuffer().catch(this.errorHandler)
+                if (this.autoRefresh.value) {
+                    this.refreshCountRef.value += 1
+                    this.refreshBuffer().catch(this.errorHandler)
+                }
             }, this.updatePeriod)
         } else {
             this.stopAutoRefresh()

--- a/tests/unit/utils/TableController.spec.ts
+++ b/tests/unit/utils/TableController.spec.ts
@@ -523,8 +523,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loadCounter).toBe(2)
         expect(currentRoute.value.query).toStrictEqual({p: "1", k: "49"})
-        expect(tc.getAbortedRefreshCounter()).toBe(1)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(1)
 
         // Unmount
         tc.unmount()
@@ -534,8 +533,7 @@ describe("TableController.ts", () => {
         expect(tc.refreshCount.value).toBe(0)
         expect(tc.loadCounter).toBe(2)
         expect(currentRoute.value.query).toStrictEqual({p: "1", k: "49"})
-        expect(tc.getAbortedRefreshCounter()).toBe(1)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(1)
     })
 
     test("mount + stop + immediate start auto refresh", async () => {
@@ -551,8 +549,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loadCounter).toBe(1) // +1 "refresh" operation
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(0)
 
         // Stop + immediate start auto refresh
         tc.stopAutoRefresh() // Starts "move to page" operation : all rows are loaded => completes instantaneously
@@ -564,8 +561,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loadCounter).toBe(2) // +1 "refresh"
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(0)
 
         // Unmount
         tc.unmount()
@@ -575,8 +571,7 @@ describe("TableController.ts", () => {
         expect(tc.refreshCount.value).toBe(0)
         expect(tc.loadCounter).toBe(2)
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(0)
     })
 
     test("brutal", async () => {
@@ -593,8 +588,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loadCounter).toBe(1) // +1 "refresh" operation
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(0)
 
         // Goto page 10, 20, 30 + play
         tc.onPageChange(10)
@@ -608,8 +602,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loadCounter).toBe(51) // +10 +20 +30 (aborted) "move to page" + 1 refresh
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(3)
+        expect(tc.getExecutedAbortCounter()).toBe(3)
 
         // Unmount
         tc.unmount()
@@ -619,8 +612,7 @@ describe("TableController.ts", () => {
         expect(tc.refreshCount.value).toBe(0)
         expect(tc.loadCounter).toBe(51)
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(3)
+        expect(tc.getExecutedAbortCounter()).toBe(3)
     })
 
     test("updating sources between mount / unmount", async () => {
@@ -638,8 +630,7 @@ describe("TableController.ts", () => {
         expect(tc.currentPage.value).toBe(1)
         expect(tc.loadCounter).toBe(1) // +1 "refresh" operation
         expect(currentRoute.value.query).toStrictEqual({})
-        expect(tc.getAbortedRefreshCounter()).toBe(0)
-        expect(tc.getAbortedMoveToPageCounter()).toBe(0)
+        expect(tc.getExecutedAbortCounter()).toBe(0)
 
         // Refresh #1
         vi.runOnlyPendingTimers()


### PR DESCRIPTION
**Description**:

Changes below fix auto refresh logic in two ways:
- `RowBuffer` class now manages a single abort flag (`RowBuffer.abortCounter` replaces `refreshCounter` and `moveToPageCounter`).
- `TableController.refreshBuffer()` now checks `autoRefresh` value (which might have changed in-between) before restarting the next refresh.

**Related issue(s)**:

Fixes #1634 

**Notes for reviewer**:

See #1634 for reproducing issue.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
