### PR TITLE
fix!: Add info-tooltips for Gas Used and Gas Consumed in ContractResult.

### DIFF
--- a/src/components/contract/ContractResult.vue
+++ b/src/components/contract/ContractResult.vue
@@ -83,7 +83,7 @@
             />
           </template>
         </Property>
-        <Property id="gasUsed">
+        <Property id="gasUsed" :tooltip="gasUsedTooltip">
           <template v-slot:name>Gas Used</template>
           <template v-slot:value>
             <GasAmount
@@ -92,7 +92,7 @@
             />
           </template>
         </Property>
-        <Property id="gasConsumed">
+        <Property id="gasConsumed" :tooltip="gasConsumedTooltip">
           <template v-slot:name>Gas Consumed</template>
           <template v-slot:value>
             <GasAmount
@@ -197,6 +197,9 @@ const props = defineProps({
     default: TransactionType.ETHEREUMTRANSACTION
   }
 })
+
+const gasUsedTooltip = "This represents the actual amount of gas (i.e. the real computational effort) required to execute the smart contract."
+const gasConsumedTooltip = "This represents the amount of gas that is actually deducted from the user's balance (i.e it may include additional factors like base fees or refunds, etc…)."
 
 const isSmallScreen = inject('isSmallScreen', true)
 const isMediumScreen = inject('isMediumScreen', true)


### PR DESCRIPTION
**Description**:

All is said in the title.

Note this is in no way a breaking change, but marked with `fix!` in order to trigger the switch to version numbers 25.x.y moving forward.

**Related issue(s)**:

Fixes #1621 

**Notes for reviewer**:
<img width="558" alt="Screenshot 2025-02-18 at 15 56 29" src="https://github.com/user-attachments/assets/0aad9eb1-f92b-4e89-8944-de531d34964d" />
<img width="558" alt="Screenshot 2025-02-18 at 15 56 38" src="https://github.com/user-attachments/assets/15e8ea23-ecb6-4c8f-bb0e-7ff38541e4dc" />

