### PR TITLE
fix: fixed tinybar to hbar conversion in NetworkFeeController

### DIFF
--- a/src/charts/hgraph/NetworkFeeController.ts
+++ b/src/charts/hgraph/NetworkFeeController.ts
@@ -42,7 +42,7 @@ export class NetworkFeeController extends GenericMetricController {
     protected async transformMetrics(metrics: EcosystemMetric[], range: ChartRange): Promise<EcosystemMetric[]> {
         const result = await super.transformMetrics(metrics, range);
         for (const m of result) {
-            m.total = Math.round(m.total / 10_000_000) // Convert to HBAR
+            m.total = Math.round(m.total / 100_000_000) // Convert to HBAR
         }
         return Promise.resolve(result)
     }


### PR DESCRIPTION
**Description**:
This is a one-line change to fix tbar to hbar conversion in `NetworkFeeController.transformMetrics`() method.

**Related issue(s)**:

None

**Notes for reviewer**:

Go to `Dashboard` tab and look at `Network Fees` chart in `Network` section : value for Feb 2024 should be `20_000_000` (not `200_000_000`).


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
