### PR TITLE
chore: removing unused code from MainDashboard vue

### DIFF
--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -69,7 +69,6 @@ import {TxOverTimeController} from "@/charts/hgraph/TxOverTimeController.ts";
 import ChartView from "@/charts/core/ChartView.vue";
 import {NetworkFeeController} from "@/charts/hgraph/NetworkFeeController.ts";
 import {ActiveAccountController} from "@/charts/hgraph/ActiveAccountController.ts";
-import {TPSMetricLoader} from "@/components/dashboard/metrics/TPSMetricLoader.ts";
 import {ThemeController} from "@/components/ThemeController.ts";
 import {routeManager} from "@/router.ts";
 
@@ -82,15 +81,6 @@ const themeController = ThemeController.inject()
 const txOverTimeController = new TxOverTimeController(themeController, routeManager)
 onMounted(() => txOverTimeController.mount())
 onBeforeUnmount(() => txOverTimeController.unmount())
-
-// const tpsController = new TPSController(themeController, routeManager)
-// onMounted(() => tpsController.mount())
-// onBeforeUnmount(() => tpsController.unmount())
-
-const tpsMetricLoader = new TPSMetricLoader()
-const currentTPS = tpsMetricLoader.currentTPS
-onMounted(() => tpsMetricLoader.mount())
-onBeforeUnmount(() => tpsMetricLoader.unmount())
 
 const networkFeeController = new NetworkFeeController(themeController, routeManager)
 onMounted(() => networkFeeController.mount())

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -68,7 +68,6 @@ describe("MainDashboard.vue", () => {
 
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/network/exchangerate",
-            "api/v1/blocks?limit=100",
             "api/v1/network/exchangerate",
             "api/v1/network/supply",
             "api/v1/network/supply",


### PR DESCRIPTION
**Description**:

Changes below remove some unused code: `MainDashboard` vue creates a `TPSMetricLoader` instance which is not used but generates some useless calls to `api/v1/blocks`.

**Related issue(s)**:

None

**Notes for reviewer**:

1) Go https://hashscan.io
2) Open `Network` tab in `Developer` panel
    => without the fix, periodic calls to `api/v1/blocks` are executed
    => with the fix, those calls no longer exist

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
