### PR TITLE
fix: bring back link to all transactions with same ID

### DIFF
--- a/src/components/ArrowLink.vue
+++ b/src/components/ArrowLink.vue
@@ -66,7 +66,6 @@ div.arrow-link {
   display: flex;
   gap: 2px;
   height: 18px;
-  justify-content: center;
 }
 
 span.link-text {

--- a/src/components/token/TokensSection.vue
+++ b/src/components/token/TokensSection.vue
@@ -126,6 +126,7 @@
           v-if="showAllTokensLink"
           :route="routeManager.makeRouteToTokensByAccount(accountId)"
           text="All tokens"
+          style="display: flex; justify-content: center;"
       />
     </template>
 

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -65,11 +65,12 @@
           <template #name>Type</template>
           <template #value>
             <StringValue :string-value="transactionType ? makeTypeLabel(transactionType) : null"/>
-            <div v-if="scheduledTransaction" id="scheduledLink">
-              <router-link :to="routeManager.makeRouteToTransactionObj(scheduledTransaction)">
-                <span class="h-is-low-contrast">Show scheduled transaction</span>
-              </router-link>
-            </div>
+            <ArrowLink
+                v-if="scheduledTransaction"
+                id="scheduledLink"
+                :route="routeManager.makeRouteToTransactionObj(scheduledTransaction)"
+                text="Scheduled transaction"
+            />
           </template>
         </Property>
         <Property v-if="displayResult" id="result">
@@ -194,11 +195,12 @@
           <template #name>Scheduled</template>
           <template v-if="transaction?.scheduled===true" #value>
             True
-            <div v-if="schedulingTransaction" id="schedulingLink">
-              <router-link :to="routeManager.makeRouteToTransactionObj(schedulingTransaction)">
-                <span class="h-is-low-contrast">Show schedule create transaction</span>
-              </router-link>
-            </div>
+            <ArrowLink
+                v-if="schedulingTransaction"
+                id="schedulingLink"
+                :route="routeManager.makeRouteToTransactionObj(schedulingTransaction)"
+                text="Schedule create transaction"
+            />
           </template>
           <template v-else-if="scheduledTransaction!==null" #value>
             False
@@ -227,10 +229,13 @@
                 <TokenExtra :token-id="id" :use-anchor="true"/>
               </span>
             </div>
-            <router-link v-if="displayAllChildrenLinks" class="h-is-low-contrast"
-                         :to="routeManager.makeRouteToTransactionsById(transactionId ?? '')">
-              {{ 'Show all ' + childTransactions.length + ' child transactions' }}
-            </router-link>
+            <ArrowLink
+                style="text-align: left"
+                v-if="displayAllChildrenLink"
+                id="allChildrenLink"
+                :route="routeManager.makeRouteToTransactionsById(transactionId ?? '')"
+                :text="'All ' + childTransactions.length + ' child transactions'"
+            />
           </template>
         </Property>
       </template>
@@ -334,7 +339,7 @@ onBeforeUnmount(() => transactionGroupLookup.unmount())
 
 const transactionGroupAnalyzer = new TransactionGroupAnalyzer(transactionGroupLookup.entity)
 
-const displayAllChildrenLinks = computed(() => {
+const displayAllChildrenLink = computed(() => {
   return transactionGroupAnalyzer.childTransactions.value.length > MAX_INLINE_CHILDREN
 })
 

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -38,6 +38,12 @@
             FAILURE
           </div>
         </template>
+        <ArrowLink
+            v-if="transactionId && displayAllTransactionsLink"
+            id="allTransactionsLink"
+            :route="routeManager.makeRouteToTransactionsById(transactionId)"
+            text="Transactions with same ID"
+        />
       </template>
       <template #right-control>
         <SelectView
@@ -294,6 +300,7 @@ import {CoreConfig} from "@/config/CoreConfig.ts";
 import SelectView from "@/elements/SelectView.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
+import ArrowLink from "@/components/ArrowLink.vue";
 
 const MAX_INLINE_CHILDREN = 10
 
@@ -303,6 +310,11 @@ const props = defineProps({
 })
 
 const cryptoName = CoreConfig.inject().cryptoName
+
+const displayAllTransactionsLink = computed(() => {
+  const txnCount = transactionGroupAnalyzer.transactions.value?.length ?? 0
+  return txnCount >= 2
+})
 
 const txIdForm = ref(TransactionID.useAtForm.value ? 'atForm' : 'dashForm')
 watch(txIdForm, () => TransactionID.setUseAtForm(txIdForm.value === 'atForm'))

--- a/tests/e2e/specs/TransactionNavigation.cy.ts
+++ b/tests/e2e/specs/TransactionNavigation.cy.ts
@@ -158,8 +158,7 @@ describe('Transaction Navigation', () => {
             })
     })
 
-    // TODO: To be re-enabled one "Show all transactions with same ID" is restored
-    it.skip('should follow link "Show all transactions with same ID"', () => {
+    it('should follow link "Transactions with same ID"', () => {
         const timestamp = "1674505116.619586693"
         const transactionId = "0.0.995584@1674505107.270597663"
 
@@ -167,7 +166,7 @@ describe('Transaction Navigation', () => {
         cy.url().should('include', '/mainnet/transaction/' + timestamp)
 
         cy.get('#allTransactionsLink')
-            .contains('Show all transactions with the same ID')
+            .contains('Transactions with same ID')
             .click()
 
         cy.url().should('include', '/mainnet/transactionsById/' + makeExchangeFormat(transactionId))

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -736,8 +736,8 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("Transaction " + TransactionID.normalizeForDisplay(SCHEDULING.transaction_id)))
 
         const link = wrapper.get("#scheduledLink")
-        expect(link.text()).toBe("Show scheduled transaction")
-        expect(link.get('a').attributes("href")).toBe(
+        expect(link.text()).toBe("Scheduled transaction")
+        expect(link.attributes("href")).toBe(
             "/mainnet/transaction/" + SCHEDULED.consensus_timestamp
         )
 
@@ -801,8 +801,8 @@ describe("TransactionDetails.vue", () => {
         expect(wrapper.text()).toMatch(RegExp("Transaction " + TransactionID.normalizeForDisplay(SCHEDULED.transaction_id)))
 
         const link = wrapper.get("#schedulingLink")
-        expect(link.text()).toBe("Show schedule create transaction")
-        expect(link.get('a').attributes("href")).toBe(
+        expect(link.text()).toBe("Schedule create transaction")
+        expect(link.attributes("href")).toBe(
             "/mainnet/transaction/" + SCHEDULING.consensus_timestamp
         )
 


### PR DESCRIPTION
**Description**:

In TransactionDetails view:

- Add link `Transactions with same ID ->`
- Align style of the following links:
  - `Scheduled transaction ->`
  - `Schedule create transaction ->`
  - `All nn child transactions ->`

**Related issue(s)**:

Fixes #1645 

**Notes for reviewer**:

<img width="913" alt="Screenshot 2025-02-27 at 17 23 01" src="https://github.com/user-attachments/assets/3f6ee9b6-50e1-4efb-8c9e-c52b94801107" />

-----

<img width="619" alt="Screenshot 2025-02-27 at 17 14 41" src="https://github.com/user-attachments/assets/13f54108-dc52-451a-9774-9020082d2071" />

-----

<img width="639" alt="Screenshot 2025-02-27 at 17 15 10" src="https://github.com/user-attachments/assets/7ae79a16-bee6-4c55-95e8-2b5079f1f67a" />

-----

<img width="619" alt="Screenshot 2025-02-27 at 17 16 08" src="https://github.com/user-attachments/assets/d5f790bf-741f-4ea6-8c02-b7955ee8fa80" />
