### PR TITLE
chore:  different icon in InfoTooltip for warning message

### DIFF
--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -24,12 +24,14 @@
 
 <template>
   <Tooltip
+      v-if="props.warningLabel || props.label"
       id="info-tooltip"
       :text="props.warningLabel ?? props.label"
       :position="props.position"
       style="height: 16px;"
   >
-    <Info :size="16" style="color: var(--network-text-accent-color);"/>
+    <TriangleAlert v-if="props.warningLabel" :size="16" style="color: var(--network-text-accent-color);"/>
+    <Info v-else :size="16" style="color: var(--network-text-accent-color);"/>
   </Tooltip>
 </template>
 
@@ -41,7 +43,7 @@
 
 import {PropType} from "vue";
 import Tooltip from "@/components/Tooltip.vue";
-import {Info} from "lucide-vue-next"
+import {Info, TriangleAlert} from "lucide-vue-next"
 
 const props = defineProps({
   warningLabel: {
@@ -52,7 +54,10 @@ const props = defineProps({
     type: String as PropType<string | null>,
     default: null
   },
-  position: String
+  position: {
+    type: String as PropType<string | null>,
+    default: 'auto'
+  },
 })
 
 </script>

--- a/tests/unit/infoTooltip.spec.ts
+++ b/tests/unit/infoTooltip.spec.ts
@@ -29,7 +29,7 @@ describe("InfoTooltip.vue", () => {
     const sampleInfoLabel = 'Sample information label'
     const sampleWarningLabel = 'Sample warning label'
     const infoIconClass = 'lucide-info-icon'
-    const warningIconClass = 'lucide-info-icon'
+    const warningIconClass = 'lucide-triangle-alert-icon'
 
     test("InfoTooltip with information message", async () => {
 
@@ -104,7 +104,7 @@ describe("InfoTooltip.vue", () => {
         wrapper.unmount()
     })
 
-    test.skip("InfoTooltip with no message", async () => {
+    test("InfoTooltip with no message", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -120,7 +120,7 @@ describe("InfoTooltip.vue", () => {
         // console.log(wrapper.html())
 
         expect(wrapper.text()).toBe('')
-        expect(wrapper.find('i').exists()).toBe(false)
+        expect(wrapper.find('svg').exists()).toBe(false)
 
         wrapper.unmount()
     })


### PR DESCRIPTION
**Description**:

Bring back the use of a triangle alert icon (vs. info icon) in InfoTooltip in case of warning message (was lost during UI revamp).
