### PR TITLE
fix: bring back (metadata) name of NFT in NftDetails.

### DIFF
--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -49,6 +49,12 @@
         />
       </template>
       <template #media-description>
+        <Property v-if="name" id="name" custom-nb-col-class="is-one-quarter">
+          <template #name>Name</template>
+          <template #value>
+            <BlobValue :blob-value="name"/>
+          </template>
+        </Property>
         <Property v-if="description" id="description" custom-nb-col-class="is-one-quarter">
           <template #name>Description</template>
           <template #value>
@@ -302,6 +308,7 @@ watch(serialNumber, () => {
 
 const nftInfo = nftLookup.entity
 const transactionType = transactionTableController.transactionType
+const name = metadataAnalyzer.name
 const creator = metadataAnalyzer.creator
 const description = metadataAnalyzer.description
 const type = metadataAnalyzer.type

--- a/tests/unit/token/NftDetails.spec.ts
+++ b/tests/unit/token/NftDetails.spec.ts
@@ -107,7 +107,7 @@ describe("NftDetails.vue", () => {
         expect(wrapper.vm.transactionTableController.mounted.value).toBe(false)
     });
 
-    it.skip("Should display NFT with image and metadata", async () => {
+    it("Should display NFT with image and metadata", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -129,7 +129,8 @@ describe("NftDetails.vue", () => {
 
         const wrapper = mount(NftDetails, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [router, Oruga],
+                provide: { "isMediumScreen": false }
             },
             props: {
                 tokenId: nftId,
@@ -142,11 +143,12 @@ describe("NftDetails.vue", () => {
         // expect((wrapper.vm as any).tokenBalanceTableController.mounted.value).toBe(true)
         expect(wrapper.vm.transactionTableController.mounted.value).toBe(true)
 
-        expect(wrapper.text()).toMatch(RegExp(IPFS_METADATA_CONTENT.name + 'Non Fungible Token'))
+        expect(wrapper.text()).toMatch(RegExp('Non Fungible Token'))
 
         const media = wrapper.get('#image-content')
         expect(media.find('img').exists()).toBe(true)
 
+        expect(wrapper.find("#nameValue").text()).toBe(IPFS_METADATA_CONTENT.name)
         expect(wrapper.find("#descriptionValue").text()).toBe(IPFS_METADATA_CONTENT.description)
         expect(wrapper.get("#tokenIdValue").text()).toBe(`${SAMPLE_NONFUNGIBLE.name}(${SAMPLE_NONFUNGIBLE.token_id})`)
         expect(wrapper.get("#serialNumberValue").text()).toBe(nft.serial_number.toString())


### PR DESCRIPTION
**Description**:

- Add property to display metadata name of the NFT. This used to be displayed at the title of the card and disappeared during the UI revamp.
- Re-enable the corresponding unit test.

**Notes for reviewer**:
<img width="1136" alt="Screenshot 2025-03-03 at 16 30 48" src="https://github.com/user-attachments/assets/91ede5d6-8c02-4782-b1e9-43bc0d1cdeb2" />

