### PR TITLE
fix: boost font size in SearchBar input field to avoid auto zoom.

### DIFF
--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -168,7 +168,7 @@ input {
   background-color: transparent;
   border-color: transparent;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 16px;
   outline: none;
 }
 


### PR DESCRIPTION
**Description**:

1-line change to use 16px font size in SearchBar input field. With a smaller font, certain browsers (incl. Safari) automatically zoom in to ease the input and never zoom back.

