### PR TITLE
feat: add option to filter out the dusting transactions (i.e. with tiny amounts transferred).

### DIFF
--- a/src/AppStorage.ts
+++ b/src/AppStorage.ts
@@ -351,6 +351,21 @@ export class AppStorage {
     }
 
     //
+    // minimum transfer value for filtering 'spam' CRYPTO TRANSFER transactions
+    //
+
+    private static readonly MIN_TINYBAR_TRANSFER_KEY = 'minTinyBarTransfer'
+
+    public static getMinTinyBarTransfer(): number | null {
+        const size = this.getLocalStorageItem(this.MIN_TINYBAR_TRANSFER_KEY)
+        return size ? Number(size) : null
+    }
+
+    public static setMinTinyBarTransfer(newValue: number | null): void {
+        this.setLocalStorageItem(this.MIN_TINYBAR_TRANSFER_KEY, newValue ? newValue?.toString() : null)
+    }
+
+    //
     // Private
     //
 

--- a/src/components/transaction/TransactionTableControllerXL.ts
+++ b/src/components/transaction/TransactionTableControllerXL.ts
@@ -6,13 +6,14 @@ import {ref, Ref, watch, WatchStopHandle} from "vue";
 import axios from "axios";
 import {LocationQuery, Router} from "vue-router";
 import {fetchStringQueryParam} from "@/utils/RouteManager";
-import {drainTransactions} from "@/schemas/MirrorNodeUtils.ts";
+import {drainAndFilterTransactions, drainTransactions} from "@/schemas/MirrorNodeUtils.ts";
 
 
 export class TransactionTableControllerXL extends TableController<Transaction, string> {
 
     private readonly accountId: Ref<string | null>
     private readonly accountIdMandatory: boolean
+    private readonly minTinyBar: Ref<number>
 
     //
     // Public
@@ -23,7 +24,8 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
                        pageSize: Ref<number>,
                        accountIdMandatory: boolean,
                        storageKey: string,
-                       pageParamName = "p", keyParamName = "k") {
+                       pageParamName = "p", keyParamName = "k",
+                       minTinyBar = ref(0)) {
         super(
             router,
             pageSize,
@@ -36,8 +38,9 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
         );
         this.accountId = accountId
         this.accountIdMandatory = accountIdMandatory
+        this.minTinyBar = minTinyBar
         this.storageKey = storageKey
-        this.watchAndReload([this.transactionType, this.accountId, this.pageSize])
+        this.watchAndReload([this.transactionType, this.accountId, this.pageSize, this.minTinyBar])
     }
 
     public readonly transactionType: Ref<string> = ref("")
@@ -73,7 +76,11 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
                 params.timestamp = operator + ":" + consensusTimestamp
             }
             const r = await axios.get<TransactionResponse>("api/v1/transactions", {params: params})
-            result = await drainTransactions(r.data, limit)
+            if (this.accountId.value && this.minTinyBar.value > 0) {
+                result = await drainAndFilterTransactions(r.data, limit, this.minTinyBar.value, this.accountId.value)
+            } else {
+                result = await drainTransactions(r.data, limit)
+            }
         }
 
         return Promise.resolve(result)

--- a/src/components/transaction/TransactionTableControllerXL.ts
+++ b/src/components/transaction/TransactionTableControllerXL.ts
@@ -64,7 +64,7 @@ export class TransactionTableControllerXL extends TableController<Transaction, s
                 transactiontype: string | undefined
                 timestamp: string | undefined
             }
-            params.limit = limit
+            params.limit = (this.minTinyBar.value > 0) ? 100 : limit
             params.order = order
             if (this.accountId.value !== null) {
                 params["account.id"] = this.accountId.value

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -275,7 +275,7 @@
               :tabLabels="tabLabels"
               @update:selected-tab="handleTabUpdate($event)"
           />
-          <div style="display: flex; align-items: baseline; justify-content: flex-end; gap: 8px;">
+          <div v-if="selectedTab === 'transactions'" style="display: flex; align-items: baseline; justify-content: flex-end; gap: 8px;">
             <div>Hide transfers below</div>
             <SelectView v-model="minTinyBar" small :style="{'font-size':minTinyBar!=0?'12px':'10px'}" style="width: 110px">
               <option value=100000000>

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -267,12 +267,36 @@
       </template>
 
       <template #content>
-        <Tabs
-            :selected-tab="selectedTab"
-            :tab-ids="tabIds"
-            :tabLabels="tabLabels"
-            @update:selected-tab="handleTabUpdate($event)"
-        />
+
+        <div style="display: flex; align-items: baseline; justify-content: space-between; flex-wrap: wrap; gap:16px">
+          <Tabs
+              :selected-tab="selectedTab"
+              :tab-ids="tabIds"
+              :tabLabels="tabLabels"
+              @update:selected-tab="handleTabUpdate($event)"
+          />
+          <div style="display: flex; align-items: baseline; justify-content: flex-end; gap: 8px;">
+            <div>Hide transfers below</div>
+            <SelectView v-model="minTinyBar" small :style="{'font-size':minTinyBar!=0?'12px':'10px'}" style="width: 110px">
+              <option value=100000000>
+                <HbarAmount :amount="100000000"/>
+              </option>
+              <option value=10000000>
+                <HbarAmount :amount="10000000"/>
+              </option>
+              <option value=1000000>
+                <HbarAmount :amount="1000000"/>
+              </option>
+              <option value=100000>
+                <HbarAmount :amount="100000"/>
+              </option>
+              <option value=10000>
+                <HbarAmount :amount="10000"/>
+              </option>
+              <option value=0>NONE</option>
+            </SelectView>
+          </div>
+        </div>
 
         <div v-if="selectedTab === 'transactions'" id="recentTransactionsTable">
           <TransactionTable v-if="account" :controller="transactionTableController" :narrowed="true"/>
@@ -404,6 +428,9 @@ function onDateCleared() {
   // (1) will restart auto-refresh
 }
 
+const minTinyBar = ref(AppStorage.getMinTinyBarTransfer() ?? 0)
+watch(minTinyBar, (newValue) => AppStorage.setMinTinyBarTransfer(newValue))
+
 //
 // account
 //
@@ -478,7 +505,8 @@ const transactionTableController = new TransactionTableControllerXL(
     perPage,
     true,
     AppStorage.ACCOUNT_OPERATION_TABLE_PAGE_SIZE_KEY,
-    "p1", "k1")
+    "p1", "k1",
+    minTinyBar)
 
 const contractCreateTableController = new TransactionTableController(
     router,

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -277,21 +277,21 @@
           />
           <div v-if="selectedTab === 'transactions'" style="display: flex; align-items: baseline; justify-content: flex-end; gap: 8px;">
             <div>Hide transfers below</div>
-            <SelectView v-model="minTinyBar" small :style="{'font-size':minTinyBar!=0?'12px':'10px'}" style="width: 110px">
+            <SelectView v-model="minTinyBar" small :style="{'font-size':minTinyBar!=0?'12px':'10px'}" style="min-width: 70px">
+              <option value=500000000>
+                <HbarAmount :amount="500000000" :decimals="0"/>
+              </option>
+              <option value=400000000>
+                <HbarAmount :amount="400000000" :decimals="0"/>
+              </option>
+              <option value=300000000>
+                <HbarAmount :amount="300000000" :decimals="0"/>
+              </option>
+              <option value=200000000>
+                <HbarAmount :amount="200000000" :decimals="0"/>
+              </option>
               <option value=100000000>
-                <HbarAmount :amount="100000000"/>
-              </option>
-              <option value=10000000>
-                <HbarAmount :amount="10000000"/>
-              </option>
-              <option value=1000000>
-                <HbarAmount :amount="1000000"/>
-              </option>
-              <option value=100000>
-                <HbarAmount :amount="100000"/>
-              </option>
-              <option value=10000>
-                <HbarAmount :amount="10000"/>
+                <HbarAmount :amount="100000000" :decimals="0"/>
               </option>
               <option value=0>NONE</option>
             </SelectView>

--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -394,8 +394,10 @@ export async function drainTransactions(r: TransactionResponse, limit: number): 
     let result = r.transactions ?? []
     // let i = 1
     while (r.links?.next && result.length < limit) {
-        // console.log("drain iteration: " + i);
-        // i += 1
+        // console.log(`drainTransactions (iteration ${i++})`)
+        // console.log(`  - limit:${limit}`)
+        // console.log(`  - result.length:${result.length}`)
+        // console.log(`  - r.links.next:${r.links.next}`)
         const ar = await axios.get<TransactionResponse>(r.links.next)
         if (ar.data.transactions) {
             result = result.concat(ar.data.transactions)
@@ -437,8 +439,10 @@ export async function drainAndFilterTransactions(
     let result = (r.transactions ?? []).filter(filterTinyTxn)
     // let i = 1
     while (r.links?.next && result.length < limit) {
-        // console.log("drain iteration: " + i);
-        // i += 1
+        // console.log(`drainAndFilterTransactions (iteration ${i++})`)
+        // console.log(`  - limit:${limit}`)
+        // console.log(`  - result.length:${result.length}`)
+        // console.log(`  - r.links.next:${r.links.next}`)
         const ar = await axios.get<TransactionResponse>(r.links.next)
         if (ar.data.transactions) {
             result = result.concat(ar.data.transactions.filter(filterTinyTxn))

--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -417,9 +417,9 @@ export async function drainAndFilterTransactions(
     const MAX_DRAIN_ITERATION_WHEN_FILTERING = 40
 
     // This function is used to filter out what we consider as 'spam' transactions
-    // A transaction is considered spam if it contains a CREDIT transfer involving the user account which has an amount
+    // A transaction is considered spam if it contains a transfer involving the user account which has an amount
     // below the limit chosen by the user (e.g. 1 hbar).
-    // The amount considered is the net value of the transfer -- we deduce the amount of the perceived staking reward if any.
+    // The amount considered is the (absolute) net value of the transfer -- we deduce the amount of the perceived staking reward if any.
     const filterTinyTxn = (txn: Transaction) => {
         let filter = true
         let reward = 0
@@ -430,8 +430,8 @@ export async function drainAndFilterTransactions(
                 }
             }
             for (const t of txn.transfers) {
-                if (t.account === account && t.amount > 0) {
-                    const netAmount = t.amount - reward
+                if (t.account === account) {
+                    const netAmount = Math.abs(t.amount - reward)
                     if (netAmount < minTinyBar) {
                         filter = false
                     }

--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -416,6 +416,10 @@ export async function drainAndFilterTransactions(
 
     const MAX_DRAIN_ITERATION_WHEN_FILTERING = 40
 
+    // This function is used to filter out what we consider as 'spam' transactions
+    // A transaction is considered spam if it contains a CREDIT transfer involving the user account which has an amount
+    // below the limit chosen by the user (e.g. 1 hbar).
+    // The amount considered is the net value of the transfer -- we deduce the amount of the perceived staking reward if any.
     const filterTinyTxn = (txn: Transaction) => {
         let filter = true
         let reward = 0
@@ -426,7 +430,7 @@ export async function drainAndFilterTransactions(
                 }
             }
             for (const t of txn.transfers) {
-                if (t.account === account) {
+                if (t.account === account && t.amount > 0) {
                     const netAmount = t.amount - reward
                     if (netAmount < minTinyBar) {
                         filter = false

--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -414,6 +414,8 @@ export async function drainAndFilterTransactions(
     account: string
 ): Promise<Transaction[]> {
 
+    const MAX_DRAIN_ITERATION_WHEN_FILTERING = 40
+
     const filterTinyTxn = (txn: Transaction) => {
         let filter = true
         let reward = 0
@@ -437,9 +439,9 @@ export async function drainAndFilterTransactions(
     }
 
     let result = (r.transactions ?? []).filter(filterTinyTxn)
-    // let i = 1
-    while (r.links?.next && result.length < limit) {
-        // console.log(`drainAndFilterTransactions (iteration ${i++})`)
+    let i = 0
+    while (r.links?.next && result.length < limit && i < MAX_DRAIN_ITERATION_WHEN_FILTERING) {
+        // console.log(`drainAndFilterTransactions (iteration ${i + 1})`)
         // console.log(`  - limit:${limit}`)
         // console.log(`  - result.length:${result.length}`)
         // console.log(`  - r.links.next:${r.links.next}`)
@@ -448,6 +450,7 @@ export async function drainAndFilterTransactions(
             result = result.concat(ar.data.transactions.filter(filterTinyTxn))
         }
         r = ar.data
+        i += 1
     }
     return result
 }


### PR DESCRIPTION
**Description**:

Add a selector to the Recent Transactions table in AccountDetails, to optionally filter transaction with a net transfer (to or from this account) which is smaller that the specified amount. This amount can be set to 1, 2, 3, 4 or 5 hbar.

**Related issue(s)**:

Fixes #1627 

**Notes for reviewer**:

Deployed on the staging server.

<img width="1120" alt="Screenshot 2025-03-10 at 19 29 22" src="https://github.com/user-attachments/assets/9abbcde4-785e-49dd-a55a-ce85b8587a54" />

<img width="1120" alt="Screenshot 2025-03-10 at 19 33 43" src="https://github.com/user-attachments/assets/b5bd11a4-2735-4d92-b632-f7774420fc4e" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
