### PR TITLE
feat: Add the admin_key for nodes

### DIFF
--- a/src/components/values/ComplexKeyValue.vue
+++ b/src/components/values/ComplexKeyValue.vue
@@ -6,7 +6,7 @@
 
 <template>
   <div v-if="key">
-    <div v-if=" !details && maxLevel >= MAX_INLINE_LEVEL && adminKeyRoute">
+    <div v-if=" !inDetailsPage && maxLevel >= MAX_INLINE_LEVEL && adminKeyRoute">
       <span>{{ 'Complex Key (' + (maxLevel + 1) + ' levels)' }}</span>
       <router-link v-if="adminKeyRoute" :to="adminKeyRoute">
         <span class="ml-2 h-is-low-contrast">
@@ -14,11 +14,11 @@
         </span>
       </router-link>
     </div>
-    <div v-else :style="containerStyle(details ? 30 : 20)">
+    <div v-else :style="containerStyle(inDetailsPage ? 30 : 20)">
       <template v-for="line in lines" :key="line.seqNb">
         <div :style="lineStyle(line)">
           <template v-if="line.innerKeyBytes() !== null">
-            <div v-if="details" :class="lineClass(line)">
+            <div v-if="inDetailsPage" :class="lineClass(line)">
               <span class="h-is-extra-text">{{ line.innerKeyType() }}</span>
               <span class="h-is-monospace h-is-low-contrast">{{ ':&#8239;' + line.innerKeyBytes() }}</span>
             </div>
@@ -36,7 +36,7 @@
             <ContractLink :contract-id="line.delegatableContractId()"/>
           </template>
           <template v-else>
-            <div v-if="details && line.level" :class="lineClass(line)">{{ lineText(line) }}</div>
+            <div v-if="inDetailsPage && line.level" :class="lineClass(line)">{{ lineText(line) }}</div>
             <div v-else>{{ lineText(line) }}</div>
           </template>
         </div>
@@ -84,7 +84,11 @@ const props = defineProps({
     type: String as PropType<string | null>,
     default: null
   },
-  details: {
+  nodeId: {
+    type: Number as PropType<number | null>,
+    default: null
+  },
+  inDetailsPage: {
     type: Boolean,
     default: false
   },
@@ -160,7 +164,11 @@ const lineText = (line: ComplexKeyLine): string => {
 }
 
 const adminKeyRoute = computed(() => {
-  return props.accountId ? routeManager.makeRouteToAdminKey(props.accountId) : null
+  return props.accountId !== null
+      ? routeManager.makeRouteToAdminKey(props.accountId)
+      : props.nodeId !== null
+          ? routeManager.makeRouteToNodeAdminKey(props.nodeId.toString())
+          : null
 })
 
 const initialLoading = inject(initialLoadingKey, ref(false))

--- a/src/components/values/KeyValue.vue
+++ b/src/components/values/KeyValue.vue
@@ -6,10 +6,16 @@
 
 <template>
   <template v-if="isComplexKey">
-    <ComplexKeyValue :account-id="accountId" :details="details" :key-bytes="keyBytes" :show-none="showNone"/>
+    <ComplexKeyValue
+        :account-id="accountId"
+        :node-id="nodeId"
+        :in-details-page="inDetailsPage"
+        :key-bytes="keyBytes"
+        :show-none="showNone"
+    />
   </template>
   <template v-else>
-    <div v-if="details">
+    <div v-if="inDetailsPage">
       <span class="h-is-extra-text">{{ keyType }}</span>
       <span class="h-is-monospace h-is-low-contrast">{{ ':&#8239;' + keyBytes }}</span>
     </div>
@@ -43,7 +49,11 @@ const props = defineProps({
     type: String as PropType<string | null>,
     default: null
   },
-  details: {
+  nodeId: {
+    type: Number as PropType<number | null>,
+    default: null
+  },
+  inDetailsPage: {
     type: Boolean,
     default: false
   },

--- a/src/pages/AdminKeyDetails.vue
+++ b/src/pages/AdminKeyDetails.vue
@@ -26,7 +26,7 @@
       <template #content>
         <KeyValue
             v-if="normalizedAccountId"
-            :details="true"
+            :in-details-page="true"
             :key-bytes="key?.key"
             :key-type="key?._type"
             :show-none="true"

--- a/src/pages/NodeAdminKeyDetails.vue
+++ b/src/pages/NodeAdminKeyDetails.vue
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <PageFrameV2 page-title="Admin Key Details">
+
+    <DashboardCardV2>
+      <template #title>
+        <span>Admin Key for Node </span>
+        <div v-if="nodeId !== null">
+          <router-link :to="routeManager.makeRouteToNode(nodeId)">
+            <span>{{ nodeId }} - {{ nodeDescription }}</span>
+          </router-link>
+        </div>
+      </template>
+
+      <template #content>
+        <KeyValue
+            v-if="nodeId !== null"
+            :in-details-page="true"
+            :key-bytes="nodeKey?.key"
+            :key-type="nodeKey?._type"
+            :show-none="true"
+        />
+      </template>
+    </DashboardCardV2>
+
+  </PageFrameV2>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script setup lang="ts">
+
+import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
+import PageFrameV2 from "@/components/page/PageFrameV2.vue";
+import KeyValue from "@/components/values/KeyValue.vue";
+import DashboardCardV2 from "@/components/DashboardCardV2.vue";
+import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer.ts";
+import {routeManager} from "@/router.ts";
+
+const props = defineProps({
+  nodeId: {
+    type: String as PropType<string | null>,
+    default: null
+  },
+  network: String
+})
+
+//
+// node
+//
+
+const nodeLocator = computed(() => props.nodeId ?? null)
+const nodeAnalyzer = new NodeAnalyzer(nodeLocator)
+onMounted(() => nodeAnalyzer.mount())
+onBeforeUnmount(() => nodeAnalyzer.unmount())
+
+const nodeId = nodeAnalyzer.nodeId
+const nodeKey = nodeAnalyzer.adminKey
+const nodeDescription = nodeAnalyzer.shortNodeDescription
+
+</script>
+
+<style/>

--- a/src/pages/NodeAdminKeyDetails.vue
+++ b/src/pages/NodeAdminKeyDetails.vue
@@ -58,12 +58,21 @@ const props = defineProps({
 // node
 //
 
-const nodeLocator = computed(() => props.nodeId ?? null)
-const nodeAnalyzer = new NodeAnalyzer(nodeLocator)
+const nodeId = computed(() => {
+  let result: number | null
+  if (props.nodeId !== null) {
+    const id = parseInt(props.nodeId)
+    result = isNaN(id) || id < 0 ? null : id
+  } else {
+    result = null
+  }
+  return result;
+})
+
+const nodeAnalyzer = new NodeAnalyzer(nodeId)
 onMounted(() => nodeAnalyzer.mount())
 onBeforeUnmount(() => nodeAnalyzer.unmount())
 
-const nodeId = nodeAnalyzer.nodeId
 const nodeKey = nodeAnalyzer.adminKey
 const nodeDescription = nodeAnalyzer.shortNodeDescription
 

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -54,6 +54,17 @@
             <Endpoints :endpoints="node?.service_endpoints"></Endpoints>
           </template>
         </Property>
+        <Property id="adminKey">
+          <template #name>Admin Key</template>
+          <template #value>
+            <KeyValue
+                :node-id="nodeIdNb"
+                :key-bytes="node?.admin_key?.key"
+                :key-type="node?.admin_key?._type"
+                :show-none="true"
+            />
+          </template>
+        </Property>
         <template v-if="enableStaking">
           <Property id="publicKey">
             <template #name>Public Key</template>

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -704,15 +704,16 @@ export interface NetworkNodesResponse {
 }
 
 export interface NetworkNode {
-    description: string | null | undefined
-    file_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    memo: string | undefined
-    node_id: number | undefined
-    node_account_id: string | null | undefined   // Network entity ID in the format of shard.realm.num
-    node_cert_hash: string | null | undefined
-    public_key: string | null | undefined   // hex encoded X509 RSA public key used to sign stream files
-    service_endpoints: ServiceEndPoint[] | undefined
-    timestamp: TimestampRange | undefined
+    admin_key: Key | null
+    description: string | null
+    file_id: string | null          // Network entity ID in the format of shard.realm.num
+    memo: string
+    node_id: number
+    node_account_id: string | null  // Network entity ID in the format of shard.realm.num
+    node_cert_hash: string | null
+    public_key: string | null       // hex encoded X509 RSA public key used to sign stream files
+    service_endpoints: ServiceEndPoint[]
+    timestamp: TimestampRange
     max_stake: number | null // The maximum stake (rewarded or not rewarded) this node can have as consensus weight
     min_stake: number | null // The minimum stake (rewarded or not rewarded) this node must reach before having non-zero consensus weight
     stake: number | null // The node consensus weight at the beginning of the staking period

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -22,6 +22,7 @@ import Accounts from "@/pages/Accounts.vue";
 import AccountsWithKey from "@/pages/AccountsWithKey.vue";
 import AccountDetails from "@/pages/AccountDetails.vue";
 import AdminKeyDetails from "@/pages/AdminKeyDetails.vue";
+import NodeAdminKeyDetails from "@/pages/NodeAdminKeyDetails.vue";
 import AddressDetails from "@/pages/AddressDetails.vue";
 import Tokens from "@/pages/Tokens.vue";
 import TokenDetails from "@/pages/TokenDetails.vue";
@@ -268,6 +269,12 @@ export class RouteManager {
     public makeRouteToAdminKey(accountId: string): RouteLocationRaw {
         return {
             name: 'AdminKeyDetails', params: {accountId: accountId, network: this.currentNetwork.value}
+        }
+    }
+
+    public makeRouteToNodeAdminKey(nodeId: string): RouteLocationRaw {
+        return {
+            name: 'NodeAdminKeyDetails', params: {nodeId: nodeId, network: this.currentNetwork.value}
         }
     }
 
@@ -551,6 +558,9 @@ export class RouteManager {
             case "AdminKeyDetails":
                 document.title = titlePrefix + "Admin Key for Account " + to.params.accountId
                 break;
+            case "NodeAdminKeyDetails":
+                document.title = titlePrefix + "Admin Key for Node" + to.params.nodeId
+                break;
             case "NodeDetails":
                 document.title = titlePrefix + "Node " + to.params.nodeId
                 break;
@@ -802,6 +812,15 @@ const routes: Array<RouteRecordRaw> = [
         props: true,
         meta: {
             tabId: TabId.Accounts
+        }
+    },
+    {
+        path: '/:network/nodeAdminKey/:nodeId',
+        name: 'NodeAdminKeyDetails',
+        component: NodeAdminKeyDetails,
+        props: true,
+        meta: {
+            tabId: TabId.Nodes
         }
     },
     {

--- a/src/utils/analyzer/NodeAnalyzer.ts
+++ b/src/utils/analyzer/NodeAnalyzer.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, ComputedRef, Ref} from "vue";
-import {makeShortNodeDescription, NetworkNode} from "@/schemas/MirrorNodeSchemas";
+import {Key, makeShortNodeDescription, NetworkNode} from "@/schemas/MirrorNodeSchemas";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 import {
     makeAnnualizedRate,
@@ -45,7 +45,7 @@ export class NodeAnalyzer {
         } else if (typeof this.nodeLoc.value == "string") {
             result = null
             for (const node of this.networkAnalyzer.nodes.value) {
-                if (node.node_account_id == this.nodeLoc.value) {
+                if (node.node_id.toString() == this.nodeLoc.value) {
                     result = node
                     break
                 }
@@ -66,6 +66,10 @@ export class NodeAnalyzer {
 
     public readonly shortNodeDescription: ComputedRef<string | null> = computed(
         () => this.nodeDescription.value ? makeShortNodeDescription(this.nodeDescription.value) : null)
+
+    public adminKey: ComputedRef<Key | null> = computed(() => this.node.value?.admin_key ?? null)
+
+    public nodeId: ComputedRef<number | null> = computed(() => this.node.value?.node_id ?? null)
 
     //
     // Public (staking)

--- a/src/utils/analyzer/NodeAnalyzer.ts
+++ b/src/utils/analyzer/NodeAnalyzer.ts
@@ -45,7 +45,7 @@ export class NodeAnalyzer {
         } else if (typeof this.nodeLoc.value == "string") {
             result = null
             for (const node of this.networkAnalyzer.nodes.value) {
-                if (node.node_id.toString() == this.nodeLoc.value) {
+                if (node.node_account_id == this.nodeLoc.value) {
                     result = node
                     break
                 }

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -2651,6 +2651,31 @@ export const SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS = {
     "links": {"next": null}
 }
 
+// Node account inspired from https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.3
+
+export const SAMPLE_NODE_ACCOUNT = {
+    "account": "0.0.3",
+    "alias": null,
+    "auto_renew_period": 105825166,
+    "balance": {"balance": 18831892607754, "timestamp": "1741801141.170140000", "tokens": []},
+    "created_timestamp": "1706812520.644859497",
+    "decline_reward": false,
+    "deleted": false,
+    "ethereum_nonce": 0,
+    "evm_address": "0x0000000000000000000000000000000000000003",
+    "expiry_timestamp": "1812637686.644859497",
+    "key": {"_type": "ED25519", "key": "e06b22e0966108fa5d63fc6ae53f9824319b891cd4d6050dbf2b242be7e13344"},
+    "max_automatic_token_associations": 0,
+    "memo": "",
+    "pending_reward": 0,
+    "receiver_sig_required": false,
+    "staked_account_id": null,
+    "staked_node_id": null,
+    "stake_period_start": null,
+    "transactions": [],
+    "links": {"next": "/api/v1/accounts/3?timestamp=lt:1741801116.340191143"}
+}
+
 //
 // Contract inspired from: https://mainnet-public.mirrornode.hedera.com/api/v1/contracts/0.0.749775
 //

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -3331,6 +3331,10 @@ export const SAMPLE_TOPIC_DUDE_MESSAGES = {
 export const SAMPLE_NETWORK_NODES = {
     "nodes": [
         {
+            "admin_key": {
+                "_type": "ED25519",
+                "key": "c67e3c4172e3eea8e4f45714240e453ab8702e7fc13d7ea58e523e6caeb8a38e"
+            },
             "description": "Hosted by Hedera | East Coast, USA",
             "file_id": "0.0.102",
             "memo": "0.0.3",
@@ -3402,6 +3406,10 @@ export const SAMPLE_NETWORK_NODES = {
             "staking_period": null
         },
         {
+            "admin_key": {
+                "_type": "ProtobufEncoded",
+                "key": "2aa2040802129d040a221220d40d60cfe24c1e6e63eddbbbb857c6540759e02514b1a151d8147f07d4e3eaee0ad2032acf03080112ca030a221220775334a1a5d250c3bfc75b8b81fa2d5fc8fed7d5dab4b2a5ec272aa952aa377c0a2212205b18a5aa454e99759a2e5d9c4f3239dbc3584f69ab26383470446874bb7f79d10a2212203aa16f6f6cf5b95057ba1854cf5822a446d082b37212a3f1c164babadb713f870a93023290020a221220b3a3e302a74198085e0752495528a6bc475b6bc1f4ba9ae246d9235e5a45e43c0a221220b31d0cfc76ea431928330adfc3094780985876c87864bfe094f956dee4e05d9a0a221220c5b759fee0f23620330deea250bd1a66602f8d847bc181482e268d63e16ae16a0aa101329e010a9b013298010a722a700801126c0a221220b5d243760381ec28f8df73ca2707761720482612071fead9a8a14ff1e0c2f36a0a2212202f170df8b57ee630c42e408a6fc749e4ee62174fce66b9e03c9d9b4e68d35d400a221220bce139f0d9e6d69076f8915fcc32209ade6debaca3f05ee5a713e652b65e73290a221220a4c8bfd29c164be686c18d9ddbb09c3a47a375a57f32f6df6aec9ccef80f817c0a221220c5040cb52c20d2ab9496893fca0b690cb13855e6e55231e63360c3976e64a25c0a22122078b769551a81d0fd10c3b5390abb3de92ed4878977a119c2be2039247d8182da0a2212205b18a5aa454e99759a2e5d9c4f3239dbc3584f69ab26383470446874bb7f79d1"
+            },
             "description": "Hosted by Hedera | Central, USA",
             "file_id": "0.0.102",
             "memo": "0.0.5",

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -19,6 +19,7 @@ import {
     SAMPLE_FAILED_TRANSACTIONS,
     SAMPLE_NETWORK_EXCHANGERATE,
     SAMPLE_NETWORK_NODES,
+    SAMPLE_NODE_ACCOUNT,
     SAMPLE_NONFUNGIBLE,
     SAMPLE_TOKEN,
     SAMPLE_TOKEN_DUDE,
@@ -174,6 +175,91 @@ describe("AccountDetails.vue", () => {
 
         expect(wrapper.find("#recentTransactions").exists()).toBe(true)
         expect(wrapper.findComponent(TransactionTable).exists()).toBe(true)
+
+        mock.restore()
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("Should display a node account details", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios as any);
+
+        const accountId = SAMPLE_NODE_ACCOUNT.account
+        const nodeId = 0
+
+        const matcher1 = "api/v1/accounts/" + accountId
+        mock.onGet(matcher1).reply(200, SAMPLE_NODE_ACCOUNT);
+
+        const matcher2 = "api/v1/network/nodes"
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_NODES);
+
+        mock.onGet("/api/v1/transactions").reply(200, []);
+
+        mock.onGet("api/v1/tokens").reply(200, []);
+
+        const matcher8 = "api/v1/accounts/" + accountId + "/nfts"
+        mock.onGet(matcher8).reply(200, {nfts: []});
+
+        const matcher9 = "/api/v1/accounts/" + accountId + "/allowances/crypto"
+        mock.onGet(matcher9).reply(200, {allowances: []})
+
+        const matcher10 = "/api/v1/accounts/" + accountId + "/allowances/tokens"
+        mock.onGet(matcher10).reply(200, {allowances: []})
+
+        const matcher11 = "/api/v1/accounts/" + accountId + "/allowances/nfts"
+        mock.onGet(matcher11).reply(200, {allowances: []})
+
+        const matcher14 = "api/v1/accounts/" + accountId + "/airdrops/pending"
+        mock.onGet(matcher14).reply(200, {airdrops: []});
+
+        const wrapper = mount(AccountDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                accountId: SAMPLE_NODE_ACCOUNT.account ?? undefined
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/" + accountId,
+            "api/v1/network/nodes",
+            "api/v1/accounts/0.0.3/rewards?limit=1",
+            "api/v1/balances",
+            "api/v1/contracts/" + accountId,
+            "api/v1/transactions",
+            "api/v1/network/exchangerate",
+            "api/v1/transactions",
+            "api/v1/accounts/" + accountId + "/nfts",
+            "api/v1/tokens",
+            "api/v1/accounts/" + accountId + "/airdrops/pending",
+            "api/v1/accounts/" + accountId + "/airdrops/pending",
+            "api/v1/accounts/" + accountId + "/allowances/crypto",
+            "api/v1/accounts/" + accountId + "/allowances/tokens",
+            "api/v1/accounts/" + accountId + "/nfts",
+            "api/v1/accounts/" + accountId + "/nfts",
+            "api/v1/tokens",
+            "api/v1/accounts/" + accountId + "/airdrops/pending",
+            "api/v1/accounts/" + accountId + "/airdrops/pending",
+            "api/v1/accounts/" + accountId + "/allowances/crypto",
+            "api/v1/accounts/" + accountId + "/allowances/tokens",
+            "api/v1/accounts/" + accountId + "/nfts",
+            "api/v1/accounts/" + accountId + "/allowances/nfts",
+            "api/v1/accounts/" + accountId + "/allowances/nfts",
+        ])
+
+        expect(wrapper.text()).toMatch("Account  Account ID " + accountId)
+
+        expect(wrapper.find("#nodeLinkValue").exists()).toBe(true)
+        const link = wrapper.get("#nodeLinkValue")
+        expect(link.text()).toBe("0 - Hosted by Hedera | East Coast, USA")
+        expect(link.get('a').attributes('href')).toMatch(RegExp("/node/" + nodeId + "$"))
 
         mock.restore()
         wrapper.unmount()

--- a/tests/unit/account/NodeAdminKeyDetails.spec.ts
+++ b/tests/unit/account/NodeAdminKeyDetails.spec.ts
@@ -1,0 +1,116 @@
+// noinspection DuplicatedCode
+
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, test} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import router from "@/router";
+import axios from "axios";
+import {SAMPLE_NETWORK_NODES,} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
+import KeyValue from "@/components/values/KeyValue.vue";
+import {fetchGetURLs} from "../MockUtils";
+import NodeAdminKeyDetails from "@/pages/NodeAdminKeyDetails.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+describe("NodeAdminKeyDetails.vue", () => {
+
+    test("NodeAdminKeyDetails displaying complex (Protobuf) key", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+        const mock = new MockAdapter(axios as any);
+
+        const node = 2
+        const matcher1 = "api/v1/network/nodes"
+        mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
+
+        const wrapper = mount(NodeAdminKeyDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                nodeId: node.toString()
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+        ])
+
+        expect(wrapper.text()).toMatch("Admin Key for Node " + node + ' - Hosted by Hedera')
+        const key = wrapper.findComponent(ComplexKeyValue)
+        expect(key.exists()).toBe(true)
+        expect(key.text()).toBe(
+            "THRESHOLD (2 of 3)" +
+            "ED25519: d40d60cfe24c1e6e63eddbbbb857c6540759e02514b1a151d8147f07d4e3eaee" +
+            "THRESHOLD (1 of 6)" +
+            "ED25519: 775334a1a5d250c3bfc75b8b81fa2d5fc8fed7d5dab4b2a5ec272aa952aa377c" +
+            "ED25519: 5b18a5aa454e99759a2e5d9c4f3239dbc3584f69ab26383470446874bb7f79d1" +
+            "ED25519: 3aa16f6f6cf5b95057ba1854cf5822a446d082b37212a3f1c164babadb713f87" +
+            "LIST (all of 4)" +
+            "ED25519: b3a3e302a74198085e0752495528a6bc475b6bc1f4ba9ae246d9235e5a45e43c" +
+            "ED25519: b31d0cfc76ea431928330adfc3094780985876c87864bfe094f956dee4e05d9a" +
+            "ED25519: c5b759fee0f23620330deea250bd1a66602f8d847bc181482e268d63e16ae16a" +
+            "LIST (all of 2)" +
+            "THRESHOLD (1 of 3)" +
+            "ED25519: b5d243760381ec28f8df73ca2707761720482612071fead9a8a14ff1e0c2f36a" +
+            "ED25519: 2f170df8b57ee630c42e408a6fc749e4ee62174fce66b9e03c9d9b4e68d35d40" +
+            "ED25519: bce139f0d9e6d69076f8915fcc32209ade6debaca3f05ee5a713e652b65e7329" +
+            "ED25519: a4c8bfd29c164be686c18d9ddbb09c3a47a375a57f32f6df6aec9ccef80f817c" +
+            "ED25519: c5040cb52c20d2ab9496893fca0b690cb13855e6e55231e63360c3976e64a25c" +
+            "ED25519: 78b769551a81d0fd10c3b5390abb3de92ed4878977a119c2be2039247d8182da" +
+            "ED25519: 5b18a5aa454e99759a2e5d9c4f3239dbc3584f69ab26383470446874bb7f79d1"
+        )
+
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    test("NodeAdminKeyDetails displaying simple (ED25519) key", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+        const mock = new MockAdapter(axios as any);
+
+        const node = 0
+        const matcher1 = "api/v1/network/nodes"
+        mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
+
+        const wrapper = mount(NodeAdminKeyDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                nodeId: node.toString()
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+        ])
+
+        expect(wrapper.text()).toMatch("Admin Key for Node " + node + ' - Hosted by Hedera')
+        const key = wrapper.findComponent(KeyValue)
+        expect(key.exists()).toBe(true)
+        expect(key.text()).toBe("ED25519: c67e3c4172e3eea8e4f45714240e453ab8702e7fc13d7ea58e523e6caeb8a38e")
+
+        wrapper.unmount()
+        await flushPromises()
+    });
+});

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -69,6 +69,8 @@ describe("NodeDetails.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toMatch(RegExp("Node " + node))
+
+        expect(wrapper.get("#adminKeyValue").text()).toBe("0xc67e3c4172e3eea8e4f45714240e453ab8702e7fc13d7ea58e523e6caeb8a38e" + "Copy" + "ED25519")
         expect(wrapper.get("#nodeAccountValue").text()).toBe("0.0.3")
         expect(wrapper.get("#descriptionValue").text()).toBe("Hosted by Hedera | East Coast, USA")
         expect(wrapper.get("#publicKeyValue").text()).toBe("0x308201a2300d0609CopyRSA")
@@ -151,4 +153,38 @@ describe("NodeDetails.vue", () => {
         await flushPromises()
     });
 
+    it("should display node details with complex admin-key and link", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+        const mock = new MockAdapter(axios as any);
+
+        const node = 2
+        const matcher1 = "api/v1/network/nodes"
+        mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
+
+        const matcher2 = "api/v1/network/stake"
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
+
+        const wrapper = mount(NodeDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                nodeId: node.toString()
+            }
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(wrapper.text()).toMatch(RegExp("Node " + node))
+
+        expect(wrapper.get("#adminKeyValue").text()).toBe("Complex Key (6 levels) See details")
+
+        mock.restore()
+        wrapper.unmount()
+        await flushPromises()
+    });
 });

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -162,9 +162,6 @@ describe("NodeDetails.vue", () => {
         const matcher1 = "api/v1/network/nodes"
         mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
 
-        const matcher2 = "api/v1/network/stake"
-        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
-
         const wrapper = mount(NodeDetails, {
             global: {
                 plugins: [router, Oruga],


### PR DESCRIPTION
**Description**:

This PR handles the new admin_key property for nodes:
- displays the property inline in NodeDetails when the key is simple, and a link to a dedicated page when complex (similar to what is done for accounts.
- adds a NodeAdminKeyDetails page to display the details of a node admin_key, similar to AdminKeyDetails for account key.

**Related issue(s)**:

Fixes #1720

**Notes for reviewer**:

- deployed on staging server
- screenshots below:

<img width="839" alt="Screenshot 2025-03-12 at 16 13 41" src="https://github.com/user-attachments/assets/62c4a85e-f77b-45e0-8319-5e53c1aaaf7c" />

____

<img width="839" alt="Screenshot 2025-03-12 at 16 14 08" src="https://github.com/user-attachments/assets/644f7e44-8a3a-4119-9ca2-1613d78aee9c" />

____

<img width="839" alt="Screenshot 2025-03-12 at 16 14 46" src="https://github.com/user-attachments/assets/217a983b-0dc3-46ed-b97a-7298559c8b0e" />

