### PR TITLE
fix: ABI tab unable to call a function when connected through Metamask extension

### DIFF
--- a/src/utils/wallet/client/WalletClient_Ethereum.ts
+++ b/src/utils/wallet/client/WalletClient_Ethereum.ts
@@ -107,7 +107,7 @@ export class WalletClient_Ethereum extends WalletClient {
 
 
     public async callContract(contractId: string, functionData: string): Promise<ContractResultDetails | string> {
-        throw "to be implemented"
+        return this.executeCall(contractId, functionData)
     }
 
     //


### PR DESCRIPTION
**Description**:

Changes below add missing implementation for `WalletClient_Ethereum.callContract()`.

**Related issue(s)**:

Fixes #1735

**Notes for reviewer**:

See #1735 for reproducing the issue.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
