### PR TITLE
fix: show topic custom fees section even when fixed_fees are empty

### DIFF
--- a/src/components/topic/TopicFeesSection.vue
+++ b/src/components/topic/TopicFeesSection.vue
@@ -6,7 +6,7 @@
 
 <template>
 
-  <DashboardCardV2 v-if="hasFixedFees" collapsible-key="customFees">
+  <DashboardCardV2 collapsible-key="customFees">
 
     <template #title>
       Custom Fees
@@ -23,7 +23,8 @@
       <Property id="fixedFee" full-width>
         <template #name>Fixed Fees</template>
         <template #value>
-          <FixedFeeTable :fees="props.fees.fixed_fees ?? []"/>
+          <FixedFeeTable v-if="fixedFees.length" :fees="fixedFees"/>
+          <div v-else class="h-is-low-contrast">None</div>
         </template>
       </Property>
 
@@ -53,7 +54,7 @@ const props = defineProps({
   }
 })
 
-const hasFixedFees = computed(() => props.fees.fixed_fees.length > 0)
+const fixedFees = computed(() => props.fees.fixed_fees)
 
 </script>
 


### PR DESCRIPTION
**Description**:

It is possible to have a topic with `custom_fees` containing empty `fixed_fees` (even if it does not make much sense).
With the following change, we display the Custom Fees section instead of hiding it in this particular case (to help diagnose a potential issue).

**Notes for reviewer**:

We now display the following in such a case:

<img width="626" alt="Screenshot 2025-04-10 at 16 05 57" src="https://github.com/user-attachments/assets/3e3360db-8ccb-4b4f-a04f-c0312c86044f" />
