### PR TITLE
fix: rename Admin Key property to Node Admin Key

### DIFF
--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -73,7 +73,7 @@
           </template>
         </Property>
         <Property id="adminKey">
-          <template #name>Admin Key</template>
+          <template #name>Node Admin Key</template>
           <template #value>
             <KeyValue
                 :node-id="nodeIdNb"


### PR DESCRIPTION
**Description**:

1-line change to rename property in NodeDetails view.

**Related issue(s)**:

Fixes #2053 
