### PR TITLE
chore: removed some explicit use of "any"

### DIFF
--- a/src/charts/hgraph/HgraphChartController.ts
+++ b/src/charts/hgraph/HgraphChartController.ts
@@ -4,7 +4,7 @@ import {ChartController, LoadedData} from "@/charts/core/ChartController.ts";
 import {ChartGranularity, ChartRange, computeGranularityForRange} from "@/charts/core/ChartRange.ts";
 import {aggregateMetrics, EcosystemMetric, getEndDate, getStartDate} from "@/charts/hgraph/EcosystemMetric.ts";
 import axios, {AxiosRequestConfig} from "axios";
-import {ChartConfiguration} from "chart.js";
+import {ChartConfiguration, ChartDataset} from "chart.js";
 
 export abstract class HgraphChartController extends ChartController<EcosystemMetric> {
 
@@ -26,7 +26,7 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
                                  context: CanvasRenderingContext2D): ChartConfiguration {
         const granularity = computeGranularityForRange(range)
         const graphLabels = makeGraphLabels(metrics, granularity)
-        const graphDataSet = this.makeBarGraphDataSet(metrics, context) as any
+        const graphDataSet = this.makeBarGraphDataSet(metrics, context)
         const textPrimaryColor = this.themeController.getTextPrimaryColor()
         const textSecondaryColor = this.themeController.getTextSecondaryColor()
         const yScaleType = logarithmic ? "logarithmic" : "linear"
@@ -78,7 +78,7 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
                                   context: CanvasRenderingContext2D): ChartConfiguration {
         const granularity = computeGranularityForRange(range)
         const graphLabels = makeGraphLabels(metrics, granularity)
-        const graphDataSet = this.makeLineGraphDataSet(metrics, context) as any
+        const graphDataSet = this.makeLineGraphDataSet(metrics, context)
         const textPrimaryColor = this.themeController.getTextPrimaryColor()
         const textSecondaryColor = this.themeController.getTextSecondaryColor()
         const yScaleType = logarithmic ? "logarithmic" : "linear"
@@ -133,7 +133,7 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
     }
 
     protected makeBarGraphDataSet(metrics: EcosystemMetric[],
-                                  context: CanvasRenderingContext2D): object {
+                                  context: CanvasRenderingContext2D): ChartDataset {
         const totals = metrics.map((m: EcosystemMetric) => m.total)
         const graphBarColor = this.themeController.getGraphBarColor()
         return {
@@ -146,7 +146,7 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
     }
 
     protected makeLineGraphDataSet(metrics: EcosystemMetric[],
-                                   context: CanvasRenderingContext2D): object {
+                                   context: CanvasRenderingContext2D): ChartDataset {
         const totals = metrics.map((m: EcosystemMetric) => m.total)
         const graphLineColor = this.themeController.getGraphLineColor()
         const gradient = context.createLinearGradient(0, 0, 0, 300)

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -242,7 +242,7 @@ const handleDownload = async () => {
       zip.file(filePath, file.content);
     }
     zip.generateAsync({type: "blob"})
-        .then(function (content: any) {
+        .then(function (content: Blob) {
           const zipName = props.contractAnalyzer.contractAddress.value + '.zip'
           saveAs(content, zipName);
         });

--- a/src/config/ConfigUtils.ts
+++ b/src/config/ConfigUtils.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-export function fetchBoolean(obj: any, key: string): boolean | null {
+export function fetchBoolean(obj: Record<string, unknown>, key: string): boolean | null {
     let result: boolean | null
     if (key in obj) {
         const value = obj[key]
@@ -17,7 +17,7 @@ export function fetchBoolean(obj: any, key: string): boolean | null {
     return result
 }
 
-export function fetchNumber(obj: any, key: string): number | null {
+export function fetchNumber(obj: Record<string, unknown>, key: string): number | null {
     let result: number | null
     if (key in obj) {
         const value = obj[key]
@@ -34,7 +34,7 @@ export function fetchNumber(obj: any, key: string): number | null {
     return result
 }
 
-export function fetchString(obj: any, key: string): string | null {
+export function fetchString(obj: Record<string, unknown>, key: string): string | null {
     let result: string | null
     if (key in obj) {
         const value = obj[key]
@@ -51,7 +51,7 @@ export function fetchString(obj: any, key: string): string | null {
     return result
 }
 
-export function fetchURL(obj: any, key: string): string | null {
+export function fetchURL(obj: Record<string, unknown>, key: string): string | null {
     let result: string | null
     const s = fetchString(obj, key)
     if (s !== null) {
@@ -66,14 +66,14 @@ export function fetchURL(obj: any, key: string): string | null {
     return result
 }
 
-export function fetchObject(obj: any, key: string): object | null {
-    let result: object | null
+export function fetchObject(obj: Record<string, unknown>, key: string): Record<string, unknown> | null {
+    let result: Record<string, unknown> | null
     if (key in obj) {
         const value = obj[key]
         if (value === null) {
             result = null
         } else if (typeof value === 'object') {
-            result = value
+            result = value as Record<string, unknown>
         } else {
             throw new TypeError('Expected ' + key + ' to be object, got ' + typeof value)
         }

--- a/src/config/CoreConfig.ts
+++ b/src/config/CoreConfig.ts
@@ -18,7 +18,7 @@ export class CoreConfig {
         let result: CoreConfig
         const response = await axios.get<unknown>(url)
         if (response.status === 200 && typeof response.data === "object" && response.data !== null) {
-            result = this.parse(response.data)
+            result = this.parse(response.data as Record<string, unknown>)
         } else {
             throw new Error("core-config.json is missing or cannot be decoded")
         }
@@ -98,7 +98,7 @@ export class CoreConfig {
     ) {
     }
 
-    private static parse(obj: object): CoreConfig {
+    private static parse(obj: Record<string, unknown>): CoreConfig {
         return new CoreConfig(
             fetchString(obj, "productName") ?? "Hiero Explorer",
             fetchURL(obj, "productLogoLightURL") ?? localPathToURL("product-logo-light.png") ,

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -14,7 +14,7 @@ export class SourcifySetup {
     // Public
     //
 
-    static parse(obj: object): SourcifySetup {
+    static parse(obj: Record<string, unknown>): SourcifySetup {
 
         const activate = fetchBoolean(obj, "activate") ?? true
         const repoURL = fetchURL(obj, "repoURL")
@@ -80,7 +80,7 @@ export class NetworkEntry {
 
     public static readonly NETWORK_NAME_MAX_LENGTH = 15
 
-    static parse(obj: object): NetworkEntry {
+    static parse(obj: Record<string, unknown>): NetworkEntry {
 
         const name = fetchString(obj, "name")
         const displayName = fetchString(obj, "displayName")

--- a/src/dialogs/verification/ContractVerificationController.ts
+++ b/src/dialogs/verification/ContractVerificationController.ts
@@ -94,13 +94,7 @@ export class ContractVerificationController extends TaskController {
     //
 
     public readonly extraErrorMessage = computed(() => {
-        let result: string | null
-        if (this.verificationError.value !== null) {
-            result = (this.verificationError.value as any).toString()
-        } else {
-            result = null
-        }
-        return result
+        return this.verificationError.value?.toString() ?? null
     })
 
     //

--- a/src/utils/HCSAssetFragment.ts
+++ b/src/utils/HCSAssetFragment.ts
@@ -11,13 +11,13 @@ export class HCSAssetFragment {
 
     public static parse(topicMessage: TopicMessage): HCSAssetFragment | null {
         let result: HCSAssetFragment | null
-        let chunk: any
+        let chunk: Record<string, unknown>|null
         try {
             chunk = JSON.parse(atob(topicMessage.message))
         } catch {
             chunk = null
         }
-        if (chunk !== null && chunk.o != undefined && chunk.c != undefined) {
+        if (chunk !== null && typeof chunk.o === "number" && typeof chunk.c === "string") {
             result = new HCSAssetFragment(
                 chunk.o,
                 chunk.c

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -123,7 +123,7 @@ export class FunctionCallAnalyzer {
                     result.push(
                         new NameTypeValue("signature", "string", this.callDecoder.signature.value, null, null),
                     )
-                    for (let ntv of this.callDecoder.decodedInput.value) {
+                    for (const ntv of this.callDecoder.decodedInput.value) {
                         result.push(ntv)
                     }
                 }

--- a/src/utils/cache/SourcifyCache.ts
+++ b/src/utils/cache/SourcifyCache.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import axios, {AxiosResponse} from "axios";
+import axios from "axios";
 import {EntityCache} from "@/utils/cache/base/EntityCache";
 import {SolcMetadata} from "@/utils/solc/SolcMetadata";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
@@ -49,10 +49,10 @@ export class SourcifyCache extends EntityCache<string, SourcifyRecord | null> {
             queryParams.append('addresses', addressesToCheck.slice(i, i + MAX_VERIFICATIONS).join());
             const requestURL = `${baseURL}?${queryParams.toString()}`;
 
-            const sourcifyResponse: AxiosResponse<Array<any>> = await axios.get<Array<any>>(requestURL)
+            const sourcifyResponse = await axios.get<Array<Record<string, unknown>>>(requestURL)
             if (sourcifyResponse.data) {
                 for (const r of sourcifyResponse.data) {
-                    if ('chainIds' in r) {
+                    if ('chainIds' in r && typeof r.address === 'string') {
                         verifiedAddresses.push(r.address.toLowerCase())
                     }
                 }

--- a/src/utils/name_service/provider/HNSProvider.ts
+++ b/src/utils/name_service/provider/HNSProvider.ts
@@ -2,6 +2,7 @@
 
 import {NameServiceProvider} from "@/utils/name_service/provider/NameServiceProvider";
 import {Resolver} from '@hedera-name-service/hns-resolution-sdk'
+import {NetworkType} from "@hedera-name-service/hns-resolution-sdk/dist/types/NetworkType";
 
 export class HNSProvider extends NameServiceProvider {
 
@@ -36,7 +37,7 @@ export class HNSProvider extends NameServiceProvider {
 
     private findResolver(network: string): Resolver | null {
 
-        let service: string | null
+        let service: NetworkType | null
         switch (network) {
             case "mainnet":
                 service = "hedera_main"
@@ -53,7 +54,7 @@ export class HNSProvider extends NameServiceProvider {
         if (service !== null) {
             result = this.resolverCache.get(service) ?? null
             if (result == null) {
-                result = new Resolver(service as any)
+                result = new Resolver(service)
                 this.resolverCache.set(service, result)
             }
         } else {

--- a/src/utils/wallet/WalletConnectAgent.ts
+++ b/src/utils/wallet/WalletConnectAgent.ts
@@ -383,7 +383,7 @@ class Provider_WC implements EIP1193Provider {
     request(request: { method: string, params?: Array<unknown> } | object): Promise<unknown> {
         const requestParams = {
             topic: this.session.topic,
-            request: request as any,
+            request: request as { method: string; params: unknown; },
             chainId: this.caChainId.toString()
         }
         return this.signClient.request(requestParams)

--- a/src/utils/wallet/client/WalletClient_Ethereum.ts
+++ b/src/utils/wallet/client/WalletClient_Ethereum.ts
@@ -142,7 +142,7 @@ export class WalletClient_Ethereum extends WalletClient {
     }
 
     private async sendTransaction(fromAddress: string, toAddress: string, callData: string, value: string|null): Promise<string> {
-        const ethParams: Record<string, any> = {
+        const ethParams: Record<string, unknown> = {
             from: fromAddress,
             to: toAddress,
             data: callData,


### PR DESCRIPTION
**Description**:

Changes below remove some explicit uses of `any` reported by `eslint`.
Goal is to someday switch `@typescript-eslint/no-explicit-any` on in `eslint.config.mjs`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
