### PR TITLE
fix: BlobValue when displaying JSON

### DIFF
--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -29,7 +29,7 @@
 
       <template v-else>
         <div v-if="decodedValue.length > 1024"
-             class="json-formatting h-code-box is-inline-block h-should-wrap">
+             class="scrollable-content h-code-box is-inline-block h-should-wrap">
           <span id="blob-main">
             {{ (b64EncodingFound && showBase64AsExtra) ? blobValue : decodedValue }}
           </span>
@@ -172,7 +172,11 @@ const decodedValue = computed(() => {
 
 div.json-formatting {
   white-space: pre-wrap;
-  max-height: 200px;
+}
+
+div.scrollable-content {
+  max-height: 50px;
+  overflow: auto;
 }
 
 </style>


### PR DESCRIPTION
**Description**:

Fix BlobValue such that JSON content is properly displayed -- it will always be displayed in full and non JSON content keeps max size and is scrollable.

**Notes for reviewer**:

Before fix:
<img width="1076" height="580" alt="Screenshot 2025-07-30 at 20 15 38" src="https://github.com/user-attachments/assets/eb837393-b77f-46d9-8f88-3ec04c2c913f" />

After fix:
<img width="1076" height="580" alt="Screenshot 2025-07-30 at 20 16 23" src="https://github.com/user-attachments/assets/6781bdca-22b8-4722-b59a-e2a288e62fae" />
