### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/flow-release-explorer.yaml
+++ b/.github/workflows/flow-release-explorer.yaml
@@ -109,6 +109,7 @@ jobs:
             marked-mangle@1.1.10 marked-gfm-heading-id@4.1.1 semantic-release-conventional-commits@3.0.0
 
       - name: Finalize Release
+        working-directory: _frontend
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
**Description**:

Update `.github/workflows/flow-release-explorer.yaml` to make sure the semantic-versioning step is run from the _frontend/ directory, which is where all explorer code (including `package.json`) is now located.

**Note:** I  have run this version of the workflow in dry-run mode, but since the subsequent workflows releasing container and chart do not complete successfuly, I am not 100%  sure this change will be enough for the overall release process to succeed.
