### PR TITLE
fix: change operations tab to transactions

### DIFF
--- a/_frontend/src/components/token/TokensSection.vue
+++ b/_frontend/src/components/token/TokensSection.vue
@@ -169,7 +169,7 @@ const claimActionEnabled = true
 
 const tabIds = ['fungible', 'nfts', 'pendingAirdrop']
 
-const tabLabels = ['Fungible', 'NFTs', 'Pending Airdrops']
+const tabLabels = ['Fungible', 'NFTs', 'Pending airdrops']
 const selectedTab = ref<string | null>(AppStorage.getAccountTokenTab() ?? tabIds[0])
 const onSelectTab = (tab: string | null) => {
   selectedTab.value = tab

--- a/_frontend/src/components/values/ContractByteCodeValue.vue
+++ b/_frontend/src/components/values/ContractByteCodeValue.vue
@@ -97,7 +97,7 @@ onMounted(() => showAssemblyBytecode.value = AppStorage.getShowAssemblyBytecode(
 watch(showAssemblyBytecode, () => AppStorage.setShowAssemblyBytecode(showAssemblyBytecode.value ? showAssemblyBytecode.value : null))
 
 const tabIds = ['runtime', 'creation']
-const tabLabels = ['Runtime Bytecode', 'Creation Bytecode']
+const tabLabels = ['Runtime bytecode', 'Creation bytecode']
 const selectedTab = ref<string | null>(AppStorage.getContractByteCodeTab() ?? tabIds[0])
 const handleTabUpdate = (tab: string | null) => {
   selectedTab.value = tab

--- a/_frontend/src/pages/AccountDetails_Operations.vue
+++ b/_frontend/src/pages/AccountDetails_Operations.vue
@@ -9,7 +9,7 @@
   <template v-if="!isInactiveEvmAddress">
     <DashboardCardV2 v-if="!isInactiveEvmAddress">
       <template #title>
-        <p id="recentTransactions">Recent Operations</p>
+        <p id="recentTransactions">Recent Transactions</p>
       </template>
 
       <template #left-control>
@@ -102,7 +102,7 @@
   </template>
   <template v-else>
     <DashboardCardV2 v-if="accountId">
-      <template #title>Recent Operations</template>
+      <template #title>Recent Transactions</template>
       <template #content>
         <DocSnippet><p>There is no activity on this account because it is not yet activated.</p></DocSnippet>
       </template>
@@ -187,7 +187,7 @@ onMounted(() => accountLocParser.mount())
 onBeforeUnmount(() => accountLocParser.unmount())
 
 const tabIds = enableStaking ? ['transactions', 'contracts', 'rewards'] : ['transactions', 'contracts']
-const tabLabels = enableStaking ? ['Transactions', 'Created Contracts', 'Staking Rewards'] : ['Transactions', 'Created Contracts']
+const tabLabels = enableStaking ? ['All transactions', 'Created contracts', 'Staking rewards'] : ['Transactions', 'Created contracts']
 const selectedTab = ref<string | null>(AppStorage.getAccountOperationTab() ?? tabIds[0])
 const handleTabUpdate = (tab: string | null) => {
   selectedTab.value = tab

--- a/_frontend/src/router.ts
+++ b/_frontend/src/router.ts
@@ -506,7 +506,7 @@ export const NODES_ROUTE: RouteRecordRaw =     {
             component: Nodes_NodeTable,
             props: true,
             meta: {
-                tabLabel: "Node Table"
+                tabLabel: "Node table"
             }
         },
     ],

--- a/_frontend/src/router.ts
+++ b/_frontend/src/router.ts
@@ -424,7 +424,7 @@ export const ACCOUNT_DETAILS_ROUTE: RouteRecordRaw = {
             component: AccountDetails_Operations,
             props: true,
             meta: {
-                tabLabel: "Operations"
+                tabLabel: "Transactions"
             }
         },
         {

--- a/_frontend/tests/e2e/specs/TopNavigationBar.cy.ts
+++ b/_frontend/tests/e2e/specs/TopNavigationBar.cy.ts
@@ -63,7 +63,7 @@ describe('Top Navigation Bar', () => {
 
         cy.contains('Nodes').click()
         cy.contains('Network')
-        cy.contains('Node Table')
+        cy.contains('Node table')
 
         cy.contains('Staking').click()
         cy.contains('My Staking')

--- a/_frontend/tests/unit/account/AccountDetails.spec.ts
+++ b/_frontend/tests/unit/account/AccountDetails.spec.ts
@@ -41,6 +41,7 @@ import PageHeader from "@/components/page/header/PageHeader.vue";
 import router, {routeManager} from "@/utils/RouteManager.ts";
 import AccountDetails_Operations from "@/pages/AccountDetails_Operations.vue";
 import AccountDetails_Summary from "@/pages/AccountDetails_Summary.vue";
+import Tabs from "@/components/Tabs.vue";
 
 /*
     Bookmarks
@@ -53,7 +54,59 @@ HMSF.forceUTC = true
 
 describe("AccountDetails.vue", () => {
 
-    it("AccountDetails should display account details", async () => {
+    it("AccountDetails should display top level tabs", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios as any);
+
+        const matcher1 = "/api/v1/accounts/" + SAMPLE_ACCOUNT.account
+        mock.onGet(matcher1).reply(200, SAMPLE_ACCOUNT);
+
+        const wrapper = mount(AccountDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                accountId: SAMPLE_ACCOUNT.account ?? undefined
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/exchangerate",
+            "api/v1/accounts/" + SAMPLE_ACCOUNT.account,
+            "api/v1/network/nodes",
+            "api/v1/contracts/" + SAMPLE_ACCOUNT.account,
+            "api/v1/network/exchangerate",
+            "api/v1/balances",
+            "api/v1/accounts/" + SAMPLE_ACCOUNT.account + "/hooks",
+            "api/v1/transactions",
+            "api/v1/contracts/" + SAMPLE_ACCOUNT.evm_address,
+            "api/v1/tokens/" + SAMPLE_ACCOUNT.account,
+        ])
+
+        expect(wrapper.getComponent(PageHeader).text()).toMatch("Account " + SAMPLE_ACCOUNT.account)
+
+        const tab = wrapper.findComponent(Tabs)
+        expect(tab.exists()).toBe(true)
+        const tabs = tab.findAll('li')
+        expect(tabs.length).toBe(5)
+
+        expect(tabs[0].text()).toBe('Summary')
+        expect(tabs[1].text()).toBe('Assets')
+        expect(tabs[2].text()).toBe('Transactions')
+        expect(tabs[3].text()).toBe('Allowances')
+        expect(tabs[4].text()).toBe('Hooks')
+
+        mock.restore()
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("AccountDetails default tab should display account summary", async () => {
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any);
@@ -170,6 +223,17 @@ describe("AccountDetails.vue", () => {
             "api/v1/tokens/" + SAMPLE_TRANSACTION.token_transfers[0].token_id,
             "api/v1/blocks",
         ])
+
+        const tab = wrapper.findComponent(Tabs)
+        expect(tab.exists()).toBe(true)
+        const tabs = tab.findAll('li')
+        expect(tabs.length).toBe(3)
+
+        expect(tabs[0].text()).toBe('All transactions')
+        expect(tabs[1].text()).toBe('Created contracts')
+        expect(tabs[2].text()).toBe('Staking rewards')
+
+        expect(wrapper.text()).toMatch("Recent Transactions")
 
         const select = wrapper.findComponent(TransactionFilterSelect)
         expect(select.exists()).toBe(true)

--- a/_frontend/tests/unit/account/TokensSection.spec.ts
+++ b/_frontend/tests/unit/account/TokensSection.spec.ts
@@ -179,7 +179,7 @@ describe("TokensSection.vue", () => {
         expect(tabs.length).toBe(3)
         expect(tabs[0].text()).toBe('Fungible')
         expect(tabs[1].text()).toBe('NFTs')
-        expect(tabs[2].text()).toBe('Pending Airdrops')
+        expect(tabs[2].text()).toBe('Pending airdrops')
 
         wrapper.unmount()
         await flushPromises()

--- a/_frontend/tests/unit/contract/ContractDetails.spec.ts
+++ b/_frontend/tests/unit/contract/ContractDetails.spec.ts
@@ -129,8 +129,8 @@ describe("ContractDetails.vue", () => {
 
         const tabs = tabComponent.findAll('li')
         expect(tabs.length).toBe(2)
-        expect(tabs[0].text()).toBe('Runtime Bytecode')
-        expect(tabs[1].text()).toBe('Creation Bytecode')
+        expect(tabs[0].text()).toBe('Runtime bytecode')
+        expect(tabs[1].text()).toBe('Creation bytecode')
 
         expect(wrapper2.get("#bytecode").text()).toContain(
             "6080 6040 5236 606d 5730 73ff ffff ffff ffff ffff ffff ffff ffff ffff ffff ff16 3373 ffff ffff ffff ffff" +


### PR DESCRIPTION
**Description**:

- Rename the "Operations" tab to "Transactions" in the Account Details page.
- Apply sentence case (i.e. only first word capitalized) to all tab labels: 
  - account details tabs ("All transactions", "Created contracts", "Staking rewards"), 
  - token tabs ("Pending airdrops"), 
  - contract bytecode tabs ("Runtime bytecode", "Creation bytecode"), 
  - Nodes page ("Node table")
- Expand AccountDetails  unit tests

**Related issue(s)**:

Fixes #2346

**Notes for reviewer**:

I made that change to tab labels because title case feels really heavy there.
moreover, I tend to think we should also get rid of title case (all words capitalized) pretty much everywhere, as this is starting to look dated...

Fix deployed on staging server.