### PR TITLE
feat: disable in app contract verification

### DIFF
--- a/_frontend/.env
+++ b/_frontend/.env
@@ -10,3 +10,6 @@ VITE_APP_ACTIVATE_HIP_1137=true
 
 # When set to true, support for HIP-1137 (registered nodes) will be mocked.
 VITE_APP_MOCK_HIP_1137=false
+
+# When set to true, switch to enable verified contract filtering is hidden
+VITE_APP_HIDE_VERIFIED_FILTER=true

--- a/_frontend/.env
+++ b/_frontend/.env
@@ -3,7 +3,7 @@
 ###
 
 # When set to true, this variable will enable the support for HIP-1195 (Hiero hooks)
-VITE_APP_ACTIVATE_HIP_1195=true
+VITE_APP_ACTIVATE_HIP_1195=false
 
 # When set to true, this variable will enable the support for HIP-1137 (registered nodes)
 VITE_APP_ACTIVATE_HIP_1137=true

--- a/_frontend/public/networks-config.json
+++ b/_frontend/public/networks-config.json
@@ -19,6 +19,7 @@
       "activate": true,
       "repoURL": "https://repo.sourcify.dev/",
       "serverURL": "https://sourcify.dev/server/",
+      "verifierURL": "https://verify.sourcify.dev/",
       "chainID": 295
     }
   },
@@ -41,6 +42,7 @@
       "activate": true,
       "repoURL": "https://repo.sourcify.dev/",
       "serverURL": "https://sourcify.dev/server/",
+      "verifierURL": "https://verify.sourcify.dev/",
       "chainID": 296
     }
   },
@@ -63,6 +65,7 @@
       "activate": false,
       "repoURL": "https://repo.sourcify.dev/",
       "serverURL": "https://sourcify.dev/server/",
+      "verifierURL": "https://verify.sourcify.dev/",
       "chainID": 297
     }
   }

--- a/_frontend/src/components/account/AccountCreatedContractsTable.vue
+++ b/_frontend/src/components/account/AccountCreatedContractsTable.vue
@@ -32,11 +32,11 @@
       </div>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="contract_name" label="CONTRACT NAME">
+    <o-table-column v-if="isVerificationAvailable" v-slot="props" field="contract_name" label="CONTRACT NAME">
       <ContractName :contract-id="props.row.entity_id"/>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="created" label="CREATE">
+    <o-table-column v-slot="props" field="created" label="CREATED">
       <TimestampValue v-bind:timestamp="props.row.consensus_timestamp"/>
     </o-table-column>
 
@@ -64,7 +64,7 @@
 
 <script setup lang="ts">
 
-import {onBeforeUnmount, onMounted, PropType} from 'vue';
+import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -84,6 +84,12 @@ const props = defineProps({
 
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
+
+const isVerificationAvailable = computed(() => {
+  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
+  return sourcifySetup?.activate
+      && sourcifySetup?.serverURL.length
+})
 
 const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToContract(t.entity_id!, event)

--- a/_frontend/src/components/account/AccountCreatedContractsTable.vue
+++ b/_frontend/src/components/account/AccountCreatedContractsTable.vue
@@ -32,7 +32,7 @@
       </div>
     </o-table-column>
 
-    <o-table-column v-if="isVerificationAvailable" v-slot="props" field="contract_name" label="CONTRACT NAME">
+    <o-table-column v-if="enableVerification" v-slot="props" field="contract_name" label="CONTRACT NAME">
       <ContractName :contract-id="props.row.entity_id"/>
     </o-table-column>
 
@@ -64,7 +64,7 @@
 
 <script setup lang="ts">
 
-import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
+import {onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -85,13 +85,7 @@ const props = defineProps({
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
 
-const isVerificationAvailable = computed(() => {
-  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
-  return sourcifySetup?.activate
-      && sourcifySetup?.serverURL.length
-})
-
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
+const handleClick = (t: Transaction, _c: unknown, _i: number, _ci: number, event: Event) => {
   routeManager.routeToContract(t.entity_id!, event)
 }
 
@@ -103,6 +97,7 @@ const onPageChange = props.controller.onPageChange
 const perPage = props.controller.pageSize
 const paginated = props.controller.paginated
 const showPageSizeSelector = props.controller.showPageSizeSelector
+const enableVerification = routeManager.enableVerification
 
 </script>
 

--- a/_frontend/src/components/contract/ContractTable.vue
+++ b/_frontend/src/components/contract/ContractTable.vue
@@ -29,7 +29,7 @@
       <ContractIOL class="contract_id" :contract-id="props.row.contract_id"/>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="contract_name" label="CONTRACT NAME">
+    <o-table-column v-if="isVerificationAvailable" v-slot="props" field="contract_name" label="CONTRACT NAME">
       <ContractName :contract-id="props.row.contract_id"/>
     </o-table-column>
 
@@ -60,7 +60,7 @@
 
 <script setup lang="ts">
 
-import {onBeforeUnmount, onMounted, PropType} from 'vue';
+import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Contract} from "@/schemas/MirrorNodeSchemas";
 import BlobValue from "@/components/values/BlobValue.vue";
@@ -82,6 +82,12 @@ const props = defineProps({
     type: Boolean,
     default: false
   }
+})
+
+const isVerificationAvailable = computed(() => {
+  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
+  return sourcifySetup?.activate
+      && sourcifySetup?.serverURL.length
 })
 
 onMounted(() => props.controller.mount())

--- a/_frontend/src/components/contract/ContractTable.vue
+++ b/_frontend/src/components/contract/ContractTable.vue
@@ -29,7 +29,7 @@
       <ContractIOL class="contract_id" :contract-id="props.row.contract_id"/>
     </o-table-column>
 
-    <o-table-column v-if="isVerificationAvailable" v-slot="props" field="contract_name" label="CONTRACT NAME">
+    <o-table-column v-if="enableVerification" v-slot="props" field="contract_name" label="CONTRACT NAME">
       <ContractName :contract-id="props.row.contract_id"/>
     </o-table-column>
 
@@ -60,7 +60,7 @@
 
 <script setup lang="ts">
 
-import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
+import {onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Contract} from "@/schemas/MirrorNodeSchemas";
 import BlobValue from "@/components/values/BlobValue.vue";
@@ -84,16 +84,10 @@ const props = defineProps({
   }
 })
 
-const isVerificationAvailable = computed(() => {
-  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
-  return sourcifySetup?.activate
-      && sourcifySetup?.serverURL.length
-})
-
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
 
-const handleClick = (contract: Contract, c: unknown, i: number, ci: number, event: Event) => {
+const handleClick = (contract: Contract, _c: unknown, _i: number, _ci: number, event: Event) => {
   if (contract.contract_id) {
     routeManager.routeToContract(contract.contract_id, event)
   }
@@ -105,6 +99,7 @@ const total = props.controller.totalRowCount
 const currentPage = props.controller.currentPage
 const onPageChange = props.controller.onPageChange
 const perPage = props.controller.pageSize
+const enableVerification = routeManager.enableVerification
 
 </script>
 

--- a/_frontend/src/config/NetworkConfig.ts
+++ b/_frontend/src/config/NetworkConfig.ts
@@ -16,19 +16,11 @@ export class SourcifySetup {
     static parse(obj: Record<string, unknown>): SourcifySetup {
 
         const activate = fetchBoolean(obj, "activate") ?? true
-        const repoURL = fetchURL(obj, "repoURL")
-        const serverURL = fetchURL(obj, "serverURL")
+        const verifierURL = fetchURL(obj, "verifierURL") ?? "https://verify.sourcify.dev/"
+        const repoURL = fetchURL(obj, "repoURL") ?? "https://repo.sourcify.dev/"
+        const serverURL = fetchURL(obj, "serverURL") ?? "https://sourcify.dev/server/"
         const chainID = fetchNumber(obj, "chainID")
 
-        if (activate === null) {
-            throw this.missingPropertyError("activate")
-        }
-        if (repoURL === null) {
-            throw this.missingPropertyError("repoURL")
-        }
-        if (serverURL === null) {
-            throw this.missingPropertyError("serverURL")
-        }
         if (chainID === null) {
             throw this.missingPropertyError("chainID")
         }
@@ -37,6 +29,7 @@ export class SourcifySetup {
             activate,
             repoURL,
             serverURL,
+            verifierURL,
             chainID
         )
     }
@@ -63,6 +56,7 @@ export class SourcifySetup {
         public readonly activate: boolean,
         public readonly repoURL: string,
         public readonly serverURL: string,
+        public readonly verifierURL: string,
         public readonly chainID: number,
     ) {
     }
@@ -76,6 +70,7 @@ export class NetworkEntry {
 
     public static readonly NETWORK_NAME_MAX_LENGTH = 15
 
+    // eslint-disable-next-line complexity,max-lines-per-function
     static parse(obj: Record<string, unknown>): NetworkEntry {
 
         const name = fetchString(obj, "name")

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -5,37 +5,37 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <ModalDialog v-model:show-dialog="showDialog" :width="600">
+  <ModalDialog v-model:show-dialog="showDialog" :width="520">
 
-    <template #modalDialogTitle>Verify Contract {{ props.contractId }}</template>
+    <template #modalDialogTitle>Verify Contract</template>
 
     <template #modalDialogContent>
 
       <div class="dialog-content">
-        <p>Smart contract verification is now provided by the
-          <a :href="sourcifyUrl" class="h-is-extra-text" target="_blank">sourcify.dev</a>
-          service.</p>
+        <p class="dialog-primary-text" >Smart contract verification is now handled by sourcify.dev</p>
 
-        <p>You may use any of the following options to verify the contract:</p>
+        <p class="dialog-secondary-text">You can verify your contract using one of the following methods:</p>
 
-        <div class="dialog-options">
-          <p>&bull; Verify directly with sourcify.dev verification service</p>
-          <p>&bull; Use the forge command-line of the Foundry toolkit</p>
-          <p>&bull; Use the Hardhat environment with its Sourcify plugin</p>
+        <div class="dialog-options dialog-secondary-text">
+          <p>&bull; Verify directly via the sourcify.dev service</p>
+          <p>&bull; Use the Forge CLI (Foundry)</p>
+          <p>&bull; Use Hardhat with the Sourcify plugin</p>
         </div>
 
-        <p>More information on how to verify a contract is available
-          <a :href="docUrl" class="h-is-extra-text" target="_blank">here</a>.</p>
+        <p class="dialog-secondary-text">Learn more about smart contract verification
+          <a :href="docUrl" class="h-is-extra-text" target="_blank">here</a></p>
 
-        <div class="h-is-low-contrast" style="font-size: 0.9em;">Note: All contracts previously verified with Hashscan
-          are
-          verified with <a :href="sourcifyUrl" class="" target="_blank">sourcify.dev</a>.
-        </div>
+        <p class="dialog-secondary-text">Contracts previously verified on HashScan are verified on sourcify.dev</p>
       </div>
     </template>
 
     <template #modalDialogButtons>
-      <ModalDialogButton v-model:show-dialog="showDialog">CLOSE</ModalDialogButton>
+      <ModalDialogButton v-model:show-dialog="showDialog">CANCEL</ModalDialogButton>
+      <ModalDialogButton
+          v-model:show-dialog="showDialog"
+          :is-default="true"
+          @action="handleGoToSourcify">GO TO SOURCIFY
+      </ModalDialogButton>
     </template>
 
   </ModalDialog>
@@ -51,8 +51,8 @@ import ModalDialog from "@/dialogs/core/ModalDialog.vue";
 import ModalDialogButton from "@/dialogs/core/ModalDialogButton.vue";
 import {PropType} from "vue";
 
-const props = defineProps({
-  contractId: {
+defineProps({
+  contractAddress: {
     type: String as PropType<string | null>,
     default: null
   }
@@ -63,8 +63,22 @@ const showDialog = defineModel("showDialog", {
   required: true
 })
 
-const sourcifyUrl = "https://sourcify.dev"
 const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/verifying-smart-contracts-beta"
+const verifyUrl = "https://verify.sourcify.dev"
+
+// const verifyUrl = computed(() => {
+//   const baseUrl = "https://verify.sourcify.dev"
+//   const chainId = routeManager.currentNetworkEntry.value.sourcifySetup?.chainID ?? null
+//   if (chainId && props.contractAddress) {
+//     return `${baseUrl}?chain=${chainId}&address=${props.contractAddress}`
+//   } else {
+//     return baseUrl
+//   }
+// })
+
+const handleGoToSourcify = () => {
+  window.open(verifyUrl, "_blank")
+}
 
 </script>
 
@@ -79,6 +93,15 @@ const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/ver
   flex-direction: column;
   gap: 1rem;
   align-items: center;
+}
+
+.dialog-primary-text {
+  font-size: 1.2rem;
+}
+
+.dialog-secondary-text {
+  font-size: 0.9em;
+  color: var(--text-secondary);
 }
 
 div.dialog-options {

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -7,11 +7,31 @@
 <template>
   <ModalDialog v-model:show-dialog="showDialog" :width="600">
 
-    <template #modalDialogTitle>Verify Contract</template>
+    <template #modalDialogTitle>Verify Contract {{ props.contractId }}</template>
 
     <template #modalDialogContent>
 
+      <div class="dialog-content">
+        <p>Smart contract verification is now provided by the
+          <a :href="sourcifyUrl" class="h-is-extra-text" target="_blank">sourcify.dev</a>
+          service.</p>
 
+        <p>You may use any of the following options to verify the contract:</p>
+
+        <div class="dialog-options">
+          <p>&bull; Verify directly with sourcify.dev verification service</p>
+          <p>&bull; Use the forge command-line of the Foundry toolkit</p>
+          <p>&bull; Use the Hardhat environment with its Sourcify plugin</p>
+        </div>
+
+        <p>More information on how to verify a contract is available
+          <a :href="docUrl" class="h-is-extra-text" target="_blank">here</a>.</p>
+
+        <div class="h-is-low-contrast" style="font-size: 0.9em;">Note: All contracts previously verified with Hashscan
+          are
+          verified with <a :href="sourcifyUrl" class="" target="_blank">sourcify.dev</a>.
+        </div>
+      </div>
     </template>
 
     <template #modalDialogButtons>
@@ -43,10 +63,26 @@ const showDialog = defineModel("showDialog", {
   required: true
 })
 
+const sourcifyUrl = "https://sourcify.dev"
+const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/verifying-smart-contracts-beta"
+
 </script>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 <!--                                                       STYLE                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style/>
+<style scoped>
+
+.dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+div.dialog-options {
+  display: inline-block;
+}
+
+</style>

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <ModalDialog v-model:show-dialog="showDialog" :width="600">
+
+    <template #modalDialogTitle>Verify Contract</template>
+
+    <template #modalDialogContent>
+
+
+    </template>
+
+    <template #modalDialogButtons>
+      <ModalDialogButton v-model:show-dialog="showDialog">CLOSE</ModalDialogButton>
+    </template>
+
+  </ModalDialog>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts" setup>
+
+import ModalDialog from "@/dialogs/core/ModalDialog.vue";
+import ModalDialogButton from "@/dialogs/core/ModalDialogButton.vue";
+import {PropType} from "vue";
+
+const props = defineProps({
+  contractId: {
+    type: String as PropType<string | null>,
+    default: null
+  }
+})
+
+const showDialog = defineModel("showDialog", {
+  type: Boolean,
+  required: true
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -50,7 +50,7 @@
 import ModalDialog from "@/dialogs/core/ModalDialog.vue";
 import ModalDialogButton from "@/dialogs/core/ModalDialogButton.vue";
 import {PropType} from "vue";
-import {SourcifyUtils} from "@/utils/sourcify/SourcifyUtils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 defineProps({
   contractAddress: {
@@ -67,7 +67,12 @@ const showDialog = defineModel("showDialog", {
 const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/verifying-smart-contracts-beta"
 
 const handleGoToSourcify = () => {
-  window.open(SourcifyUtils.VERIFY_URL, "_blank")
+  const verifierURL = routeManager.currentNetworkEntry.value.sourcifySetup?.verifierURL
+  if (verifierURL) {
+    window.open(verifierURL, "_blank")
+  } else {
+    console.error("No verifier URL defined for selected network")
+  }
 }
 
 </script>

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -66,16 +66,6 @@ const showDialog = defineModel("showDialog", {
 const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/verifying-smart-contracts-beta"
 const verifyUrl = "https://verify.sourcify.dev"
 
-// const verifyUrl = computed(() => {
-//   const baseUrl = "https://verify.sourcify.dev"
-//   const chainId = routeManager.currentNetworkEntry.value.sourcifySetup?.chainID ?? null
-//   if (chainId && props.contractAddress) {
-//     return `${baseUrl}?chain=${chainId}&address=${props.contractAddress}`
-//   } else {
-//     return baseUrl
-//   }
-// })
-
 const handleGoToSourcify = () => {
   window.open(verifyUrl, "_blank")
 }

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -5,7 +5,7 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <ModalDialog v-model:show-dialog="showDialog" :width="520">
+  <ModalDialog v-model:show-dialog="showDialog" :width="550">
 
     <template #modalDialogTitle>Verify Contract</template>
 
@@ -17,15 +17,14 @@
         <p class="dialog-secondary-text">You can verify your contract using one of the following methods:</p>
 
         <div class="dialog-options dialog-secondary-text">
-          <p>&bull; Verify directly via the sourcify.dev service</p>
-          <p>&bull; Use the Forge CLI (Foundry)</p>
+          <p>&bull; Verify directly at verify.sourcify.dev</p>
+          <p>&bull; Use Foundry:
+            <span class="h-is-monospace" style="font-size: 0.9rem">forge verify-contract --verifier sourcify...</span>
+          </p>
           <p>&bull; Use Hardhat with the Sourcify plugin</p>
         </div>
 
-        <p class="dialog-secondary-text">Learn more about smart contract verification
-          <a :href="docUrl" class="h-is-extra-text" target="_blank">here</a></p>
-
-        <p class="dialog-secondary-text">Contracts previously verified on HashScan are verified on sourcify.dev</p>
+        <p class="dialog-secondary-text">{{ bottomNotice }}</p>
       </div>
     </template>
 
@@ -51,6 +50,7 @@ import ModalDialog from "@/dialogs/core/ModalDialog.vue";
 import ModalDialogButton from "@/dialogs/core/ModalDialogButton.vue";
 import {PropType} from "vue";
 import {routeManager} from "@/utils/RouteManager.ts";
+import {CoreConfig} from "@/config/CoreConfig.ts";
 
 defineProps({
   contractAddress: {
@@ -64,7 +64,8 @@ const showDialog = defineModel("showDialog", {
   required: true
 })
 
-const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/verifying-smart-contracts-beta"
+const coreConfig = CoreConfig.inject()
+const bottomNotice = `Contracts previously verified by ${coreConfig.productName} are verified on sourcify.dev.`
 
 const handleGoToSourcify = () => {
   const verifierURL = routeManager.currentNetworkEntry.value.sourcifySetup?.verifierURL

--- a/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationInfoDialog.vue
@@ -50,6 +50,7 @@
 import ModalDialog from "@/dialogs/core/ModalDialog.vue";
 import ModalDialogButton from "@/dialogs/core/ModalDialogButton.vue";
 import {PropType} from "vue";
+import {SourcifyUtils} from "@/utils/sourcify/SourcifyUtils.ts";
 
 defineProps({
   contractAddress: {
@@ -64,10 +65,9 @@ const showDialog = defineModel("showDialog", {
 })
 
 const docUrl = "https://docs.hedera.com/hedera/core-concepts/smart-contracts/verifying-smart-contracts-beta"
-const verifyUrl = "https://verify.sourcify.dev"
 
 const handleGoToSourcify = () => {
-  window.open(verifyUrl, "_blank")
+  window.open(SourcifyUtils.VERIFY_URL, "_blank")
 }
 
 </script>

--- a/_frontend/src/pages/AccountDetails_Operations.vue
+++ b/_frontend/src/pages/AccountDetails_Operations.vue
@@ -36,7 +36,7 @@
           <Download :size="24" @click="transactionDownloadDialogVisible = true"/>
           <TransactionFilterSelect v-model:selected-filter="transactionType"/>
         </template>
-        <template v-else-if="selectedTab === 'contracts' && isVerificationAvailable">
+        <template v-else-if="selectedTab === 'contracts' && enableVerification">
           <span>All</span>
           <SwitchView v-model="filterVerified"/>
           <span>Verified</span>
@@ -160,12 +160,7 @@ const isMediumScreen = inject('isMediumScreen', true)
 const networkConfig = NetworkConfig.inject()
 
 const enableStaking = routeManager.enableStaking
-
-const isVerificationAvailable = computed(() => {
-  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
-  return sourcifySetup?.activate
-      && sourcifySetup?.serverURL.length
-})
+const enableVerification = routeManager.enableVerification
 
 const timeSelection = ref("LATEST")
 watch(timeSelection, (newValue, oldValue) => {

--- a/_frontend/src/pages/AccountDetails_Operations.vue
+++ b/_frontend/src/pages/AccountDetails_Operations.vue
@@ -36,7 +36,7 @@
           <Download :size="24" @click="transactionDownloadDialogVisible = true"/>
           <TransactionFilterSelect v-model:selected-filter="transactionType"/>
         </template>
-        <template v-else-if="selectedTab === 'contracts' && enableVerification">
+        <template v-else-if="selectedTab === 'contracts' && enableVerification && !hideVerifiedFilter">
           <span>All</span>
           <SwitchView v-model="filterVerified"/>
           <span>Verified</span>
@@ -161,6 +161,7 @@ const networkConfig = NetworkConfig.inject()
 
 const enableStaking = routeManager.enableStaking
 const enableVerification = routeManager.enableVerification
+const hideVerifiedFilter = import.meta.env.VITE_APP_HIDE_VERIFIED_FILTER === 'true'
 
 const timeSelection = ref("LATEST")
 watch(timeSelection, (newValue, oldValue) => {

--- a/_frontend/src/pages/AccountDetails_Operations.vue
+++ b/_frontend/src/pages/AccountDetails_Operations.vue
@@ -36,7 +36,7 @@
           <Download :size="24" @click="transactionDownloadDialogVisible = true"/>
           <TransactionFilterSelect v-model:selected-filter="transactionType"/>
         </template>
-        <template v-else-if="selectedTab === 'contracts'">
+        <template v-else-if="selectedTab === 'contracts' && isVerificationAvailable">
           <span>All</span>
           <SwitchView v-model="filterVerified"/>
           <span>Verified</span>
@@ -160,6 +160,12 @@ const isMediumScreen = inject('isMediumScreen', true)
 const networkConfig = NetworkConfig.inject()
 
 const enableStaking = routeManager.enableStaking
+
+const isVerificationAvailable = computed(() => {
+  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
+  return sourcifySetup?.activate
+      && sourcifySetup?.serverURL.length
+})
 
 const timeSelection = ref("LATEST")
 watch(timeSelection, (newValue, oldValue) => {

--- a/_frontend/src/pages/ContractDetails.vue
+++ b/_frontend/src/pages/ContractDetails.vue
@@ -34,7 +34,7 @@
 
     <template #right-toolbar>
       <ButtonView
-          v-if="isVerificationAvailable && !isVerified"
+          v-if="enableVerification && !isVerified"
           :size="ButtonSize.small"
           :for-toolbar="true"
           @action="showVerifyDialog = true"
@@ -114,15 +114,7 @@ const contractAnalyzer = new ContractAnalyzer(parsedContractId)
 onMounted(() => contractAnalyzer.mount())
 onBeforeUnmount(() => contractAnalyzer.unmount())
 const isVerified = contractAnalyzer.isVerified
-
-
-// True when the verification is ENABLED by configuration and the current verification STATUS is known, which
-// enables to decide which option to present to the user
-const isVerificationAvailable = computed(() => {
-  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
-  return sourcifySetup?.activate
-      && sourcifySetup?.serverURL.length
-})
+const enableVerification = routeManager.enableVerification
 
 const showVerifyDialog = ref(false)
 

--- a/_frontend/src/pages/ContractDetails.vue
+++ b/_frontend/src/pages/ContractDetails.vue
@@ -53,7 +53,7 @@
 
   <ContractVerificationInfoDialog
       v-model:show-dialog="showVerifyDialog"
-      :contract-id="parsedContractId"
+      :contract-address="contractAddress"
   />
 
 </template>
@@ -101,6 +101,7 @@ const contractLocParser = new ContractLocParser(computed(() => props.contractId 
 onMounted(() => contractLocParser.mount())
 onBeforeUnmount(() => contractLocParser.unmount())
 const parsedContractId = contractLocParser.contractId
+const contractAddress = contractLocParser.ethereumAddress
 const notification = contractLocParser.errorNotification
 const pageTitle = computed(() =>
     parsedContractId.value !== null ? "Contract " + parsedContractId.value : null

--- a/_frontend/src/pages/ContractDetails.vue
+++ b/_frontend/src/pages/ContractDetails.vue
@@ -51,10 +51,10 @@
 
   </PageFrameV2>
 
-  <ContractVerificationDialog
+  <ContractVerificationInfoDialog
       v-model:show-dialog="showVerifyDialog"
       :contract-id="parsedContractId"
-      v-on:verify-did-complete="verifyDidComplete"/>
+  />
 
 </template>
 
@@ -73,7 +73,7 @@ import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
 import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer.ts";
 import {ContractLocParser} from "@/utils/parser/ContractLocParser";
 import {routeManager} from "@/utils/RouteManager.ts";
-import ContractVerificationDialog from "@/dialogs/verification/ContractVerificationDialog.vue";
+import ContractVerificationInfoDialog from "@/dialogs/verification/ContractVerificationInfoDialog.vue";
 import ArrowLink from "@/components/ArrowLink.vue";
 
 const props = defineProps({
@@ -124,9 +124,6 @@ const isVerificationAvailable = computed(() => {
 })
 
 const showVerifyDialog = ref(false)
-const verifyDidComplete = () => {
-  contractAnalyzer.verifyDidComplete()
-}
 
 //
 // Account route

--- a/_frontend/src/pages/ContractDetails_Summary.vue
+++ b/_frontend/src/pages/ContractDetails_Summary.vue
@@ -56,8 +56,16 @@
             {{ isFullMatch ? "Full Match" : "Partial Match" }}
             <InfoTooltip :label="tooltipText"/>
             <ButtonView
-                v-if="!isFullMatch"
-                id="verify-button"
+                v-if="isFullMatch"
+                id="go-to-sourcify-button"
+                :size="ButtonSize.small"
+                @action="handleGoToSourcify"
+            >
+              GO TO SOURCIFY
+            </ButtonView>
+            <ButtonView
+                v-else
+                id="re-verify-button"
                 :size="ButtonSize.small"
                 @action="showVerifyDialog = true"
             >
@@ -174,6 +182,16 @@ const accountChecksum = computed(() =>
 // Verify dialog
 //
 const showVerifyDialog = ref(false)
+
+const handleGoToSourcify = () => {
+  const repoUrl = routeManager.currentNetworkEntry.value.sourcifySetup?.repoURL
+  const chainId = routeManager.currentNetworkEntry.value.sourcifySetup?.chainID
+  if (repoUrl && chainId) {
+    const contractUrl = repoUrl + chainId.toString() + "/" + contractAddress.value
+    window.open(contractUrl, "_blank")
+
+  }
+}
 
 </script>
 

--- a/_frontend/src/pages/ContractDetails_Summary.vue
+++ b/_frontend/src/pages/ContractDetails_Summary.vue
@@ -84,7 +84,7 @@
 
   <ContractVerificationInfoDialog
       v-model:show-dialog="showVerifyDialog"
-      :contract-id="parsedContractId"
+      :contract-address="contractAddress"
   />
 
 </template>

--- a/_frontend/src/pages/ContractDetails_Summary.vue
+++ b/_frontend/src/pages/ContractDetails_Summary.vue
@@ -187,4 +187,9 @@ const verifyDidComplete = () => {
 
 <style scoped>
 
+.verification-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
 </style>

--- a/_frontend/src/pages/ContractDetails_Summary.vue
+++ b/_frontend/src/pages/ContractDetails_Summary.vue
@@ -82,10 +82,10 @@
 
   <ContractERCSection :erc-analyzer="ercAnalyzer"/>
 
-  <ContractVerificationDialog
+  <ContractVerificationInfoDialog
       v-model:show-dialog="showVerifyDialog"
       :contract-id="parsedContractId"
-      v-on:verify-did-complete="verifyDidComplete"/>
+  />
 
 </template>
 
@@ -112,7 +112,7 @@ import MirrorLink from "@/components/MirrorLink.vue";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
-import ContractVerificationDialog from "@/dialogs/verification/ContractVerificationDialog.vue";
+import ContractVerificationInfoDialog from "@/dialogs/verification/ContractVerificationInfoDialog.vue";
 import ContractSectionTitle from "@/components/contract/ContractSectionTitle.vue";
 
 const props = defineProps({
@@ -174,10 +174,6 @@ const accountChecksum = computed(() =>
 // Verify dialog
 //
 const showVerifyDialog = ref(false)
-const verifyDidComplete = () => {
-  contractAnalyzer.verifyDidComplete()
-}
-
 
 </script>
 

--- a/_frontend/src/pages/Contracts.vue
+++ b/_frontend/src/pages/Contracts.vue
@@ -17,7 +17,7 @@
         <PlayPauseButton v-else :controller="verifiedContractsController"/>
       </template>
       <template #right-control>
-        <div class="verify-switch">
+        <div v-if="isVerificationAvailable" class="verify-switch">
           <div class="switch-text">All</div>
           <SwitchView v-model="filterVerified"/>
           <div class="switch-text">Verified</div>
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 
-import {inject, ref} from 'vue';
+import {computed, inject, ref} from 'vue';
 import ContractTable from "@/components/contract/ContractTable.vue";
 import PageFrameV2 from "@/components/page/PageFrameV2.vue";
 import {ContractTableController} from "@/components/contract/ContractTableController";
@@ -55,6 +55,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import PlayPauseButton from "@/components/PlayPauseButton.vue";
 import SwitchView from "@/elements/SwitchView.vue";
 import {VerifiedContractTableController} from "@/components/contract/verified/VerifiedContractTableController.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 defineProps({
   network: String
@@ -65,6 +66,12 @@ const router = useRouter()
 const isMediumScreen = inject('isMediumScreen', true)
 
 const filterVerified = ref(false)
+
+const isVerificationAvailable = computed(() => {
+  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
+  return sourcifySetup?.activate
+      && sourcifySetup?.serverURL.length
+})
 
 //
 // ContractTableController

--- a/_frontend/src/pages/Contracts.vue
+++ b/_frontend/src/pages/Contracts.vue
@@ -17,7 +17,7 @@
         <PlayPauseButton v-else :controller="verifiedContractsController"/>
       </template>
       <template #right-control>
-        <div v-if="isVerificationAvailable" class="verify-switch">
+        <div v-if="enableVerification" class="verify-switch">
           <div class="switch-text">All</div>
           <SwitchView v-model="filterVerified"/>
           <div class="switch-text">Verified</div>
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 
-import {computed, inject, ref} from 'vue';
+import {inject, ref} from 'vue';
 import ContractTable from "@/components/contract/ContractTable.vue";
 import PageFrameV2 from "@/components/page/PageFrameV2.vue";
 import {ContractTableController} from "@/components/contract/ContractTableController";
@@ -65,13 +65,9 @@ const router = useRouter()
 
 const isMediumScreen = inject('isMediumScreen', true)
 
-const filterVerified = ref(false)
+const enableVerification = routeManager.enableVerification
 
-const isVerificationAvailable = computed(() => {
-  const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup
-  return sourcifySetup?.activate
-      && sourcifySetup?.serverURL.length
-})
+const filterVerified = ref(false)
 
 //
 // ContractTableController

--- a/_frontend/src/pages/Contracts.vue
+++ b/_frontend/src/pages/Contracts.vue
@@ -17,7 +17,7 @@
         <PlayPauseButton v-else :controller="verifiedContractsController"/>
       </template>
       <template #right-control>
-        <div v-if="enableVerification" class="verify-switch">
+        <div v-if="enableVerification && !hideVerifiedFilter" class="verify-switch">
           <div class="switch-text">All</div>
           <SwitchView v-model="filterVerified"/>
           <div class="switch-text">Verified</div>
@@ -66,6 +66,8 @@ const router = useRouter()
 const isMediumScreen = inject('isMediumScreen', true)
 
 const enableVerification = routeManager.enableVerification
+const hideVerifiedFilter = import.meta.env.VITE_APP_HIDE_VERIFIED_FILTER === 'true'
+
 
 const filterVerified = ref(false)
 

--- a/_frontend/src/utils/RouteManager.ts
+++ b/_frontend/src/utils/RouteManager.ts
@@ -98,6 +98,12 @@ export class RouteManager {
         return this.currentNetworkEntry.value.enableMarket
     })
 
+    public enableVerification = computed(() => {
+        const sourcifySetup = this.currentNetworkEntry.value.sourcifySetup
+        return sourcifySetup?.activate
+            && sourcifySetup.serverURL.length > 0
+    })
+
     public readonly nbNetworks = computed(() => {
         return this.networkConfig.value.entries.length
     })

--- a/_frontend/src/utils/cache/SourcifyCache.ts
+++ b/_frontend/src/utils/cache/SourcifyCache.ts
@@ -51,6 +51,7 @@ export class SourcifyCache extends EntityCache<string, SourcifyRecord | null> {
     // Cache
     //
 
+    // eslint-disable-next-line complexity
     protected async load(contractId: string): Promise<SourcifyRecord | null> {
         let result: SourcifyRecord | null
         const sourcifySetup = routeManager.currentNetworkEntry.value.sourcifySetup

--- a/_frontend/src/utils/sourcify/SourcifyUtils.ts
+++ b/_frontend/src/utils/sourcify/SourcifyUtils.ts
@@ -6,6 +6,7 @@ import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SourcifyUtils {
 
+    public static readonly VERIFY_URL = "https://verify.sourcify.dev"
 
     //
     // Session verification

--- a/_frontend/src/utils/sourcify/SourcifyUtils.ts
+++ b/_frontend/src/utils/sourcify/SourcifyUtils.ts
@@ -6,8 +6,6 @@ import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SourcifyUtils {
 
-    public static readonly VERIFY_URL = "https://verify.sourcify.dev"
-
     //
     // Session verification
     //

--- a/_frontend/tests/unit/contract/ContractDetails.spec.ts
+++ b/_frontend/tests/unit/contract/ContractDetails.spec.ts
@@ -102,7 +102,8 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address 0x00000000000000000000000000000000000b70cfCopy")
 
         // None of the elements related to contract verification should be present in this context
-        expect(wrapper.find('#verify-button').exists()).toBe(false)
+        expect(wrapper.find('#re-verify-button').exists()).toBe(false)
+        expect(wrapper.find('#go-to-sourcify-button').exists()).toBe(false)
         expect(wrapper.find('#showSource').exists()).toBe(false)
         expect(wrapper.find('#verificationStatus').exists()).toBe(false)
         expect(wrapper.find('#contractName').exists()).toBe(false)
@@ -259,7 +260,8 @@ describe("ContractDetails.vue", () => {
         expect(wrapper.get("#evmAddress").text()).toBe("EVM Address 0x00000000000000000000000000000000000b70cfCopy")
 
         // None of the elements related to contract verification should be present in this context
-        expect(wrapper.find('#verify-button').exists()).toBe(false)
+        expect(wrapper.find('#re-verify-button').exists()).toBe(false)
+        expect(wrapper.find('#go-to-sourcify-button').exists()).toBe(false)
         expect(wrapper.find('#showSource').exists()).toBe(false)
         expect(wrapper.find('#verificationStatus').exists()).toBe(false)
         expect(wrapper.find('#contractName').exists()).toBe(false)


### PR DESCRIPTION
**Description**:

Disable in-app smart contract verification capability and point user to `verify.sourcify.dev` to perform their verification. Also make sure that none of the verification information/actions are visible when contract verification is not available for the selected network (i.e. on previewnet).
 - Buttons `VERIFY` and `RE-VERIFY` now bring up a modal information dialog -- screenshot below -- in place of the previous modal verification dialog
 - Hide All/Verified selector and CONTRACT NAME column for contract tables when verification is not available
 - Add `GO TO SOURCIFY` button next to verification status for fully verify contract (navigates to relevant contract in repo.sourcify.dev)
 
Fixes #2415 

**Notes for reviewer**:

This PR is based on, and should be merged _immediately_ after, PR #2437

New Verification Dialog:

<img width="683" height="444" alt="Screenshot 2026-04-30 at 09 40 06" src="https://github.com/user-attachments/assets/4085d628-2a01-47dc-a840-8004300bf5bf" />
