### PR TITLE
fix: avoiding transient unverified state when displaying Contract source code

### DIFF
--- a/_frontend/src/pages/ContractDetails_ABI.vue
+++ b/_frontend/src/pages/ContractDetails_ABI.vue
@@ -53,6 +53,10 @@
                           :fragment-collection="selectedCollection as FragmentCollection"/>
       </template>
 
+      <template v-else-if="isAnalyzing">
+        <EmptyTable :loading="true"/>
+      </template>
+
       <template v-else>
         <DocSnippet
             doc-hint="See how to verify a contract"
@@ -89,6 +93,7 @@ import Property from "@/components/Property.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import ContractSectionTitle from "@/components/contract/ContractSectionTitle.vue";
 import DocSnippet from "@/components/DocSnippet.vue";
+import EmptyTable from "@/components/EmptyTable.vue";
 
 const props = defineProps({
   contractId: String,
@@ -100,6 +105,7 @@ const contractAnalyzer = new ContractAnalyzer(contractId)
 onMounted(() => contractAnalyzer.mount())
 onBeforeUnmount(() => contractAnalyzer.unmount())
 const isVerified = contractAnalyzer.isVerified
+const isAnalyzing = contractAnalyzer.isAnalyzing
 
 
 const abiAnalyzer = new ABIAnalyzer(contractAnalyzer)

--- a/_frontend/src/pages/ContractDetails_SourceCode.vue
+++ b/_frontend/src/pages/ContractDetails_SourceCode.vue
@@ -36,6 +36,10 @@
         <ContractSourceValue :source-files="solidityFiles" :filter="selectedSource"/>
       </template>
 
+      <template v-else-if="isAnalyzing">
+        <EmptyTable :loading="true"/>
+      </template>
+
       <template v-else>
         <DocSnippet
             doc-hint="See how to verify a contract"
@@ -67,6 +71,7 @@ import JSZip from "jszip";
 import {saveAs} from "file-saver";
 import {SourcifyResponseItem} from "@/utils/cache/SourcifyCache.ts";
 import DocSnippet from "@/components/DocSnippet.vue";
+import EmptyTable from "@/components/EmptyTable.vue";
 
 const props = defineProps({
   contractId: String,
@@ -85,6 +90,7 @@ const isVerified = contractAnalyzer.isVerified
 const solidityFiles = contractAnalyzer.solidityFiles
 const sourceFileName = contractAnalyzer.sourceFileName
 const contractFileName = contractAnalyzer.contractFileName
+const isAnalyzing = contractAnalyzer.isAnalyzing
 
 const selectedSource = ref('')
 watch(contractAnalyzer.contractFileName,

--- a/_frontend/src/utils/analyzer/ContractAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/ContractAnalyzer.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {computed, ComputedRef, Ref, shallowRef, ShallowRef, watch, WatchStopHandle} from "vue";
+import {computed, ComputedRef, ref, Ref, shallowRef, ShallowRef, watch, WatchStopHandle} from "vue";
 import {SystemContractEntry, systemContractRegistry} from "@/schemas/SystemContractRegistry";
 import {ethers} from "ethers";
 import {SourcifyCache, SourcifyRecord, SourcifyResponseItem} from "@/utils/cache/SourcifyCache";
@@ -37,6 +37,8 @@ export class ContractAnalyzer {
         this.watchHandles = []
         this.report.value = null
     }
+
+    public readonly isAnalyzing = computed(() => this.analyzing.value)
 
     public readonly contractAddress = computed<string | null>(() => {
         let result: string | null
@@ -231,8 +233,11 @@ export class ContractAnalyzer {
     // Private
     //
 
+    private readonly analyzing = ref(false)
+
     private readonly analyze = async () => {
         if (this.contractId.value !== null) {
+            this.analyzing.value = true
             const e = systemContractRegistry.lookup(this.contractId.value)
             try {
                 if (e !== null) {
@@ -271,6 +276,8 @@ export class ContractAnalyzer {
                     abi: null,
                     reportError: error
                 }
+            } finally {
+                this.analyzing.value = false
             }
         } else {
             this.report.value = null


### PR DESCRIPTION
**Description**:

Changes update `ContractDetails_SourceCode` and `ContractDetails_ABI` views to display `Loading…` visual when contract analysis is on-going (ie verification data are loading).

**Related issue(s)**:

Fixes #2436

**Notes for reviewer**:

```
M       _frontend/src/utils/analyzer/ContractAnalyzer.ts
        # Added isAnalyzing() computed value to indicate that analysis is on-going

M       _frontend/src/pages/ContractDetails_ABI.vue
M       _frontend/src/pages/ContractDetails_SourceCode.vue
        # Both views now checks ContractAnalyzer.isAnalyzing and setup display accordingly
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
