### PR TITLE
feat: improve contrast of source code in light mode.

### DIFF
--- a/_frontend/public/themes/prism-tomorrow.css
+++ b/_frontend/public/themes/prism-tomorrow.css
@@ -1,0 +1,122 @@
+/**
+ * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
+ * Based on https://github.com/chriskempson/tomorrow-theme
+ * @author Rose Pritchard
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #ccc;
+	background: none;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #2d2d2d;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.block-comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: #999;
+}
+
+.token.punctuation {
+	color: #ccc;
+}
+
+.token.tag,
+.token.attr-name,
+.token.namespace,
+.token.deleted {
+	color: #e2777a;
+}
+
+.token.function-name {
+	color: #6196cc;
+}
+
+.token.boolean,
+.token.number,
+.token.function {
+	color: #f08d49;
+}
+
+.token.property,
+.token.class-name,
+.token.constant,
+.token.symbol {
+	color: #f8c555;
+}
+
+.token.selector,
+.token.important,
+.token.atrule,
+.token.keyword,
+.token.builtin {
+	color: #cc99cd;
+}
+
+.token.string,
+.token.char,
+.token.attr-value,
+.token.regex,
+.token.variable {
+	color: #7ec699;
+}
+
+.token.operator,
+.token.entity,
+.token.url {
+	color: #67cdcc;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+
+.token.inserted {
+	color: green;
+}

--- a/_frontend/public/themes/prism.css
+++ b/_frontend/public/themes/prism.css
@@ -1,0 +1,140 @@
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: black;
+	background: none;
+	text-shadow: 0 1px white;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+@media print {
+	code[class*="language-"],
+	pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #f5f2f0;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: slategray;
+}
+
+.token.punctuation {
+	color: #999;
+}
+
+.token.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+	color: #9a6e3a;
+	/* This background color was intended by the author of this theme. */
+	background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+	color: #07a;
+}
+
+.token.function,
+.token.class-name {
+	color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+	color: #e90;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}

--- a/_frontend/src/components/ThemeController.ts
+++ b/_frontend/src/components/ThemeController.ts
@@ -174,14 +174,16 @@ export class ThemeController {
 
     private setPrismTheme(isDark: boolean) {
 
-        let link = document.getElementById("prism-theme") as HTMLLinkElement | null;
+        const existing = document.getElementById("prism-theme");
+        const themeElement: HTMLLinkElement = existing instanceof HTMLLinkElement
+            ? existing
+            : document.createElement("link");
 
-        if (!link) {
-            link = document.createElement("link") as HTMLLinkElement;
-            link.id = "prism-theme";
-            link.rel = "stylesheet";
-            document.head.appendChild(link);
+        if (!existing) {
+            themeElement.id = "prism-theme";
+            themeElement.rel = "stylesheet";
+            document.head.appendChild(themeElement);
         }
-        link.href = isDark ? "/themes/prism-tomorrow.css" : "/themes/prism.css";
+        themeElement.href = isDark ? "/themes/prism-tomorrow.css" : "/themes/prism.css";
     }
 }

--- a/_frontend/src/components/ThemeController.ts
+++ b/_frontend/src/components/ThemeController.ts
@@ -76,6 +76,7 @@ export class ThemeController {
     // Private
     //
 
+    // eslint-disable-next-line complexity,max-lines-per-function
     private darkSelectedDidChange = () => {
         if (this.darkSelected.value) {
             AppStorage.setTheme('dark')
@@ -168,5 +169,19 @@ export class ThemeController {
             document.getElementById('crypto-logo')?.setAttribute('src', this.coreConfig.cryptoLogoLightURL)
         }
 
+        this.setPrismTheme(this.darkSelected.value)
+    }
+
+    private setPrismTheme(isDark: boolean) {
+
+        let link = document.getElementById("prism-theme") as HTMLLinkElement | null;
+
+        if (!link) {
+            link = document.createElement("link") as HTMLLinkElement;
+            link.id = "prism-theme";
+            link.rel = "stylesheet";
+            document.head.appendChild(link);
+        }
+        link.href = isDark ? "/themes/prism-tomorrow.css" : "/themes/prism.css";
     }
 }

--- a/_frontend/src/components/values/ContractByteCodeValue.vue
+++ b/_frontend/src/components/values/ContractByteCodeValue.vue
@@ -72,7 +72,6 @@
 
 import {onMounted, PropType, ref, watch} from 'vue';
 import "prismjs/prism";
-import "prismjs/themes/prism-tomorrow.css"
 import "prismjs/prism.js";
 import "prismjs/components/prism-clike.js";
 import "prismjs/components/prism-solidity.js";

--- a/_frontend/src/components/values/ContractSourceValue.vue
+++ b/_frontend/src/components/values/ContractSourceValue.vue
@@ -41,7 +41,6 @@ import {inject, PropType, ref} from 'vue';
 import {initialLoadingKey} from "@/AppKeys";
 import {SourcifyResponseItem} from "@/utils/cache/SourcifyCache";
 import "prismjs/prism";
-import "prismjs/themes/prism-tomorrow.css"
 import "prismjs/prism.js";
 import "prismjs/components/prism-clike.js";
 import "prismjs/components/prism-solidity.js";

--- a/_frontend/src/dialogs/abi/ContractAbiEntry.vue
+++ b/_frontend/src/dialogs/abi/ContractAbiEntry.vue
@@ -55,7 +55,6 @@
 
 import {computed, onMounted, PropType, ref} from "vue";
 import "prismjs/prism";
-import "prismjs/themes/prism-tomorrow.css"
 import "prismjs/prism.js";
 import "prismjs/components/prism-clike.js";
 import "prismjs/components/prism-solidity.js";

--- a/_frontend/src/dialogs/abi/ContractAbiValue.vue
+++ b/_frontend/src/dialogs/abi/ContractAbiValue.vue
@@ -95,7 +95,6 @@ import {computed, PropType} from "vue";
 import {ethers} from "ethers";
 import ContractAbiEntry from "@/dialogs/abi/ContractAbiEntry.vue";
 import "prismjs/prism";
-import "prismjs/themes/prism-tomorrow.css"
 import "prismjs/prism.js";
 import "prismjs/components/prism-clike.js";
 import "prismjs/components/prism-solidity.js";


### PR DESCRIPTION
**Description**:

Use a different theme for `prismjs` (component which renders source code) when in _light_ mode.
The 2 corresponding CSS files (`prism.css` for _light_ theme and `prism-tomorrow.css` for _dark_ theme) are copied to the `public/` directory so we can switch them dynamically in the DOM. This is performed by ThemeController when the user switches modes.

**Related issue(s)**:

Fixes #2435 

**Notes for reviewer**:

Deployed on staging server