### PR TITLE
fix: improving user feedback during verified contracts loading

### DIFF
--- a/_frontend/src/components/account/AccountCreatedContractsTable.vue
+++ b/_frontend/src/components/account/AccountCreatedContractsTable.vue
@@ -54,7 +54,7 @@
       style="width: 116px; margin-left: 4px"
   />
 
-  <EmptyTable v-if="!transactions.length"/>
+  <EmptyTable v-if="!transactions.length" :loading="loading"/>
 
 </template>
 

--- a/_frontend/src/components/transaction/TransactionTable.vue
+++ b/_frontend/src/components/transaction/TransactionTable.vue
@@ -66,7 +66,7 @@
       style="width: 116px; margin-left: 4px"
   />
 
-  <EmptyTable v-if="transactions.length === 0"/>
+  <EmptyTable v-if="transactions.length === 0" :loading="loading"/>
 
 </template>
 

--- a/_frontend/src/components/transaction/TransactionTableController.ts
+++ b/_frontend/src/components/transaction/TransactionTableController.ts
@@ -18,7 +18,10 @@ export class TransactionTableController extends TableController<Transaction, str
     // Public
     //
 
-    public constructor(router: Router, defaultPageSize: number,
+    public constructor(router: Router,
+                       defaultPageSize: number,
+                       updatePeriod: number,
+                       maxUpdatePeriod: number,
                        transactionType = "",
                        transactionResult = "",
                        storageKey: string,
@@ -28,8 +31,8 @@ export class TransactionTableController extends TableController<Transaction, str
         super(
             router,
             defaultPageSize,
-            TableController.FAST_REFRESH_PERIOD,
-            TableController.FAST_REFRESH_COUNT,
+            updatePeriod,
+            maxUpdatePeriod,
             100,
             storageKey,
             pageParamName,

--- a/_frontend/src/pages/AccountDetails_Operations.vue
+++ b/_frontend/src/pages/AccountDetails_Operations.vue
@@ -149,6 +149,7 @@ import PlayPauseButton from "@/components/PlayPauseButton.vue";
 import {Download} from 'lucide-vue-next';
 import router, {routeManager} from "@/utils/RouteManager.ts";
 import DocSnippet from "@/components/DocSnippet.vue";
+import {TableController} from "@/utils/table/TableController.ts";
 
 const props = defineProps({
   accountId: String,
@@ -214,6 +215,8 @@ const transactionTableController = new TransactionTableControllerXL(
 const contractCreateTableController = new TransactionTableController(
     router,
     defaultPageSize,
+    TableController.SLOW_REFRESH_PERIOD,
+    TableController.SLOW_REFRESH_COUNT,
     TransactionType.CONTRACTCREATEINSTANCE,
     "success",
     AppStorage.ACCOUNT_OPERATION_TABLE_PAGE_SIZE_KEY,

--- a/_frontend/src/pages/Topics.vue
+++ b/_frontend/src/pages/Topics.vue
@@ -35,6 +35,7 @@ import {TransactionResult, TransactionType} from "@/schemas/MirrorNodeSchemas";
 import {useRouter} from "vue-router";
 import {AppStorage} from "@/AppStorage";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
+import {TableController} from "@/utils/table/TableController.ts";
 
 const props = defineProps({
   network: String
@@ -47,6 +48,8 @@ const defaultPageSize = isMediumScreen ? 15 : 5
 const transactionTableController = new TransactionTableController(
     router,
     defaultPageSize,
+    TableController.FAST_REFRESH_PERIOD,
+    TableController.FAST_REFRESH_COUNT,
     TransactionType.CONSENSUSCREATETOPIC,
     TransactionResult.SUCCESS,
     AppStorage.TOPIC_TABLE_PAGE_SIZE_KEY

--- a/_frontend/src/utils/table/RowBuffer.ts
+++ b/_frontend/src/utils/table/RowBuffer.ts
@@ -24,6 +24,8 @@ export class RowBuffer<R, K> {
 
     public readonly drained: Ref<boolean> = ref(false)
 
+    public readonly loading: Ref<boolean> = ref(false)
+
     public readonly shadowRowCount: Ref<number> = ref(0)
 
     public readonly totalRowCount: ComputedRef<number> = computed(() => {
@@ -93,30 +95,35 @@ export class RowBuffer<R, K> {
         const capturedAbortCounter = this.abortCounter
 
         const pageSize = this.tableController.pageSize.value
-        if (this.headKey.value !== null) {
-            const newRows = await this.lastLoad(this.headKey.value, pageSize)
-            if (this.abortCounter == capturedAbortCounter) {
-                if (newRows !== null) {
-                    this.rows.value = this.concatOrReplace(newRows, this.rows.value)
-                    this.startIndex.value = 0
-                    // this.drained.value unchanged
-                    this.shadowRowCount.value = 0
+        this.loading.value = true
+        try {
+            if (this.headKey.value !== null) {
+                const newRows = await this.lastLoad(this.headKey.value, pageSize)
+                if (this.abortCounter == capturedAbortCounter) {
+                    if (newRows !== null) {
+                        this.rows.value = this.concatOrReplace(newRows, this.rows.value)
+                        this.startIndex.value = 0
+                        // this.drained.value unchanged
+                        this.shadowRowCount.value = 0
+                    }
+                } else {
+                    this.executedAbortCounter += 1
                 }
             } else {
-                this.executedAbortCounter += 1
-            }
-        } else {
-            const newRows = await this.tailLoad(null, pageSize, false)
-            if (this.abortCounter == capturedAbortCounter) {
-                if (newRows !== null) {
-                    this.rows.value = newRows
-                    this.startIndex.value = 0
-                    this.drained.value = newRows.length < pageSize
-                    this.shadowRowCount.value = 0
+                const newRows = await this.tailLoad(null, pageSize, false)
+                if (this.abortCounter == capturedAbortCounter) {
+                    if (newRows !== null) {
+                        this.rows.value = newRows
+                        this.startIndex.value = 0
+                        this.drained.value = newRows.length < pageSize
+                        this.shadowRowCount.value = 0
+                    }
+                } else {
+                    this.executedAbortCounter += 1
                 }
-            } else {
-                this.executedAbortCounter += 1
             }
+        } finally {
+            this.loading.value = false
         }
 
         return Promise.resolve()
@@ -139,78 +146,83 @@ export class RowBuffer<R, K> {
         const headKey = this.headKey.value
         const tailKey = this.tailKey.value
 
-        if (this.abortCounter == captureAbortCounter) {
+        this.loading.value = true
+        try {
+            if (this.abortCounter == captureAbortCounter) {
 
-            if (key !== null) {
-                const newRows = await this.tailLoad(key, pageSize, true)
-                if (this.abortCounter == captureAbortCounter) {
-                    if (newRows !== null) {
-                        this.rows.value = newRows
-                        this.drained.value = newRows.length < pageSize
-                        this.startIndex.value = 0
-                        this.shadowRowCount.value = (page - 1) * pageSize
+                if (key !== null) {
+                    const newRows = await this.tailLoad(key, pageSize, true)
+                    if (this.abortCounter == captureAbortCounter) {
+                        if (newRows !== null) {
+                            this.rows.value = newRows
+                            this.drained.value = newRows.length < pageSize
+                            this.startIndex.value = 0
+                            this.shadowRowCount.value = (page - 1) * pageSize
+                        }
+                    } else {
+                        this.executedAbortCounter += 1
                     }
-                } else {
-                    this.executedAbortCounter += 1
-                }
 
-            } else if (headKey === null || tailKey === null) {
+                } else if (headKey === null || tailKey === null) {
 
-                // Buffer is empty
-                const newRows = await this.tailLoad(null, pageSize, false)
-                if (this.abortCounter == captureAbortCounter) {
-                    if (newRows !== null) {
-                        this.rows.value = this.rows.value.concat(newRows)
-                        this.drained.value = newRows.length < pageSize
-                        this.startIndex.value = Math.min(nextStartIndex - shadowRowCount, this.maxStartIndex.value)
-                        // this.shadowRowCount.value unchanged
+                    // Buffer is empty
+                    const newRows = await this.tailLoad(null, pageSize, false)
+                    if (this.abortCounter == captureAbortCounter) {
+                        if (newRows !== null) {
+                            this.rows.value = this.rows.value.concat(newRows)
+                            this.drained.value = newRows.length < pageSize
+                            this.startIndex.value = Math.min(nextStartIndex - shadowRowCount, this.maxStartIndex.value)
+                            // this.shadowRowCount.value unchanged
+                        }
+                    } else {
+                        this.executedAbortCounter += 1
                     }
-                } else {
-                    this.executedAbortCounter += 1
-                }
 
-            } else if (nextStartIndex < shadowRowCount) {
+                } else if (nextStartIndex < shadowRowCount) {
 
-                // We need to load rows at buffer head      :/
-                const rowCount = shadowRowCount - nextStartIndex
-                const newRows = await this.headLoad(headKey, rowCount)
-                if (this.abortCounter == captureAbortCounter) {
-                    if (newRows !== null) {
-                        this.rows.value = newRows.concat(this.rows.value)
-                        this.startIndex.value = 0
-                        this.shadowRowCount.value -= rowCount
-                        // rowBuffer.drained.value unchanged
+                    // We need to load rows at buffer head      :/
+                    const rowCount = shadowRowCount - nextStartIndex
+                    const newRows = await this.headLoad(headKey, rowCount)
+                    if (this.abortCounter == captureAbortCounter) {
+                        if (newRows !== null) {
+                            this.rows.value = newRows.concat(this.rows.value)
+                            this.startIndex.value = 0
+                            this.shadowRowCount.value -= rowCount
+                            // rowBuffer.drained.value unchanged
+                        }
+                    } else {
+                        this.executedAbortCounter += 1
                     }
-                } else {
-                    this.executedAbortCounter += 1
-                }
 
-            } else if (nextEndIndex > bufferLength + shadowRowCount && !this.drained.value) {
+                } else if (nextEndIndex > bufferLength + shadowRowCount && !this.drained.value) {
 
-                // We need to load rows at buffer tail      :\
-                const rowCount = nextEndIndex - bufferLength - shadowRowCount
-                const newRows = await this.tailLoad(tailKey, rowCount, false)
-                if (this.abortCounter == captureAbortCounter) {
-                    if (newRows !== null) {
-                        this.rows.value = this.rows.value.concat(newRows)
-                        this.drained.value = newRows.length < rowCount
-                        this.startIndex.value = Math.min(nextStartIndex - shadowRowCount, this.maxStartIndex.value)
-                        // rowBuffer.shadowRowCount.value unchanged
+                    // We need to load rows at buffer tail      :\
+                    const rowCount = nextEndIndex - bufferLength - shadowRowCount
+                    const newRows = await this.tailLoad(tailKey, rowCount, false)
+                    if (this.abortCounter == captureAbortCounter) {
+                        if (newRows !== null) {
+                            this.rows.value = this.rows.value.concat(newRows)
+                            this.drained.value = newRows.length < rowCount
+                            this.startIndex.value = Math.min(nextStartIndex - shadowRowCount, this.maxStartIndex.value)
+                            // rowBuffer.shadowRowCount.value unchanged
+                        }
+                    } else {
+                        this.executedAbortCounter += 1
                     }
+
                 } else {
-                    this.executedAbortCounter += 1
+
+                    // We have all the rows already loaded      :)
+                    this.startIndex.value = nextStartIndex - shadowRowCount
+                    // rowBuffer.buffer.value unchanged
+                    // rowBuffer.drained.value unchanged
+                    // rowBuffer.shadowRowCount.value unchanged
+
                 }
-
-            } else {
-
-                // We have all the rows already loaded      :)
-                this.startIndex.value = nextStartIndex - shadowRowCount
-                // rowBuffer.buffer.value unchanged
-                // rowBuffer.drained.value unchanged
-                // rowBuffer.shadowRowCount.value unchanged
 
             }
-
+        } finally {
+            this.loading.value = false
         }
 
         return Promise.resolve()

--- a/_frontend/src/utils/table/TableController.ts
+++ b/_frontend/src/utils/table/TableController.ts
@@ -47,7 +47,8 @@ export abstract class TableController<R, K> implements PlayPauseController {
     public readonly totalRowCount: ComputedRef<number> = computed(
         () => this.buffer.totalRowCount.value)
 
-    public readonly loading: Ref<boolean> = ref(false)
+    public readonly loading: ComputedRef<boolean> = computed(
+        () => this.buffer.loading.value)
 
     public readonly paginated: ComputedRef<boolean> = computed(
         () => this.buffer.totalRowCount.value >= this.pageSize.value)


### PR DESCRIPTION
**Description**:

Changes below: 
- increase auto-refresh period of `Account / Transactions / Created Contracts` table (was 5s, now 2min)
- make sure transaction tables displays `Loading…` during initial load (in place of `No Data`)
- fix `TableController.loading` flag (which enables `o-table` to displays its progress icon during loading)


**Related issue(s)**:

Fixes #2429

**Notes for reviewer**:

```
M       _frontend/src/components/transaction/TransactionTableController.ts
M       _frontend/src/pages/AccountDetails_Operations.vue
M       _frontend/src/pages/Topics.vue
        # AccountDetails_Operation view now refreshes its transaction table with slow period (2min)
        # (Topics keeps refreshing its transaction table as usual (2s))

M       _frontend/src/components/account/AccountCreatedContractsTable.vue
M       _frontend/src/components/transaction/TransactionTable.vue
        # Transaction table now displays "loading" during initial load (in place of "No data")

M       _frontend/src/utils/table/RowBuffer.ts
M       _frontend/src/utils/table/TableController.ts
        # Fixed TableController.loading computed value
        # => this makes o-table progress wheel appear
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
