### PR TITLE
fix: alignement of 'extra' slot in Tabs component.

### DIFF
--- a/_frontend/src/components/Tabs.vue
+++ b/_frontend/src/components/Tabs.vue
@@ -85,7 +85,7 @@ watch(() => props.tabIds, adjustSelectedTab, {immediate: true})
 <style scoped>
 
 div.tab-root {
-  align-items: baseline;
+  align-items: center ;
   column-gap: 16px;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
**Description**:

One-line fix.

The "extra" slot in Tabs is the only piece baseline-aligned in a flex-within-flex contex with everything center-aligned... which was calling for trouble. But this was working. So far. 

**Related issue(s)**:

Fixes #2451
