### PR TITLE
feat: Add feature flag to disable the support for hooks

### DIFF
--- a/_frontend/.env
+++ b/_frontend/.env
@@ -2,6 +2,9 @@
 ### The variables set in this file will be taken into account at build time.
 ###
 
+# When set to true, this variable will enable the support for HIP-1195 (Hiero hooks)
+VITE_APP_ACTIVATE_HIP_1195=true
+
 # When set to true, this variable will enable the support for HIP-1137 (registered nodes)
 VITE_APP_ACTIVATE_HIP_1137=true
 

--- a/_frontend/src/pages/AccountDetails.vue
+++ b/_frontend/src/pages/AccountDetails.vue
@@ -66,14 +66,16 @@ const props = defineProps({
   network: String,
 })
 
+const activateHooks = import.meta.env.VITE_APP_ACTIVATE_HIP_1195 === 'true'
 const networkConfig = NetworkConfig.inject()
 
 //
 // Tabs
 //
 
-const tabIds = routeManager.accountDetailsOperator.tabIds
-const tabLabels = routeManager.accountDetailsOperator.tabLabels
+const excludedTabIds = computed(() => activateHooks ? [] : ["AccountDetails_Hooks"])
+const tabIds = computed(() => routeManager.accountDetailsOperator.filterTabIds(excludedTabIds.value))
+const tabLabels = computed(() => routeManager.accountDetailsOperator.filterTabLabels(excludedTabIds.value))
 const selectedTabId = routeManager.accountDetailsOperator.selectedTabId
 
 const onUpdate = (tabId: string | null) => {

--- a/_frontend/src/utils/cache/HookStorageByIdCache.ts
+++ b/_frontend/src/utils/cache/HookStorageByIdCache.ts
@@ -16,6 +16,11 @@ export class HookStorageByIdCache extends EntityCache<string, HookStorage[] | nu
     // Cache
     //
     protected async load(key: string): Promise<HookStorage[] | null> {
+        const activateHooks = import.meta.env.VITE_APP_ACTIVATE_HIP_1195 === 'true'
+        if (!activateHooks) {
+            return null
+        }
+
         const accountAndHookId = key.split("---")
         const accountId = accountAndHookId[0]
         const hookId = Number(accountAndHookId[1])

--- a/_frontend/src/utils/cache/HooksByAccountIdCache.ts
+++ b/_frontend/src/utils/cache/HooksByAccountIdCache.ts
@@ -12,6 +12,11 @@ export class HooksByAccountIdCache extends EntityCache<string, Hook[] | null> {
     // Cache
     //
     protected async load(accountId: string): Promise<Hook[] | null> {
+        const activateHooks = import.meta.env.VITE_APP_ACTIVATE_HIP_1195 === 'true'
+        if (!activateHooks) {
+            return null
+        }
+
         let result: Hook[] | null
         const params = {
             limit: 100,

--- a/_frontend/tests/unit/account/AccountDetails.spec.ts
+++ b/_frontend/tests/unit/account/AccountDetails.spec.ts
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: Apache-2.0
 
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import axios from "axios";
 import AccountDetails from "@/pages/AccountDetails.vue";
@@ -55,6 +55,8 @@ HMSF.forceUTC = true
 describe("AccountDetails.vue", () => {
 
     it("AccountDetails should display top level tabs", async () => {
+        vi.stubEnv('VITE_APP_ACTIVATE_HIP_1195', 'true')
+
         await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any);


### PR DESCRIPTION
**Description**:

Add environment variable VITE_APP_ACTIVATE_HIP_1195 to control the display of the Hooks tab in AccountDetails and the related REST API calls.

**Related issue(s)**:

Fixes #2458
