### PR TITLE
fix: decoding panic error codes

### DIFF
--- a/_frontend/src/components/contract/ContractResultTable.vue
+++ b/_frontend/src/components/contract/ContractResultTable.vue
@@ -96,7 +96,7 @@ const handleClick = (result: ContractResult, c: unknown, i: number, ci: number, 
 }
 
 const makeErrorMessage = (result: ContractResult) => {
-  return decodeSolidityErrorMessage(result.error_message ?? null)
+  return decodeSolidityErrorMessage(result.error_message)
 }
 
 const results = props.controller.rows

--- a/_frontend/src/components/values/FunctionError.vue
+++ b/_frontend/src/components/values/FunctionError.vue
@@ -37,7 +37,13 @@
     <Property :custom-nb-col-class="customNbColClass" id="errorMessage">
       <template #name>Error Message</template>
       <template #value>
-        <StringValue v-if="decodedError" :string-value="decodedError"/>
+        <span v-if="decodedError">
+          <StringValue :string-value="decodedError"/>
+          <span v-if="decodedPanicMessage !== null">
+            <br/>
+            <span class="h-is-low-contrast h-should-wrap"> {{ decodedPanicMessage }} </span>
+          </span>
+        </span>
         <template v-else>
           <HexaDumpValue :byte-string="error" :show-none="true"/>
           <div v-if="errorDecodingStatus" class="h-is-extra-text">
@@ -62,7 +68,7 @@ import {CircleAlert} from "lucide-vue-next";
 import HexaDumpValue from "@/components/values/HexaDumpValue.vue";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
-import {decodeSolidityErrorMessage} from "@/schemas/MirrorNodeUtils.ts";
+import {decodeSolidityErrorMessage, fetchSolidityPanicMessage} from "@/schemas/MirrorNodeUtils.ts";
 import StringValue from "@/components/values/StringValue.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";
 
@@ -78,8 +84,8 @@ const props = defineProps({
   }
 })
 
-const decodedError = computed(() =>
-    props.analyzer.normalizedError.value != null ? decodeSolidityErrorMessage(props.analyzer.normalizedError.value) : null)
+const decodedError = computed(() => decodeSolidityErrorMessage(error.value))
+const decodedPanicMessage = computed(() => fetchSolidityPanicMessage(error.value))
 
 const error = props.analyzer.normalizedError
 const errorSignature = props.analyzer.errorSignature

--- a/_frontend/src/schemas/MirrorNodeUtils.ts
+++ b/_frontend/src/schemas/MirrorNodeUtils.ts
@@ -194,8 +194,63 @@ export function decodeSolidityErrorMessage(message: string|null): string | null 
 
     if (message === null || message === "0x" || message === "") {
         result = null
-    } else if (ethers.isHexString(message)) {
+    } else {
+        const errorDescription = decodeGenericError(message)
+        if (errorDescription !== null) {
+            if (errorDescription.name == "Panic") {
+                result = "Panic(" + ethers.toBeHex(errorDescription.args[0]) + ")"
+            } else {
+                result = errorDescription.name + "(\"" + errorDescription.args[0] + "\")"
+            }
+        } else {
+            try {
+                // Let's see if message is UTF-8 decodable
+                result = ethers.toUtf8String(message)
+            } catch {
+                result = message
+            }
+        }
+    }
 
+    return result
+}
+
+// https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/
+// Section "Revert on assertion failures and similar conditions instead of using the invalid opcode"
+const panicMessages = new Map<bigint, string>([
+    [0x01n, "assert called with an argument that evaluates to false"],
+    [0x11n, "Arithmetic operation results in underflow or overflow outside of an unchecked { ... } block"],
+    [0x12n, "Divide or divide modulo by zero"],
+    [0x21n, "Convert a value that is too big or negative into an enum type"],
+    [0x22n, "Access a storage byte array that is incorrectly encoded"],
+    [0x31n, "Call .pop() on an empty array"],
+    [0x32n, "Access an array, bytesN or an array slice at an out-of-bounds or negative index"],
+    [0x41n, "Allocate too much memory or create an array that is too large"],
+    [0x51n, "Call a zero-initialized variable of internal function type"],
+])
+
+export function fetchSolidityPanicMessage(message: string|null): string | null {
+    let result: string|null
+
+    const errorDescription = decodeGenericError(message)
+    if (errorDescription !== null) {
+        if (errorDescription.name == "Panic") {
+            const panicCode = errorDescription.args[0]
+            result = panicMessages.get(panicCode) ?? null
+        } else {
+            result = null
+        }
+    } else {
+        result = null
+    }
+
+    return result
+}
+
+export function decodeGenericError(message: string|null): ethers.ErrorDescription|null {
+    let result: ethers.ErrorDescription|null
+
+    if (ethers.isHexString(message)) {
         //
         // It can be:
         // - encoding of Error(string)
@@ -206,24 +261,13 @@ export function decodeSolidityErrorMessage(message: string|null): string | null 
         // https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/
         // Section "Revert on assertion failures and similar conditions instead of using the invalid opcode"
         //
-
         try {
-            const errorDescription = emptyITF.parseError(message)
-            if (errorDescription !== null) {
-                if (errorDescription.name == "Panic") {
-                    result = "Panic(" + ethers.toBeHex(errorDescription.args[0]) + ")"
-                } else {
-                    result = errorDescription.name + "(\"" + errorDescription.args[0] + "\")"
-                }
-            } else {
-                result = ethers.toUtf8String(message)
-            }
+            result = emptyITF.parseError(message)
         } catch {
-            result = message
+            result = null
         }
-
     } else {
-        result = message
+        result = null
     }
 
     return result

--- a/_frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
+++ b/_frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
@@ -15,12 +15,12 @@ describe("MirrorNodeUtils.ts", () => {
 
         expect(decodeSolidityErrorMessage("0x"))
             .toBe(null)
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage("0x"))
             .toBe(null)
 
         expect(decodeSolidityErrorMessage(""))
             .toBe(null)
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage(""))
             .toBe(null)
 
 
@@ -31,28 +31,28 @@ describe("MirrorNodeUtils.ts", () => {
 
         expect(decodeSolidityErrorMessage("0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b566963746f72204875676f000000000000000000000000000000000000000000"))
             .toBe("Error(\"Victor Hugo\")")
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage("0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b566963746f72204875676f000000000000000000000000000000000000000000"))
             .toBe(null)
 
         expect(decodeSolidityErrorMessage("0x494e56414c49445f4f5045524154494f4e"))
             .toBe("INVALID_OPERATION")
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage("0x494e56414c49445f4f5045524154494f4e"))
             .toBe(null)
 
         expect(decodeSolidityErrorMessage("0xc2bb947c"))
             .toBe("0xc2bb947c")
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage("0xc2bb947c"))
             .toBe(null)
 
         const actions = SAMPLE_REVERT_CONTRACT_RESULT_ACTIONS.actions
         expect(decodeSolidityErrorMessage(actions[0].result_data))
             .toBe("Error(\"payWithCardNFT - failed to call accept contract method\")")
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage(actions[0].result_data))
             .toBe(null)
 
         expect(decodeSolidityErrorMessage(actions[1].result_data))
             .toBeNull()
-        expect(fetchSolidityPanicMessage(null))
+        expect(fetchSolidityPanicMessage(actions[1].result_data))
             .toBe(null)
     })
 

--- a/_frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
+++ b/_frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from "vitest";
-import {decodeSolidityErrorMessage} from "@/schemas/MirrorNodeUtils.ts";
+import {decodeSolidityErrorMessage, fetchSolidityPanicMessage} from "@/schemas/MirrorNodeUtils.ts";
 import {SAMPLE_REVERT_CONTRACT_RESULT_ACTIONS} from "../Mocks.ts";
 
 describe("MirrorNodeUtils.ts", () => {
@@ -10,24 +10,50 @@ describe("MirrorNodeUtils.ts", () => {
 
         expect(decodeSolidityErrorMessage(null))
             .toBe(null)
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
+
         expect(decodeSolidityErrorMessage("0x"))
             .toBe(null)
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
+
         expect(decodeSolidityErrorMessage(""))
             .toBe(null)
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
+
 
         expect(decodeSolidityErrorMessage("0x4e487b710000000000000000000000000000000000000000000000000000000000000001"))
             .toBe("Panic(0x01)")
+        expect(fetchSolidityPanicMessage("assert called with an argument that evaluates to false"))
+            .toBe(null)
+
         expect(decodeSolidityErrorMessage("0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b566963746f72204875676f000000000000000000000000000000000000000000"))
             .toBe("Error(\"Victor Hugo\")")
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
+
         expect(decodeSolidityErrorMessage("0x494e56414c49445f4f5045524154494f4e"))
             .toBe("INVALID_OPERATION")
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
 
         expect(decodeSolidityErrorMessage("0xc2bb947c"))
             .toBe("0xc2bb947c")
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
 
         const actions = SAMPLE_REVERT_CONTRACT_RESULT_ACTIONS.actions
-        expect(decodeSolidityErrorMessage(actions[0].result_data)).toBe("Error(\"payWithCardNFT - failed to call accept contract method\")")
-        expect(decodeSolidityErrorMessage(actions[1].result_data)).toBeNull()
+        expect(decodeSolidityErrorMessage(actions[0].result_data))
+            .toBe("Error(\"payWithCardNFT - failed to call accept contract method\")")
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
+
+        expect(decodeSolidityErrorMessage(actions[1].result_data))
+            .toBeNull()
+        expect(fetchSolidityPanicMessage(null))
+            .toBe(null)
     })
 
 })

--- a/_frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
+++ b/_frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
@@ -26,8 +26,8 @@ describe("MirrorNodeUtils.ts", () => {
 
         expect(decodeSolidityErrorMessage("0x4e487b710000000000000000000000000000000000000000000000000000000000000001"))
             .toBe("Panic(0x01)")
-        expect(fetchSolidityPanicMessage("assert called with an argument that evaluates to false"))
-            .toBe(null)
+        expect(fetchSolidityPanicMessage("0x4e487b710000000000000000000000000000000000000000000000000000000000000001"))
+            .toBe("assert called with an argument that evaluates to false")
 
         expect(decodeSolidityErrorMessage("0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b566963746f72204875676f000000000000000000000000000000000000000000"))
             .toBe("Error(\"Victor Hugo\")")


### PR DESCRIPTION
**Description**:

Changes below enable Explorer to decode [Solidity 8.0 panic error codes](https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/).

Before
<img width="744" height="343" alt="image" src="https://github.com/user-attachments/assets/8118ccc4-6d9f-4a78-bc69-34be958adcc0" />

After
<img width="744" height="343" alt="image" src="https://github.com/user-attachments/assets/ed6e9f5f-cbf9-4361-af7e-52635027612f" />

Decoded error codes:
```
const panicMessages = new Map<bigint, string>([
    [0x01n, "assert called with an argument that evaluates to false"],
    [0x11n, "Arithmetic operation results in underflow or overflow outside of an unchecked { ... } block"],
    [0x12n, "Divide or divide modulo by zero"],
    [0x21n, "Convert a value that is too big or negative into an enum type"],
    [0x22n, "Access a storage byte array that is incorrectly encoded"],
    [0x31n, "Call .pop() on an empty array"],
    [0x32n, "Access an array, bytesN or an array slice at an out-of-bounds or negative index"],
    [0x41n, "Allocate too much memory or create an array that is too large"],
    [0x51n, "Call a zero-initialized variable of internal function type"],
])
```
**Related issue(s)**:

Fixes #2468 

**Notes for reviewer**:

Sample: https://hashscan.io/testnet/transaction/1733163830.893742905/result

```
M   _frontend/src/schemas/MirrorNodeUtils.ts
M   _frontend/tests/unit/schemas/MirrorNodeUtils.spec.ts
    # Added fetchSolidityPanicMessage() and matching unit tests

M   _frontend/src/components/values/FunctionError.vue
    # View now calls fetchSolidityPanicMessage() to improve it display

M   _frontend/src/components/contract/ContractResultTable.vue
    # Removed unneeded ?? operator
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
