### PR TITLE
chore: bump node to version 24.15

### DIFF
--- a/.github/workflows/flow-release-explorer.yaml
+++ b/.github/workflows/flow-release-explorer.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24.15
 
       - name: Install Semantic Release
         run: |
@@ -113,7 +113,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24.15
 
       - name: Install Semantic Release
         run: |

--- a/.github/workflows/zxc-compile-explorer-code.yaml
+++ b/.github/workflows/zxc-compile-explorer-code.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 24.15
           cache: npm
           cache-dependency-path: _frontend/package-lock.json
 

--- a/.github/workflows/zxc-release-explorer-docker-container.yaml
+++ b/.github/workflows/zxc-release-explorer-docker-container.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24.15
           cache: npm
           cache-dependency-path: _frontend/package-lock.json
 


### PR DESCRIPTION
**Description**:

Explorer CI is currently based on Node 22 which is EOL. Bump the version to 24.15 which is the current LTS.