### PR TITLE
feat: allow to copy input function & args fields

### DIFF
--- a/_frontend/src/components/contract/ContractResultLogEntry.vue
+++ b/_frontend/src/components/contract/ContractResultLogEntry.vue
@@ -43,12 +43,18 @@
               v-for="(t, ti) in props.log.topics"
               :class="{'unverif-log-args-prop': !isMediumScreen || !isSmallScreen}"
               :key="t"
-              class="unverified-log-entry"
+              class="log-entry"
           >
             <div class="topic-title-box">
               <span>{{ 'Topic ' + ti }}</span>
             </div>
             <HexaDumpValue :show-none="true" :byteString="t" :word-wrap-small="0" :word-wrap-medium="8"/>
+          </div>
+          <div :class="{'unverif-log-args-prop': !isMediumScreen || !isSmallScreen}" class="log-entry">
+            <div class="topic-title-box">
+              <span>Data</span>
+            </div>
+            <HexaDumpValue :byteString="props.log.data" :show-none="true" :word-wrap-medium="8" :word-wrap-small="0"/>
           </div>
         </div>
 
@@ -59,7 +65,7 @@
           <div
               v-for="(arg, i) in args"
               :key="arg.name"
-              class="verified-log-entry"
+              class="log-entry"
           >
             <div v-if="arg.indexed" class="topic-title-box">{{ 'Topic ' + i }}</div>
             <div v-else/>
@@ -170,16 +176,11 @@ div.log-content {
   gap: 16px;
 }
 
-div.unverified-log-entry {
-  align-items: center;
-  display: flex;
-  gap: 16px;
-}
-
-div.verified-log-entry {
+div.log-entry {
   display: grid;
   grid-template-columns: 75px 1fr;
   gap: 8px;
+  align-items: baseline;
 }
 
 .topic-title-box {

--- a/_frontend/src/components/contract/EthPrecompileAddress.vue
+++ b/_frontend/src/components/contract/EthPrecompileAddress.vue
@@ -7,12 +7,10 @@
 <template>
   <div v-if="squeezedAddress">
     <div class="evm-address">
-      <Copyable :content-to-copy="props.evmAddress" enable-copy>
-        <template #content>
-          <div class="h-is-low-contrast h-is-monospace" style="display: inline">
-            {{ squeezedAddress }}
-          </div>
-        </template>
+      <Copyable :content-to-copy="props.evmAddress">
+        <div class="h-is-low-contrast h-is-monospace" style="display: inline">
+          {{ squeezedAddress }}
+        </div>
       </Copyable>
       <div v-if="entityId" class="entity-id-or-name" style="margin-left: 4px">
         <span>({{ precompileLabel }})</span>

--- a/_frontend/src/components/values/ByteCodeValue.vue
+++ b/_frontend/src/components/values/ByteCodeValue.vue
@@ -6,13 +6,14 @@
 
 <template>
 
-  <div v-if="nonNullValue" id="bytecode">
-    <HexaDumpValue :byte-string="textValue" :copyable="false" :scroll-bar="props.scrollBar"/>
+  <div id="bytecode">
+    <HexaDumpValue
+        :byte-string="textValue"
+        :copyable="props.copyable"
+        :scroll-bar="props.scrollBar"
+        :show-none="true"
+    />
   </div>
-
-  <span v-else-if="initialLoading"/>
-
-  <span v-else class="h-is-low-contrast">None</span>
 
 </template>
 
@@ -20,26 +21,29 @@
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script setup lang="ts">
+<script lang="ts" setup>
 
-import {computed, inject, ref, watch} from 'vue';
-import {initialLoadingKey} from "@/AppKeys";
+import {computed, PropType} from 'vue';
 import HexaDumpValue from "@/components/values/HexaDumpValue.vue";
 
 const props = defineProps({
-  byteCode: String,
+  byteCode: {
+    type: String as PropType<string | null>,
+    default: null
+  },
   scrollBar: {
     type: Boolean,
     default: true
-  }
+  },
+  copyable: {
+    type: Boolean,
+    default: false
+  },
 })
 
-const textValue = ref(props.byteCode)
-watch(() => props.byteCode, () => {
-  textValue.value = props.byteCode
-})
-const nonNullValue = computed(() => props.byteCode != undefined && props.byteCode != '0x')
-const initialLoading = inject(initialLoadingKey, ref(false))
+const textValue = computed(() =>
+    props.byteCode && props.byteCode != '0x' ? props.byteCode : null
+)
 
 </script>
 

--- a/_frontend/src/components/values/EVMAddress.vue
+++ b/_frontend/src/components/values/EVMAddress.vue
@@ -8,14 +8,12 @@
   <div v-if="evmAddress">
     <div class="evm-address">
       <Copyable :content-to-copy="evmAddress" :enable-copy="enableCopy">
-        <template v-slot:content>
-          <div class="h-is-low-contrast h-is-monospace" style="display: inline">
-            {{ (props.compact || !isSmallScreen) ? nonSignificantCompact : nonSignificantFull }}
-          </div>
-          <div class="h-is-monospace" style="margin-right: 4px; display: inline">
-            {{ (props.compact || !isSmallScreen) ? significantCompact : significantFull }}
-          </div>
-        </template>
+        <div class="h-is-low-contrast h-is-monospace" style="display: inline">
+          {{ (props.compact || !isSmallScreen) ? nonSignificantCompact : nonSignificantFull }}
+        </div>
+        <div class="h-is-monospace" style="margin-right: 4px; display: inline">
+          {{ (props.compact || !isSmallScreen) ? significantCompact : significantFull }}
+        </div>
       </Copyable>
       <div v-if="entityId && showId" class="entity-id-or-name">
         <span>(</span>
@@ -130,6 +128,7 @@ const derivedEntityId = computed(() => {
 onMounted(() => updateIdAndAddress())
 watch([() => props.address, () => props.id, () => props.entityType], () => updateIdAndAddress())
 
+// eslint-disable-next-line complexity
 const updateIdAndAddress = async () => {
   entityLinkType.value = ExtendedEntityType.UNDEFINED
   evmAddress.value = props.address ?? null

--- a/_frontend/src/components/values/EntityIDView.vue
+++ b/_frontend/src/components/values/EntityIDView.vue
@@ -11,9 +11,7 @@
         :content-to-copy="props.id ?? ''"
         :enable-copy="props.enableCopy"
     >
-      <template #content>
-        <span style="font-weight: bold">{{ props.id ?? "" }}</span>
-      </template>
+      <span style="font-weight: bold">{{ props.id ?? "" }}</span>
     </Copyable>
     <span v-if="props.checksum" class="h-is-low-contrast">-{{ props.checksum }}</span>
   </div>

--- a/_frontend/src/components/values/FunctionInput.vue
+++ b/_frontend/src/components/values/FunctionInput.vue
@@ -36,7 +36,7 @@
       <Property :custom-nb-col-class="customNbColClass" id="functionInput">
         <template #name>Input Args</template>
         <template #value>
-          <ByteCodeValue :byte-code="inputArgsOnly ?? undefined"/>
+          <ByteCodeValue :byte-code="inputArgsOnly" :copyable="true"/>
           <div v-if="inputDecodingStatus" class="h-is-extra-text">
             <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
             <span>{{ inputDecodingStatus }}</span>
@@ -52,7 +52,7 @@
     <Property :custom-nb-col-class="customNbColClass" id="functionInput">
       <template #name>Input - Function & Args</template>
       <template #value>
-        <ByteCodeValue :byte-code="input ?? undefined"/>
+        <ByteCodeValue :byte-code="input" :copyable="true"/>
         <div v-if="functionDecodingStatus" class="h-is-extra-text">
           <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
           <span>{{ functionDecodingStatus }}</span>

--- a/_frontend/src/components/values/FunctionResult.vue
+++ b/_frontend/src/components/values/FunctionResult.vue
@@ -27,7 +27,7 @@
     <Property :custom-nb-col-class="customNbColClass" id="functionOutput">
       <template v-slot:name>Output Result</template>
       <template v-slot:value>
-        <ByteCodeValue :byte-code="output ?? undefined"/>
+        <ByteCodeValue :byte-code="output" :copyable="true"/>
         <div v-if="outputDecodingStatus" class="h-is-extra-text">
           <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
           <span>{{ outputDecodingStatus }}</span>

--- a/_frontend/src/components/values/FunctionValue.vue
+++ b/_frontend/src/components/values/FunctionValue.vue
@@ -8,14 +8,18 @@
 
   <div v-if="value">
     <EVMAddress v-if="addressValue" :address="addressValue" :compact="!isSmallScreen"/>
-    <div v-else :class="{'h-is-low-contrast': lowContrast}" class="function-value">
-      <p class="mr-1">{{ value }}</p>
+    <Copyable v-else :content-to-copy="value">
+      <template #content>
+        <div :class="{'h-is-low-contrast': lowContrast}" class="function-value">
+          <p class="mr-1">{{ value }}</p>
 
-      <p v-if="ntv?.comment"
-         class="h-is-extra-text">
-        ({{ ntv.comment }})
-      </p>
-    </div>
+          <p v-if="ntv?.comment"
+             class="h-is-extra-text">
+            ({{ ntv.comment }})
+          </p>
+        </div>
+      </template>
+    </Copyable>
     <div v-if="!hideType" class="h-is-extra-text">{{ type }}</div>
   </div>
   <div v-else-if="initialLoading"/>
@@ -27,12 +31,13 @@
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script setup lang="ts">
+<script lang="ts" setup>
 
 import {computed, inject, PropType, ref} from 'vue';
 import {initialLoadingKey} from "@/AppKeys";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import {NameTypeValue} from "@/utils/analyzer/call/FunctionCallDecoder.ts";
+import Copyable from "@/elements/Copyable.vue";
 
 const props = defineProps({
   ntv: Object as PropType<NameTypeValue>,

--- a/_frontend/src/components/values/FunctionValue.vue
+++ b/_frontend/src/components/values/FunctionValue.vue
@@ -9,16 +9,14 @@
   <div v-if="value">
     <EVMAddress v-if="addressValue" :address="addressValue" :compact="!isSmallScreen"/>
     <Copyable v-else :content-to-copy="value">
-      <template #content>
-        <div :class="{'h-is-low-contrast': lowContrast}" class="function-value">
-          <p class="mr-1">{{ value }}</p>
+      <div :class="{'h-is-low-contrast': lowContrast}" class="function-value">
+        <p class="mr-1">{{ value }}</p>
 
-          <p v-if="ntv?.comment"
-             class="h-is-extra-text">
-            ({{ ntv.comment }})
-          </p>
-        </div>
-      </template>
+        <p v-if="ntv?.comment"
+           class="h-is-extra-text">
+          ({{ ntv.comment }})
+        </p>
+      </div>
     </Copyable>
     <div v-if="!hideType" class="h-is-extra-text">{{ type }}</div>
   </div>

--- a/_frontend/src/components/values/FunctionValue.vue
+++ b/_frontend/src/components/values/FunctionValue.vue
@@ -8,7 +8,7 @@
 
   <div v-if="value">
     <EVMAddress v-if="addressValue" :address="addressValue" :compact="!isSmallScreen"/>
-    <Copyable v-else :content-to-copy="value">
+    <Copyable v-else :content-to-copy="value" :enable-copy="enableCopy">
       <div :class="{'h-is-low-contrast': lowContrast}" class="function-value">
         <p class="mr-1">{{ value }}</p>
 
@@ -60,6 +60,10 @@ const addressValue = computed(() => {
 
 const type = props.ntv?.type
 const value = props.ntv?.value?.toString()
+
+const enableCopy = computed(() => {
+  return type != undefined && type !== 'bool' && !type.startsWith('int') && !type.startsWith('uint')
+})
 
 </script>
 

--- a/_frontend/src/components/values/HexaDumpValue.vue
+++ b/_frontend/src/components/values/HexaDumpValue.vue
@@ -5,13 +5,14 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <Copyable v-if="normByteString"
-            :content-to-copy="'0x' + normByteString" :enable-copy="isCopyEnabled">
-    <template #content>
-      <div class="hexa-dump-value" :class="{'scrollbar': props.scrollBar}">
-        {{ flow(isMediumScreen ? wordWrapMedium : wordWrapSmall) }}
-      </div>
-    </template>
+  <Copyable
+      v-if="normByteString"
+      :content-to-copy="'0x' + normByteString"
+      :enable-copy="isCopyEnabled"
+  >
+    <div :class="{'scrollbar': props.scrollBar}" class="hexa-dump-value">
+      {{ flow(isMediumScreen ? wordWrapMedium : wordWrapSmall) }}
+    </div>
   </Copyable>
   <template v-else-if="showNone && !initialLoading">
     <div class="h-is-low-contrast">None</div>

--- a/_frontend/src/components/values/HexaValue.vue
+++ b/_frontend/src/components/values/HexaValue.vue
@@ -6,11 +6,9 @@
 
 <template>
   <Copyable v-if="normByteString" :content-to-copy="normByteString" :enable-copy="isCopyEnabled">
-    <template v-slot:content>
-      <div class="hexa-value">
-        {{ normByteString }}
-      </div>
-    </template>
+    <div class="hexa-value">
+      {{ normByteString }}
+    </div>
   </Copyable>
 
   <template v-else-if="showNone && !initialLoading">

--- a/_frontend/src/components/values/TransactionIdValue.vue
+++ b/_frontend/src/components/values/TransactionIdValue.vue
@@ -6,15 +6,10 @@
 
 <template>
 
-  <Copyable
-      :enable-copy="enableCopy"
-      :content-to-copy="transactionId ?? ''"
-  >
-    <template #content>
-      <div class="is-inline-block">
-        <span>{{ transactionId }}</span>
-      </div>
-    </template>
+  <Copyable :content-to-copy="transactionId ?? ''" :enable-copy="enableCopy">
+    <div class="is-inline-block">
+      <span>{{ transactionId }}</span>
+    </div>
   </Copyable>
 
 </template>

--- a/_frontend/src/elements/Copyable.vue
+++ b/_frontend/src/elements/Copyable.vue
@@ -6,7 +6,7 @@
 
 <template>
   <div class="shy-scope" :class="{'hoverable':enableCopy}">
-    <slot name="content"/>
+    <slot/>
     <div v-if="enableCopy && contentToCopy" id="shyCopyButton" class="shy">
       <div v-if="enableCopy" class="copy-button-container">
         <button class="copy-button" v-on:click.stop="copyToClipboard">Copy</button>

--- a/_frontend/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/_frontend/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -60,8 +60,8 @@ describe("ContractResultLogEntry.vue", () => {
         expect(wrapper.get("#blockNumber").get("a").text()).toBe('9')
         expect(wrapper.get("#blockNumber").text()).toBe("Block9")
         expect(wrapper.get("#address").text()).toBe("Address0x00…0b70cfCopy(TestEvent)")
-        expect(wrapper.get("#Args").text()).toBe("LogsFlightEvent (string phase, int256 airspeed, int256 verticalSpeed)Topic 0  signature hash0x01f789d670afa3030578cc570ac4d43ace6f1575dd6c395a711e72a30051efd2string  phaseHolding pointint256  airspeed0int256  verticalSpeed0")
-        expect(wrapper.get("#logArg_phase").text()).toBe("string  phaseHolding point")
+        expect(wrapper.get("#Args").text()).toBe("LogsFlightEvent (string phase, int256 airspeed, int256 verticalSpeed)Topic 0  signature hash0x01f789d670afa3030578cc570ac4d43ace6f1575dd6c395a711e72a30051efd2Copystring  phaseHolding pointCopyint256  airspeed0int256  verticalSpeed0")
+        expect(wrapper.get("#logArg_phase").text()).toBe("string  phaseHolding pointCopy")
         expect(wrapper.get("#logArg_airspeed").text()).toBe("int256  airspeed0")
         expect(wrapper.get("#logArg_verticalSpeed").text()).toBe("int256  verticalSpeed0")
 

--- a/_frontend/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/_frontend/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -24,7 +24,7 @@ HMSF.forceUTC = true
 
 describe("ContractResultLogEntry.vue", () => {
 
-    it("Should display the contract result and logs, given consensus timestamp", async () => {
+    it("Should display the verified contract result logs, given consensus timestamp", async () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
@@ -64,6 +64,48 @@ describe("ContractResultLogEntry.vue", () => {
         expect(wrapper.get("#logArg_phase").text()).toBe("string  phaseHolding pointCopy")
         expect(wrapper.get("#logArg_airspeed").text()).toBe("int256  airspeed0")
         expect(wrapper.get("#logArg_verticalSpeed").text()).toBe("int256  verticalSpeed0")
+
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("Should display the unverified contract result logs, given consensus timestamp", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const matcher1 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        const mock = new MockAdapter(axios as any);
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT)
+
+        const wrapper = mount(ContractResultLogEntry, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                log: SAMPLE_LOG_RESULT,
+                transactionHash: "0xc7b2ecffdefdec56b809f93bef6c8528dad22e58a02a33c20d275f2ef27936d56b1ed64b53f920fbac85d9cada4a4e78",
+                blockNumber: 9
+            },
+        });
+        await flushPromises()
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id,
+            "api/v1/contracts/" + SAMPLE_CONTRACT.evm_address,
+            "http://localhost:3000/files/any/295/" + SAMPLE_CONTRACT.evm_address,
+            "api/v1/accounts/" + SAMPLE_CONTRACT.evm_address,
+        ])
+
+        expect(wrapper.get("#transactionHash").text()).toBe("Transaction Hashc7b2 ecff defd ec56 b809 f93b ef6c 8528 dad2 2e58 a02a 33c2 0d27 5f2e f279 36d5 6b1e d64b 53f9 20fb ac85 d9ca da4a 4e78Copy")
+        expect(wrapper.get("#blockNumber").find("a").exists()).toBeTruthy()
+        expect(wrapper.get("#blockNumber").get("a").text()).toBe('9')
+        expect(wrapper.get("#blockNumber").text()).toBe("Block9")
+        expect(wrapper.get("#address").text()).toBe(`Address0x00…0b70cfCopy(${SAMPLE_CONTRACT.contract_id})`)
+        expect(wrapper.get("#Args").text()).toBe(
+            "Logs" +
+            "Topic 0" + "01f7 89d6 70af a303 0578 cc57 0ac4 d43a ce6f 1575 dd6c 395a 711e 72a3 0051 efd2Copy" +
+            "Data" + "0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0060 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 000d 486f 6c64 696e 6720 706f 696e 7400 0000 0000 0000 0000 0000 0000 0000 0000 0000Copy"
+        )
 
         wrapper.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

- Make all values copyable in Function input/output/error in contract results -- except when these are boolean or integer
- Add missing `Data` field in the Input for unverified contracts -- contains the non-indexed arguments
- Refactor Copyable component: #content slot becomes default slot

**Related issue(s)**:

Fixes #2316 

**Notes for reviewer**:

Deployed on staging server

Note addition of data field:
<img width="1176" height="278" alt="Screenshot 2026-05-15 at 13 34 25" src="https://github.com/user-attachments/assets/678b364a-5020-4424-add8-1b0b4428b788" />

