### PR TITLE
fix: layout of compact TransferGraphSection with mixed types of transfers

### DIFF
--- a/_frontend/src/components/transfer_graphs/HbarTransferGraphC.vue
+++ b/_frontend/src/components/transfer_graphs/HbarTransferGraphC.vue
@@ -6,52 +6,54 @@
 
 <template>
 
-  <div v-if="hbarTransferLayout.rowCount >= 1" class="graph-container">
+  <div>
+    <div v-if="hbarTransferLayout.rowCount >= 1" class="graph-container">
 
-    <template v-for="i in hbarTransferLayout.rowCount" v-bind:key="i">
+      <template v-for="i in hbarTransferLayout.rowCount" v-bind:key="i">
 
-      <!-- #0 : account id -->
-      <div>
-        <AccountLink v-if="i <= hbarTransferLayout.sources.length"
-                     v-bind:account-id="hbarTransferLayout.sources[i-1].transfer.account"
-                     v-bind:no-anchor="true"
-                     null-label="MINT"
-                     data-cy="sourceAccount"/>
-      </div>
+        <!-- #0 : account id -->
+        <div>
+          <AccountLink v-if="i <= hbarTransferLayout.sources.length"
+                       v-bind:account-id="hbarTransferLayout.sources[i-1].transfer.account"
+                       v-bind:no-anchor="true"
+                       null-label="MINT"
+                       data-cy="sourceAccount"/>
+        </div>
 
-      <!-- #1 : arrow -->
-      <div style="position: relative">
-        <ArrowSegment
-            v-bind:source-count="hbarTransferLayout.sources.length"
-            v-bind:compact="true"
-            v-bind:row-index="i-1"/>
-      </div>
+        <!-- #1 : arrow -->
+        <div style="position: relative">
+          <ArrowSegment
+              v-bind:source-count="hbarTransferLayout.sources.length"
+              v-bind:compact="true"
+              v-bind:row-index="i-1"/>
+        </div>
 
-      <!-- #2 : hbar amount -->
-      <div class="justify-end">
-        <HbarAmount v-if="i === 1"
-                    v-bind:amount="hbarTransferLayout.destinationAmount"/>
-      </div>
+        <!-- #2 : hbar amount -->
+        <div class="justify-end">
+          <HbarAmount v-if="i === 1"
+                      v-bind:amount="hbarTransferLayout.destinationAmount"/>
+        </div>
 
-      <!-- #3 : arrow -->
-      <div style="position: relative">
-        <ArrowSegment
-            v-bind:dest-count="hbarTransferLayout.destinations.length"
-            v-bind:compact="true"
-            v-bind:row-index="i-1"/>
-      </div>
+        <!-- #3 : arrow -->
+        <div style="position: relative">
+          <ArrowSegment
+              v-bind:dest-count="hbarTransferLayout.destinations.length"
+              v-bind:compact="true"
+              v-bind:row-index="i-1"/>
+        </div>
 
-      <!-- #4 : account id -->
-      <div>
-        <AccountLink v-if="i <= hbarTransferLayout.destinations.length"
-                     v-bind:account-id="hbarTransferLayout.destinations[i-1].transfer.account"
-                     v-bind:no-anchor="true"
-                     null-label="BURN"
-                     data-cy="destinationAccount"/>
-      </div>
+        <!-- #4 : account id -->
+        <div>
+          <AccountLink v-if="i <= hbarTransferLayout.destinations.length"
+                       v-bind:account-id="hbarTransferLayout.destinations[i-1].transfer.account"
+                       v-bind:no-anchor="true"
+                       null-label="BURN"
+                       data-cy="destinationAccount"/>
+        </div>
 
-    </template>
+      </template>
 
+    </div>
   </div>
 
 </template>

--- a/_frontend/src/components/transfer_graphs/TokenTransferGraphC.vue
+++ b/_frontend/src/components/transfer_graphs/TokenTransferGraphC.vue
@@ -6,61 +6,63 @@
 
 <template>
 
-  <div v-if="tokenTransferLayout.length >= 1" class="graph-container">
+  <div>
+    <div v-if="tokenTransferLayout.length >= 1" class="graph-container">
 
-    <template v-for="s in tokenTransferLayout.length" v-bind:key="s">
+      <template v-for="s in tokenTransferLayout.length" v-bind:key="s">
 
-      <template v-for="i in tokenTransferLayout[s-1].rowCount" v-bind:key="i">
+        <template v-for="i in tokenTransferLayout[s-1].rowCount" v-bind:key="i">
 
-        <!-- #0 : account id -->
-        <div>
-          <template v-if="i <= tokenTransferLayout[s-1].sources.length">
-            <AccountLink v-bind:account-id="tokenTransferLayout[s-1].sources[i-1].account"
-                         v-bind:no-anchor="true"
-                         null-label="MINT"
-                         data-cy="sourceAccount"/>
-          </template>
-        </div>
+          <!-- #0 : account id -->
+          <div>
+            <template v-if="i <= tokenTransferLayout[s-1].sources.length">
+              <AccountLink v-bind:account-id="tokenTransferLayout[s-1].sources[i-1].account"
+                           v-bind:no-anchor="true"
+                           null-label="MINT"
+                           data-cy="sourceAccount"/>
+            </template>
+          </div>
 
-        <!-- #1 : arrow -->
-        <div style="position: relative">
-          <ArrowSegment
-              v-bind:source-count="tokenTransferLayout[s-1].sources.length"
-              v-bind:compact="true"
-              v-bind:row-index="i-1"/>
-        </div>
+          <!-- #1 : arrow -->
+          <div style="position: relative">
+            <ArrowSegment
+                v-bind:source-count="tokenTransferLayout[s-1].sources.length"
+                v-bind:compact="true"
+                v-bind:row-index="i-1"/>
+          </div>
 
-        <!-- #2 : token amount -->
-        <div class="justify-end">
-          <TokenAmount v-if="i === 1"
-                       v-bind:amount="BigInt(tokenTransferLayout[s-1].netAmount)"
-                       v-bind:token-id="tokenTransferLayout[s-1].tokenId"
-                       v-bind:show-extra="true"/>
-        </div>
+          <!-- #2 : token amount -->
+          <div class="justify-end">
+            <TokenAmount v-if="i === 1"
+                         v-bind:amount="BigInt(tokenTransferLayout[s-1].netAmount)"
+                         v-bind:token-id="tokenTransferLayout[s-1].tokenId"
+                         v-bind:show-extra="true"/>
+          </div>
 
-        <!-- #3 : arrow -->
-        <div style="position: relative">
-          <ArrowSegment
-              v-bind:dest-count="tokenTransferLayout[s-1].destinations.length"
-              v-bind:compact="true"
-              v-bind:row-index="i-1"/>
-        </div>
+          <!-- #3 : arrow -->
+          <div style="position: relative">
+            <ArrowSegment
+                v-bind:dest-count="tokenTransferLayout[s-1].destinations.length"
+                v-bind:compact="true"
+                v-bind:row-index="i-1"/>
+          </div>
 
-        <!-- #4 : account id -->
-        <div>
-          <template v-if="i <= tokenTransferLayout[s-1].destinations.length">
-            <AccountLink v-bind:account-id="tokenTransferLayout[s-1].destinations[i-1].account"
-                         v-bind:no-anchor="true"
-                         null-label="BURN"
-                         data-cy="destinationAccount"/>
-          </template>
-        </div>
+          <!-- #4 : account id -->
+          <div>
+            <template v-if="i <= tokenTransferLayout[s-1].destinations.length">
+              <AccountLink v-bind:account-id="tokenTransferLayout[s-1].destinations[i-1].account"
+                           v-bind:no-anchor="true"
+                           null-label="BURN"
+                           data-cy="destinationAccount"/>
+            </template>
+          </div>
 
+
+        </template>
 
       </template>
 
-    </template>
-
+    </div>
   </div>
 
 </template>


### PR DESCRIPTION
**Description**:

Fix the layout of the compact version of TransferGraphSection (used in the CONTENT column of TransactionTable) when it mixes for instance hbar and tokens transfers.
Wrap the inline-grids in a div to avoid their being displayed on the same line when the table is wide enough.

**Related issue(s)**:

Fixes #2239

**Notes for reviewer**:

**Before**:
<img width="1629" height="533" alt="Screenshot 2026-05-22 at 16 41 28" src="https://github.com/user-attachments/assets/afb2963c-b6ac-4c03-97c1-8439e8b592aa" />

**After**:
<img width="1637" height="580" alt="Screenshot 2026-05-22 at 16 43 10" src="https://github.com/user-attachments/assets/f6a5d53d-f229-493b-80a1-d0980be65538" />
