### PR TITLE
chore: bump vue-tsc to 3.3.2

### DIFF
--- a/_frontend/package-lock.json
+++ b/_frontend/package-lock.json
@@ -75,7 +75,7 @@
         "typescript-eslint": "8.61.1",
         "vite": "^8.0.16",
         "vitest": "4.1.9",
-        "vue-tsc": "^2.2.12"
+        "vue-tsc": "3.3.2"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -6486,30 +6486,30 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
-      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/source-map": "2.4.15"
+        "@volar/source-map": "2.4.28"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
-      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
-      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.15",
+        "@volar/language-core": "2.4.28",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
@@ -6615,17 +6615,6 @@
         "@vue/shared": "3.5.35"
       }
     },
-    "node_modules/@vue/compiler-vue2": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
-      }
-    },
     "node_modules/@vue/devtools-api": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.2.tgz",
@@ -6680,28 +6669,32 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
-      "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.2.tgz",
+      "integrity": "sha512-CLwjSfHlPLhjd2qhuS3tTFtnOIWHXAM5u4X1DxmzlQ8j5bmOYlKCsSusOP7jCRJnlVg0mCTQtHU3vwFvopZGoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.15",
+        "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
-        "@vue/compiler-vue2": "^2.7.16",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^1.0.3",
-        "minimatch": "^9.0.3",
+        "alien-signals": "^3.2.0",
         "muggle-string": "^0.4.1",
-        "path-browserify": "^1.0.1"
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -7622,9 +7615,9 @@
       "peer": true
     },
     "node_modules/alien-signals": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
-      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -9863,13 +9856,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -11802,16 +11788,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/help-me": {
@@ -20067,14 +20043,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
-      "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.2.tgz",
+      "integrity": "sha512-n7nQoA3YWW/eiDR8jMiv/uJvlg0uLGs+YgUrsTrf9EZaYSt3tuvMZb5V8+7Mvh/EH5pnY/hoVdgfjH+XcK+wwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/typescript": "2.4.15",
-        "@vue/language-core": "2.2.12"
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.2"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/_frontend/package.json
+++ b/_frontend/package.json
@@ -91,7 +91,7 @@
     "typescript-eslint": "8.61.1",
     "vite": "^8.0.16",
     "vitest": "4.1.9",
-    "vue-tsc": "^2.2.12"
+    "vue-tsc": "3.3.2"
   },
   "overrides": {
     "@babel/core": "7.29.6",

--- a/_frontend/src/charts/core/ChartRange.ts
+++ b/_frontend/src/charts/core/ChartRange.ts
@@ -41,7 +41,6 @@ export function computeStartDateForRange(period: ChartRange): Date {
     return result
 }
 
-
 export function computeGranularityForRange(period: ChartRange): ChartGranularity {
     let result: ChartGranularity
     switch (period) {
@@ -62,3 +61,7 @@ export function computeGranularityForRange(period: ChartRange): ChartGranularity
     return result
 }
 
+export function toChartRange(value: string | null, fallback: ChartRange): ChartRange {
+    const result = value as ChartRange
+    return Object.values(ChartRange).includes(result) ? result : fallback
+}

--- a/_frontend/src/charts/core/RangeSelectView.vue
+++ b/_frontend/src/charts/core/RangeSelectView.vue
@@ -6,7 +6,7 @@
 
 <template>
   <TabsView
-      v-model:selected-tab="selectedRange"
+      v-model:selected-tab="selectedTab"
       :tab-ids="ids"
       :tab-labels="labels"
       :active-tabs="active"
@@ -22,7 +22,7 @@
 
 import {computed, PropType} from "vue";
 import {ChartController, ChartState} from "@/charts/core/ChartController.ts";
-import {ChartRange} from "@/charts/core/ChartRange.ts";
+import {ChartRange, toChartRange} from "@/charts/core/ChartRange.ts";
 import TabsView from "@/components/TabsView.vue";
 
 const props = defineProps({
@@ -41,8 +41,12 @@ const active = computed(() => [
   allRangeSupported.value
 ])
 
+const selectedTab = computed<string | null>({
+  get: () => props.controller.range.value as string,
+  set: (value: string | null) => props.controller.range.value = toChartRange(value, ChartRange.day)
+})
+
 const loading = computed(() => props.controller.state.value === ChartState.loading)
-const selectedRange = props.controller.range
 const dayRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.day))
 const monthRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.month))
 const yearRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.year))

--- a/_frontend/src/components/DateTimePicker.vue
+++ b/_frontend/src/components/DateTimePicker.vue
@@ -31,7 +31,7 @@ const props = defineProps({
   controller: Object as PropType<TransactionTableControllerXL>
 })
 
-const emit = defineEmits(["dateCleared"])
+const emit = defineEmits<{ dateCleared: [] }>()
 
 const darkSelected = ThemeController.inject().darkSelected
 const date = ref(new Date())

--- a/_frontend/src/components/EditableProperty.vue
+++ b/_frontend/src/components/EditableProperty.vue
@@ -48,7 +48,7 @@ defineProps({
   }
 })
 
-const emit = defineEmits(['edit'])
+const emit = defineEmits<{ edit: [] }>()
 
 const onEdit = () => emit('edit')
 

--- a/_frontend/src/components/MediaContent.vue
+++ b/_frontend/src/components/MediaContent.vue
@@ -99,7 +99,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['onLoadSuccess', 'onLoadError'])
+const emit = defineEmits<{ onLoadSuccess: [], onLoadError: [] }>()
 
 const videoUrl: ComputedRef<string | null> = computed(
     () => props.type?.startsWith('video') || props.type?.startsWith('audio')

--- a/_frontend/src/components/account/AccountCreatedContractsTable.vue
+++ b/_frontend/src/components/account/AccountCreatedContractsTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="transactions"
       :hoverable="true"
       :loading="loading"

--- a/_frontend/src/components/account/AccountTable.vue
+++ b/_frontend/src/components/account/AccountTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/account/FungibleTable.vue
+++ b/_frontend/src/components/account/FungibleTable.vue
@@ -13,12 +13,14 @@
       backend-pagination
       pagination-order="centered"
       :total="props.controller.totalRowCount.value"
-      v-model:current-page="props.controller.currentPage.value"
+      :current-page="props.controller.currentPage.value"
+      @update:current-page="props.controller.currentPage.value = $event as number"
       :per-page="props.controller.pageSize.value"
       @page-change="props.controller.onPageChange"
       @cell-click="handleClick"
       :checkable="props.checkEnabled"
-      v-model:checked-rows="checkedRows"
+      :checked-rows="checkedRows"
+      @update:checked-rows="checkedRows = $event as (Token | Nft)[]"
 
       :hoverable="true"
       :narrowed="true"

--- a/_frontend/src/components/account/NftsTable.vue
+++ b/_frontend/src/components/account/NftsTable.vue
@@ -13,12 +13,14 @@
       backend-pagination
       pagination-order="centered"
       :total="props.controller.totalRowCount.value"
-      v-model:current-page="props.controller.currentPage.value"
+      :current-page="props.controller.currentPage.value"
+      @update:current-page="props.controller.currentPage.value = $event as number"
       :per-page="props.controller.pageSize.value"
       @page-change="props.controller.onPageChange"
       @cell-click="handleClick"
       :checkable="props.checkEnabled"
-      v-model:checked-rows="checkedRows"
+      :checked-rows="checkedRows"
+      @update:checked-rows="checkedRows = $event as (Token | Nft)[]"
 
       :hoverable="true"
       :narrowed="true"

--- a/_frontend/src/components/account/PendingFungibleAirdropTable.vue
+++ b/_frontend/src/components/account/PendingFungibleAirdropTable.vue
@@ -23,7 +23,8 @@
       :striped="false"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      v-model:checked-rows="checkedRows"
+      :checked-rows="checkedRows"
+      @update:checked-rows="checkedRows = $event as TokenAirdrop[]"
       :checkable="props.checkEnabled"
 
   >

--- a/_frontend/src/components/account/PendingNftAirdropTable.vue
+++ b/_frontend/src/components/account/PendingNftAirdropTable.vue
@@ -23,9 +23,9 @@
       :striped="false"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      v-model:checked-rows="checkedRows"
+      :checked-rows="checkedRows"
+      @update:checked-rows="checkedRows = $event as TokenAirdrop[]"
       :checkable="props.checkEnabled"
-
   >
 
     <o-table-column v-slot="{ row }" field="image" label="IMAGE">

--- a/_frontend/src/components/allowances/HbarAllowanceTable.vue
+++ b/_frontend/src/components/allowances/HbarAllowanceTable.vue
@@ -82,8 +82,9 @@ import HbarAmount from "@/components/values/HbarAmount.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
 import {Pencil} from "lucide-vue-next";
+import {CryptoAllowance} from "@/schemas/MirrorNodeSchemas";
 
-const emit = defineEmits(["editAllowance"])
+const emit = defineEmits<{ editAllowance: [row: CryptoAllowance] }>()
 
 const props = defineProps({
   controller: {

--- a/_frontend/src/components/allowances/HbarAllowanceTable.vue
+++ b/_frontend/src/components/allowances/HbarAllowanceTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="allowances"
       :hoverable="false"
       :loading="loading"

--- a/_frontend/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/_frontend/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="allowances"
       :hoverable="false"
       :loading="loading"

--- a/_frontend/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/_frontend/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -92,7 +92,7 @@ interface DisplayedNftAllowance extends NftAllowance {
   isEditable: boolean
 }
 
-const emit = defineEmits(["deleteAllowance"])
+const emit = defineEmits<{ deleteAllowance: [row: DisplayedNftAllowance] }>()
 
 const props = defineProps({
   controller: {

--- a/_frontend/src/components/allowances/NftAllowanceTable.vue
+++ b/_frontend/src/components/allowances/NftAllowanceTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="nfts"
       :hoverable="false"
       :loading="loading"

--- a/_frontend/src/components/allowances/NftAllowanceTable.vue
+++ b/_frontend/src/components/allowances/NftAllowanceTable.vue
@@ -85,8 +85,9 @@ import {NftAllowanceTableController} from "@/components/allowances/NftAllowanceT
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
 import {Trash2} from 'lucide-vue-next';
+import {Nft} from "@/schemas/MirrorNodeSchemas";
 
-const emit = defineEmits(["deleteAllowance"])
+const emit = defineEmits<{ deleteAllowance: [row: Nft] }>()
 
 const props = defineProps({
   controller: {

--- a/_frontend/src/components/allowances/TokenAllowanceTable.vue
+++ b/_frontend/src/components/allowances/TokenAllowanceTable.vue
@@ -102,7 +102,7 @@ interface DisplayedTokenAllowance extends TokenAllowance {
   isEditable: boolean
 }
 
-const emit = defineEmits(["editAllowance"])
+const emit = defineEmits<{ editAllowance: [row: DisplayedTokenAllowance] }>()
 
 const props = defineProps({
   controller: {

--- a/_frontend/src/components/allowances/TokenAllowanceTable.vue
+++ b/_frontend/src/components/allowances/TokenAllowanceTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="allowances"
       :hoverable="false"
       :loading="loading"

--- a/_frontend/src/components/block/BlockTable.vue
+++ b/_frontend/src/components/block/BlockTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/block/BlockTransactionTable.vue
+++ b/_frontend/src/components/block/BlockTransactionTable.vue
@@ -8,7 +8,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="transactions"
       :hoverable="true"
       :narrowed="narrowed"

--- a/_frontend/src/components/contract/ContractActionsTable.vue
+++ b/_frontend/src/components/contract/ContractActionsTable.vue
@@ -16,7 +16,8 @@
 
         :detailed="isMediumScreen"
         custom-detail-row
-        v-model:detailed-rows="expandedActions"
+        :detailed-rows="expandedActions"
+        @update:detailed-rows="expandedActions = $event as Array<ContractActionWithPath>"
 
         :hoverable="false"
         :narrowed="true"

--- a/_frontend/src/components/contract/ContractResultLogs.vue
+++ b/_frontend/src/components/contract/ContractResultLogs.vue
@@ -36,7 +36,8 @@
         <div v-if="isPaginated" class="pagination">
           <o-pagination
               :total="props.logs.length"
-              v-model:current="currentPage"
+              :current="currentPage"
+              @update:current="currentPage = $event as number"
               position="centered"
               :range-before="1"
               :range-after="1"

--- a/_frontend/src/components/contract/ContractResultStates.vue
+++ b/_frontend/src/components/contract/ContractResultStates.vue
@@ -43,7 +43,8 @@
       <div v-if="isPaginated" class="pagination">
         <o-pagination
             :total="stateChanges.length"
-            v-model:current="currentPage"
+            :current="currentPage"
+            @update:current="currentPage = $event as number"
             position="centered"
             :range-before="1"
             :range-after="1"

--- a/_frontend/src/components/contract/ContractResultTable.vue
+++ b/_frontend/src/components/contract/ContractResultTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="results"
       :hoverable="true"
       :loading="loading"

--- a/_frontend/src/components/contract/ContractTable.vue
+++ b/_frontend/src/components/contract/ContractTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/contract/ERC20ByNameTable.vue
+++ b/_frontend/src/components/contract/ERC20ByNameTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="pageSize"
       @cell-click="handleClick"
 

--- a/_frontend/src/components/contract/ERC721ByNameTable.vue
+++ b/_frontend/src/components/contract/ERC721ByNameTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="pageSize"
       @cell-click="handleClick"
 

--- a/_frontend/src/components/node/map/Marker.vue
+++ b/_frontend/src/components/node/map/Marker.vue
@@ -16,7 +16,7 @@
 
 import {computed} from "vue";
 
-const emits = defineEmits(["action"])
+const emits = defineEmits<{ action: [] }>()
 
 const itemSize = 10
 const itemStyle = computed(() => {

--- a/_frontend/src/components/search/SearchBar.vue
+++ b/_frontend/src/components/search/SearchBar.vue
@@ -53,7 +53,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["search"]);
+const emit = defineEmits<{ search: [] }>();
 
 const isMediumScreen = inject('isMediumScreen', true)
 

--- a/_frontend/src/components/staking/StakingRewardsTable.vue
+++ b/_frontend/src/components/staking/StakingRewardsTable.vue
@@ -14,7 +14,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/token/NftHolderTable.vue
+++ b/_frontend/src/components/token/NftHolderTable.vue
@@ -14,7 +14,8 @@
         backend-pagination
         pagination-order="centered"
         :total="total"
-        v-model:current-page="currentPage"
+        :current-page="currentPage"
+        @update:current-page="currentPage = $event as number"
         :per-page="perPage"
         @page-change="onPageChange"
 

--- a/_frontend/src/components/token/TokenActions.vue
+++ b/_frontend/src/components/token/TokenActions.vue
@@ -104,7 +104,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["completed"])
+const emit = defineEmits<{ completed: [] }>()
 
 /*
 

--- a/_frontend/src/components/token/TokenBalanceTable.vue
+++ b/_frontend/src/components/token/TokenBalanceTable.vue
@@ -15,7 +15,8 @@
         backend-pagination
         pagination-order="centered"
         :total="total"
-        v-model:current-page="currentPage"
+        :current-page="currentPage"
+        @update:current-page="currentPage = $event as number"
         :per-page="perPage"
         @page-change="onPageChange"
         @cell-click="handleClick"

--- a/_frontend/src/components/token/TokenTable.vue
+++ b/_frontend/src/components/token/TokenTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/token/TokensByNameTable.vue
+++ b/_frontend/src/components/token/TokensByNameTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @cell-click="handleClick"
 

--- a/_frontend/src/components/token/TokensByPopularityTable.vue
+++ b/_frontend/src/components/token/TokensByPopularityTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @cell-click="handleClick"
 

--- a/_frontend/src/components/topic/TopicMessageTable.vue
+++ b/_frontend/src/components/topic/TopicMessageTable.vue
@@ -14,7 +14,8 @@
         backend-pagination
         pagination-order="centered"
         :total="total"
-        v-model:current-page="currentPage"
+        :current-page="currentPage"
+        @update:current-page="currentPage = $event as number"
         :per-page="perPage"
         @page-change="onPageChange"
         @cell-click="handleClick"

--- a/_frontend/src/components/topic/TopicTable.vue
+++ b/_frontend/src/components/topic/TopicTable.vue
@@ -13,7 +13,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/transaction/NftTransactionTable.vue
+++ b/_frontend/src/components/transaction/NftTransactionTable.vue
@@ -12,7 +12,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/components/transaction/TablePageSize.vue
+++ b/_frontend/src/components/transaction/TablePageSize.vue
@@ -37,7 +37,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["update:size"])
+const emit = defineEmits<{ 'update:size': [value: number] }>()
 
 const selected = ref(props.size)
 watch(() => props.size, () => selected.value = props.size)

--- a/_frontend/src/components/transaction/TransactionBatchTable.vue
+++ b/_frontend/src/components/transaction/TransactionBatchTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="props.transactions"
       :hoverable="true"
       :narrowed="props.narrowed"

--- a/_frontend/src/components/transaction/TransactionByIdTable.vue
+++ b/_frontend/src/components/transaction/TransactionByIdTable.vue
@@ -7,7 +7,8 @@
 <template>
 
   <o-table
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :data="props.transactions"
       :hoverable="true"
       :narrowed="props.narrowed"

--- a/_frontend/src/components/transaction/TransactionTable.vue
+++ b/_frontend/src/components/transaction/TransactionTable.vue
@@ -14,7 +14,8 @@
       backend-pagination
       pagination-order="centered"
       :total="total"
-      v-model:current-page="currentPage"
+      :current-page="currentPage"
+      @update:current-page="currentPage = $event as number"
       :per-page="perPage"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/_frontend/src/dialogs/CookiesDialog.vue
+++ b/_frontend/src/dialogs/CookiesDialog.vue
@@ -35,7 +35,10 @@ const showDialog = defineModel("showDialog", {
   required: true
 })
 
-const emit = defineEmits(["onChooseAccept", "onChooseReject"],)
+const emit = defineEmits<{
+  onChooseAccept: []
+  onChooseReject: []
+}>()
 
 const coreConfig = CoreConfig.inject()
 const cookiesDialogContent = coreConfig.cookiesDialogContent

--- a/_frontend/src/dialogs/OptOutDialog.vue
+++ b/_frontend/src/dialogs/OptOutDialog.vue
@@ -47,7 +47,7 @@ const showDialog = defineModel("showDialog", {
 
 const disclaimer = CoreConfig.inject().walletChooserDisclaimerPopup ?? ""
 
-const emit = defineEmits(["onAgree"])
+const emit = defineEmits<{ onAgree: [] }>()
 
 const dontShowNextTime = ref(false)
 const handleAgree = () => {

--- a/_frontend/src/dialogs/UpdateAccountController.ts
+++ b/_frontend/src/dialogs/UpdateAccountController.ts
@@ -27,6 +27,10 @@ export enum StakeChoice {
     StakeToAccount = "account"
 }
 
+export function toStakeChoice(value: string, fallback: StakeChoice): StakeChoice {
+    const result = value as StakeChoice
+    return Object.values(StakeChoice).includes(result) ? result : fallback
+}
 
 export class UpdateAccountController extends TransactionController {
 

--- a/_frontend/src/dialogs/UpdateAccountDialog.vue
+++ b/_frontend/src/dialogs/UpdateAccountDialog.vue
@@ -242,7 +242,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["updated"])
+const emit = defineEmits<{ updated: [] }>()
 
 const networkConfig = NetworkConfig.inject()
 const controller = new UpdateAccountController(showDialog, networkConfig)

--- a/_frontend/src/dialogs/UpdateAccountDialog.vue
+++ b/_frontend/src/dialogs/UpdateAccountDialog.vue
@@ -216,6 +216,7 @@ import {
   AutoAssociationMode,
   PeriodUnit,
   StakeChoice,
+  toStakeChoice,
   UpdateAccountController
 } from "@/dialogs/UpdateAccountController.ts";
 import {computed} from "vue";
@@ -253,7 +254,6 @@ const selectedUnit = controller.newAutoRenewPeriodUnit
 const autoAssociationMode = controller.autoAssociationMode
 const maxAutoAssociationInputText = controller.maxAutoAssociationInputText
 const newRecSigRequired = controller.newRecSigRequired
-const stakeChoice = controller.stakeChoice
 const newStakedNodeId = controller.newStakedNodeId
 const newDeclineReward = controller.newDeclineReward
 const stakedAccountIdInputText = controller.stakedAccountIdInputText
@@ -263,6 +263,10 @@ const nodes = controller.nodes
 
 const enableStaking = routeManager.enableStaking
 
+const stakeChoice = computed<string>({
+  get: () => controller.stakeChoice.value as string,
+  set: (value: string) => controller.stakeChoice.value = toStakeChoice(value, StakeChoice.NotStaking)
+})
 
 const visibleIndex = computed(() => {
   let result: number
@@ -274,6 +278,7 @@ const visibleIndex = computed(() => {
       result = 1
       break
     case StakeChoice.NotStaking:
+    default:
       result = 2
       break
   }

--- a/_frontend/src/dialogs/abi/ContractAbiDialog.vue
+++ b/_frontend/src/dialogs/abi/ContractAbiDialog.vue
@@ -89,9 +89,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(
-    ["didUpdateContractState"]
-)
+const emit = defineEmits<{ didUpdateContractState: [] }>()
 
 const controller = new ContractAbiController(showDialog, props.contractCallBuilder)
 

--- a/_frontend/src/dialogs/abi/ContractAbiEntry.vue
+++ b/_frontend/src/dialogs/abi/ContractAbiEntry.vue
@@ -74,7 +74,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["didUpdateContractState"])
+const emit = defineEmits<{ didUpdateContractState: [] }>()
 
 const running = ref(true)
 

--- a/_frontend/src/dialogs/allowance/ApproveAllowanceDialog.vue
+++ b/_frontend/src/dialogs/allowance/ApproveAllowanceDialog.vue
@@ -126,7 +126,7 @@ const showDialog = defineModel("showDialog", {
   required: true
 })
 
-const emit = defineEmits(["allowanceApproved"])
+const emit = defineEmits<{ allowanceApproved: [transactionId: string | null] }>()
 
 const networkConfig = NetworkConfig.inject()
 const controller = new ApproveAllowanceController(showDialog, networkConfig)

--- a/_frontend/src/dialogs/allowance/DeleteNftAllowanceDialog.vue
+++ b/_frontend/src/dialogs/allowance/DeleteNftAllowanceDialog.vue
@@ -60,7 +60,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(["allowanceDeleted"])
+const emit = defineEmits<{ allowanceDeleted: [transactionId: string | null] }>()
 
 const tokenId = computed(() => props.tokenId)
 const spenderId = computed(() => props.spenderId)

--- a/_frontend/src/dialogs/allowance/UpdateCryptoAllowanceDialog.vue
+++ b/_frontend/src/dialogs/allowance/UpdateCryptoAllowanceDialog.vue
@@ -64,7 +64,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["allowanceApproved"])
+const emit = defineEmits<{ allowanceApproved: [transactionId: string | null] }>()
 
 const hbarAllowance = computed(() => props.hbarAllowance)
 const controller = new UpdateCryptoAllowanceController(showDialog, hbarAllowance)

--- a/_frontend/src/dialogs/allowance/UpdateTokenAllowanceDialog.vue
+++ b/_frontend/src/dialogs/allowance/UpdateTokenAllowanceDialog.vue
@@ -63,7 +63,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["allowanceApproved"])
+const emit = defineEmits<{ allowanceApproved: [transactionId: string | null] }>()
 
 const tokenAllowance = computed(() => props.tokenAllowance)
 const controller = new UpdateTokenAllowanceController(showDialog, tokenAllowance)

--- a/_frontend/src/dialogs/core/ModalDialog.vue
+++ b/_frontend/src/dialogs/core/ModalDialog.vue
@@ -53,7 +53,7 @@ const props = defineProps({
 
 const slots = useSlots()
 
-const emit = defineEmits(["onClose"])
+const emit = defineEmits<{ onClose: [] }>()
 
 watch(showDialog, () => {
   if (!showDialog.value) {

--- a/_frontend/src/dialogs/core/ModalDialogButton.vue
+++ b/_frontend/src/dialogs/core/ModalDialogButton.vue
@@ -43,7 +43,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["action"])
+const emit = defineEmits<{ action: [] }>()
 
 const handleAction = () => {
   emit("action")

--- a/_frontend/src/dialogs/core/task/TaskDialog.vue
+++ b/_frontend/src/dialogs/core/task/TaskDialog.vue
@@ -142,7 +142,7 @@ watch(props.controller.showDialog, (show) => {
   }
 })
 
-const emit = defineEmits(["taskDialogDidSucceed"])
+const emit = defineEmits<{ taskDialogDidSucceed: [] }>()
 
 const slots = useSlots()
 

--- a/_frontend/src/dialogs/core/transaction/TransactionDialog.vue
+++ b/_frontend/src/dialogs/core/transaction/TransactionDialog.vue
@@ -96,7 +96,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["transactionDidExecute"])
+const emit = defineEmits<{ transactionDidExecute: [transactionId: string | null] }>()
 
 const slots = useSlots()
 

--- a/_frontend/src/dialogs/core/transaction/TransactionGroupDialog.vue
+++ b/_frontend/src/dialogs/core/transaction/TransactionGroupDialog.vue
@@ -104,7 +104,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["transactionGroupDidExecute"])
+const emit = defineEmits<{ transactionGroupDidExecute: [] }>()
 const taskDidSucceed = () => {
   emit("transactionGroupDidExecute")
 }

--- a/_frontend/src/dialogs/staking/StopStakingDialog.vue
+++ b/_frontend/src/dialogs/staking/StopStakingDialog.vue
@@ -48,7 +48,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(["stakingChanged"])
+const emit = defineEmits<{ stakingChanged: [transactionId: string | null] }>()
 
 const accountId = computed(() => props.accountId)
 const controller = new StopStackingController(showDialog, accountId)

--- a/_frontend/src/dialogs/token/AssociateTokenDialog.vue
+++ b/_frontend/src/dialogs/token/AssociateTokenDialog.vue
@@ -56,7 +56,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["tokenAssociated"])
+const emit = defineEmits<{ tokenAssociated: [transactionId: string | null] }>()
 
 const analyzer = computed(() => props.analyzer)
 const controller = new AssociateTokenController(showDialog, analyzer)

--- a/_frontend/src/dialogs/token/ClaimTokenDialog.vue
+++ b/_frontend/src/dialogs/token/ClaimTokenDialog.vue
@@ -51,7 +51,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["tokenClaimed"])
+const emit = defineEmits<{ tokenClaimed: [transactionId: string | null] }>()
 
 const analyzer = computed(() => props.analyzer)
 const controller = new ClaimTokenController(showDialog, analyzer)

--- a/_frontend/src/dialogs/token/ClaimTokenGroupDialog.vue
+++ b/_frontend/src/dialogs/token/ClaimTokenGroupDialog.vue
@@ -58,7 +58,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(["claimed"])
+const emit = defineEmits<{ claimed: [] }>()
 
 
 const airdrops = computed(() => props.airdrops ?? [])

--- a/_frontend/src/dialogs/token/DissociateTokenDialog.vue
+++ b/_frontend/src/dialogs/token/DissociateTokenDialog.vue
@@ -50,7 +50,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["tokenDissociated"])
+const emit = defineEmits<{ tokenDissociated: [transactionId: string | null] }>()
 
 const analyzer = computed(() => props.analyzer)
 const controller = new DissociateTokenController(showDialog, analyzer)

--- a/_frontend/src/dialogs/token/RejectTokenDialog.vue
+++ b/_frontend/src/dialogs/token/RejectTokenDialog.vue
@@ -51,7 +51,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["tokenRejected"])
+const emit = defineEmits<{ tokenRejected: [transactionId: string | null] }>()
 
 const analyzer = computed(() => props.analyzer)
 const controller = new RejectTokenController(showDialog, analyzer)

--- a/_frontend/src/dialogs/token/RejectTokenGroupDialog.vue
+++ b/_frontend/src/dialogs/token/RejectTokenGroupDialog.vue
@@ -55,7 +55,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(["rejected"])
+const emit = defineEmits<{ rejected: [] }>()
 
 
 const tokens = computed(() => props.tokens ?? [])

--- a/_frontend/src/dialogs/token/WatchTokenDialog.vue
+++ b/_frontend/src/dialogs/token/WatchTokenDialog.vue
@@ -51,7 +51,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["tokenWatched"])
+const emit = defineEmits<{ tokenWatched: [] }>()
 
 const analyzer = computed(() => props.analyzer)
 const controller = new WatchTokenController(showDialog, analyzer)

--- a/_frontend/src/dialogs/verification/ContractVerificationDialog.vue
+++ b/_frontend/src/dialogs/verification/ContractVerificationDialog.vue
@@ -141,7 +141,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["verifyDidComplete"])
+const emit = defineEmits<{ verifyDidComplete: [] }>()
 
 const contractId = computed(() => props.contractId)
 const controller = new ContractVerificationController(showDialog, contractId)

--- a/_frontend/src/dialogs/verification/FileList.vue
+++ b/_frontend/src/dialogs/verification/FileList.vue
@@ -93,7 +93,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['clearAllFiles'])
+const emit = defineEmits<{ clearAllFiles: [] }>()
 
 const currentPage = ref(1);
 const perPage = ref(10);

--- a/_frontend/src/dialogs/wallet_chooser/WalletChooserDialog.vue
+++ b/_frontend/src/dialogs/wallet_chooser/WalletChooserDialog.vue
@@ -87,7 +87,7 @@ const showDialog = defineModel("showDialog", {
 const chosenWallet = ref<WalletItem | null>(null)
 const showDisclaimerDialog = ref(false)
 
-const emit = defineEmits(["chooseWallet"])
+const emit = defineEmits<{ chooseWallet: [wallet: WalletItem] }>()
 
 watch(showDialog, (showing) => {
   if (showing) chosenWallet.value = null
@@ -137,7 +137,9 @@ const gridTemplateColumns = computed(() => {
 
 const handleAgreeDisclaimer = () => {
   showDialog.value = false
-  emit('chooseWallet', chosenWallet.value)
+  if (chosenWallet.value !== null)  {
+    emit('chooseWallet', chosenWallet.value)
+  }
 }
 
 const WALLECT_CONNECT_LOGO =

--- a/_frontend/src/dialogs/wallet_chooser/WalletChooserItem.vue
+++ b/_frontend/src/dialogs/wallet_chooser/WalletChooserItem.vue
@@ -34,7 +34,7 @@ const props = defineProps({
   walletItem: {type: Object as PropType<WalletItem>, required: true},
 })
 
-const emit = defineEmits(["connect"])
+const emit = defineEmits<{ connect: [] }>()
 
 const isSelected = computed(() => {
   return selection.value !== null && selection.value.uuid === props.walletItem.uuid

--- a/_frontend/src/elements/ButtonView.vue
+++ b/_frontend/src/elements/ButtonView.vue
@@ -60,7 +60,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(["action"])
+const emit = defineEmits<{ action: [] }>()
 
 const handleClick = () => {
   emit("action")

--- a/_frontend/src/elements/Copyable.vue
+++ b/_frontend/src/elements/Copyable.vue
@@ -29,7 +29,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['copyMade'])
+const emit = defineEmits<{ copyMade: [] }>()
 
 const copyToClipboard = (): void => {
   if (props.contentToCopy?.length) {


### PR DESCRIPTION
**Description**:

Bump `vue-tsc` dependency from `2.2.12` to `3.3.2`.

This major version brings stronger type checking and implies changes for:
 - `defineEmits()` statements -- event arguments require explicit typing
 - `v-model:` arguments -- mostly with Oruga components