### PR TITLE
fix: (regression) dark mode page controls are white

### DIFF
--- a/_frontend/src/styles/oruga-customization.css
+++ b/_frontend/src/styles/oruga-customization.css
@@ -44,18 +44,46 @@
 
 .o-pagination {
     --oruga-pagination-button-margin: 2px;
-    --oruga-pagination-button-color: var(--text-primary);
-    --oruga-pagination-button-border-width: 2px;
-    --oruga-pagination-button-border-style: solid;
-    --oruga-pagination-button-border-color: var(--background-tertiary);
-    --oruga-pagination-button-border-radius: 12px;
     --oruga-pagination-button-height: 36px;
     --oruga-pagination-button-min-width: 36px;
+    --oruga-pagination-button-border-width: 2px;
+    --oruga-pagination-button-border-style: solid;
+    --oruga-pagination-button-border-radius: 12px;
+
+    --oruga-pagination-button-color: var(--text-primary);
+    --oruga-pagination-button-background-color: transparent;
+    --oruga-pagination-button-border-color: transparent;
+
     --oruga-pagination-button-current-color: var(--text-primary);
-    --oruga-pagination-button-current-background-color: var(--background-tertiary);
+    --oruga-pagination-button-current-background-color: transparent;
     --oruga-pagination-button-current-border-color: var(--light-network-button-color);
-    --oruga-pagination-button-box-shadow: none;
+
+    --oruga-pagination-button-hover-border-color: var(--text-secondary);
+    --oruga-pagination-button-hover-color: var(--text-primary);
 }
+
+/*  ----------------------------------------------------------------------------
+    The rules below avoid the box-shadow focus on hovered and clicked pagination buttons,
+    and re-establish the button styling after selection
+*/
+
+.o-pagination__button:not(.o-pagination__button--disabled):hover,
+.o-pagination button:focus:not(:focus-visible) {
+    box-shadow: none;
+}
+
+.o-pagination__button:focus:not(:hover),
+.o-pagination__button:focus-visible:not(:hover) {
+    border-color: transparent;
+}
+
+.o-pagination__button--current:focus,
+.o-pagination__button--current:focus-visible {
+    border-color: var(--oruga-pagination-button-current-border-color);
+}
+
+/*  ----------------------------------------------------------------------------
+*/
 
 table.o-table {
     margin-bottom: 1rem;

--- a/_frontend/src/styles/oruga-customization.css
+++ b/_frontend/src/styles/oruga-customization.css
@@ -28,10 +28,10 @@
 
 .o-table__root {
     --oruga-table-background-color: var(--background-tertiary);
-    --oruga-table-striped-background-color: var(--background-tertiary);
     --oruga-table-border-radius: 0;
     --oruga-table-color: var(--text-primary);
-    --oruga-table-hoverable-background-color: var(--background-primary);
+    --oruga-table-tr-striped-background-color: var(--background-tertiary);
+    --oruga-table-tr-hover-background-color: var(--background-primary);
     --oruga-table-th-color: var(--text-secondary);
     --oruga-table-th-font-weight: 500 !important;
     --oruga-table-th-border-width: 1px;


### PR DESCRIPTION
**Description**:

Re-establish styling which was partially broken for table/pagination in dark mode after recent Oruga component version bump.

Fixes #2552 

**Notes for reviewer**:

Deployed on staging server.