### PR TITLE
fix: block transactions table with more than 100 transactions

### DIFF
--- a/_frontend/src/schemas/MirrorNodeUtils.ts
+++ b/_frontend/src/schemas/MirrorNodeUtils.ts
@@ -475,12 +475,7 @@ export async function waitForTransactionRefresh(transactionId: string, attemptIn
 
 export async function drainTransactions(r: TransactionResponse, limit: number): Promise<Transaction[]> {
     let result = r.transactions ?? []
-    // let i = 1
     while (r.links?.next && result.length < limit) {
-        // console.log(`drainTransactions (iteration ${i++})`)
-        // console.log(`  - limit:${limit}`)
-        // console.log(`  - result.length:${result.length}`)
-        // console.log(`  - r.links.next:${r.links.next}`)
         const ar = await axios.get<TransactionResponse>(r.links.next)
         if (ar.data.transactions) {
             result = result.concat(ar.data.transactions)

--- a/_frontend/src/utils/cache/TransactionGroupByBlockCache.ts
+++ b/_frontend/src/utils/cache/TransactionGroupByBlockCache.ts
@@ -18,34 +18,41 @@ export class TransactionGroupByBlockCache extends EntityCache<number, Transactio
     //
 
     protected async load(blockNb: number): Promise<Transaction[] | null> {
-        let result: Transaction[] | null
         try {
-            const block = await BlockByNbCache.instance.lookup(blockNb)
-            if (block?.timestamp?.to && block?.count) {
-                const params = {
-                    limit: Math.min(block.count, 100),
-                    timestamp: ["gte:" + block.timestamp.from, "lte:" + block.timestamp.to]
-                }
-                const response = await axios.get<TransactionResponse>("api/v1/transactions", {params: params})
-                result = await drainTransactions(response.data, block.count)
-                if (result.length !== block.count) {
-                    console.warn(`fetchBlockTransactions only retrieved ${result.length} transactions (expected ${block.count}) for block ${blockNb}`)
-                }
-
-                TransactionByHashCache.instance.updateWithTransactions(result)
-                TransactionByTsCache.instance.updateWithTransactions(result)
-            } else {
-                result = null
-            }
+            return await this.fetchBlockTransactions(blockNb)
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status == 404) {
-                result = null
-            } else {
-                throw error
+                return null
             }
+            throw error
+        }
+    }
+
+    private async fetchBlockTransactions(blockNb: number): Promise<Transaction[] | null> {
+        const block = await BlockByNbCache.instance.lookup(blockNb)
+        if (!block?.timestamp || !block.count) {
+            return null
+        }
+        const {from, to} = block.timestamp
+        if (!from || !to) {
+            return null
+        }
+        const params = {
+            limit: Math.min(block.count, 100),
+            timestamp: ["gte:" + from, "lte:" + to]
+        }
+        const response = await axios.get<TransactionResponse>(
+            "api/v1/transactions",
+            {params: params}
+        )
+        const result = await drainTransactions(response.data, block.count)
+        if (result.length !== block.count) {
+            console.warn(`fetchBlockTransactions only retrieved ${result.length} transactions (expected ${block.count}) for block ${blockNb}`)
         }
 
-        return Promise.resolve(result)
+        TransactionByHashCache.instance.updateWithTransactions(result)
+        TransactionByTsCache.instance.updateWithTransactions(result)
+        return result
     }
 }
 

--- a/_frontend/src/utils/cache/TransactionGroupByBlockCache.ts
+++ b/_frontend/src/utils/cache/TransactionGroupByBlockCache.ts
@@ -24,10 +24,14 @@ export class TransactionGroupByBlockCache extends EntityCache<number, Transactio
             if (block?.timestamp?.to && block?.count) {
                 const params = {
                     limit: Math.min(block.count, 100),
-                    timestamp: "lte:" + block.timestamp.to
+                    timestamp: ["gte:" + block.timestamp.from, "lte:" + block.timestamp.to]
                 }
                 const response = await axios.get<TransactionResponse>("api/v1/transactions", {params: params})
-                result = await drainTransactions(response.data, params.limit)
+                result = await drainTransactions(response.data, block.count)
+                if (result.length !== block.count) {
+                    console.warn(`fetchBlockTransactions only retrieved ${result.length} transactions (expected ${block.count}) for block ${blockNb}`)
+                }
+
                 TransactionByHashCache.instance.updateWithTransactions(result)
                 TransactionByTsCache.instance.updateWithTransactions(result)
             } else {

--- a/_frontend/tests/unit/Mocks.ts
+++ b/_frontend/tests/unit/Mocks.ts
@@ -2105,141 +2105,147 @@ export const SAMPLE_BATCH_TRANSACTION: TransactionResponse = {
 
 export const SAMPLE_PARENT_CHILD_TRANSACTIONS: TransactionResponse = {
     "transactions":
-        [{
-            "bytes": null,
-            "charged_tx_fee": 160800000,
-            "consensus_timestamp": "1662470957.014478705",
-            "entity_id": "0.0.48193749",
-            "high_volume": false,
-            "max_fee": "200000000",
-            "memo_base64": "",
-            "name": TransactionType.CONTRACTCALL,
-            "nft_transfers": [],
-            "node": "0.0.5",
-            "nonce": 0,
-            "parent_consensus_timestamp": null,
-            "result": "SUCCESS",
-            "scheduled": false,
-            "staking_reward_transfers": [],
-            "token_transfers": [],
-            "transaction_hash": "jthcv17LsslWUAzQkuIzeVMFpwJ3Uf5g6sSp1aZ8qqSWTz52XhPaMGAzt/5UgYob",
-            "transaction_id": "0.0.48113503-1662470948-432078184",
-            "transfers": [
-                {"account": "0.0.98", "amount": 160800000, "is_approval": false},
-                {"account": "0.0.48113503", "amount": -5160800000, "is_approval": false},
-                {"account": "0.0.48193749", "amount": 5000000000, "is_approval": false}
-            ],
-            "valid_duration_seconds": "120",
-            "valid_start_timestamp": "1662470948.432078184"
-        }, {
-            "bytes": null,
-            "charged_tx_fee": 0,
-            "consensus_timestamp": "1662470957.014478706",
-            "entity_id": "0.0.48193741",
-            "high_volume": false,
-            "max_fee": "0",
-            "memo_base64": "",
-            "name": TransactionType.TOKENMINT,
-            "nft_transfers": [{
-                "is_approval": false,
-                "receiver_account_id": "0.0.48113503",
-                "sender_account_id": null,
-                "serial_number": 1,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48113503",
-                "sender_account_id": null,
-                "serial_number": 2,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48113503",
-                "sender_account_id": null,
-                "serial_number": 3,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48113503",
-                "sender_account_id": null,
-                "serial_number": 4,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48113503",
-                "sender_account_id": null,
-                "serial_number": 5,
-                "token_id": "0.0.48193741"
-            }],
-            "node": null,
-            "nonce": 1,
-            "parent_consensus_timestamp": "1662470957.014478705",
-            "result": "SUCCESS",
-            "scheduled": false,
-            "staking_reward_transfers": [],
-            "token_transfers": [],
-            "transaction_hash": "gLobKtgAWqka6N/3K5o2TS8XKeQIafH8wxkzZfycRJcOfJ7vccaR/6drUU8j6Xci",
-            "transaction_id": "0.0.48113503-1662470948-432078184",
-            "transfers": [],
-            "valid_duration_seconds": "120",
-            "valid_start_timestamp": "1662470948.432078184"
-        }, {
-            "bytes": null,
-            "charged_tx_fee": 0,
-            "consensus_timestamp": "1662470957.014478707",
-            "entity_id": null,
-            "high_volume": false,
-            "max_fee": "0",
-            "memo_base64": "",
-            "name": TransactionType.CRYPTOTRANSFER,
-            "nft_transfers": [{
-                "is_approval": false,
-                "receiver_account_id": "0.0.48193739",
-                "sender_account_id": "0.0.48113503",
-                "serial_number": 1,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48193739",
-                "sender_account_id": "0.0.48113503",
-                "serial_number": 2,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48193739",
-                "sender_account_id": "0.0.48113503",
-                "serial_number": 3,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48193739",
-                "sender_account_id": "0.0.48113503",
-                "serial_number": 4,
-                "token_id": "0.0.48193741"
-            }, {
-                "is_approval": false,
-                "receiver_account_id": "0.0.48193739",
-                "sender_account_id": "0.0.48113503",
-                "serial_number": 5,
-                "token_id": "0.0.48193741"
-            }],
-            "node": null,
-            "nonce": 2,
-            "parent_consensus_timestamp": "1662470957.014478705",
-            "result": "SUCCESS",
-            "scheduled": false,
-            "staking_reward_transfers": [],
-            "token_transfers": [],
-            "transaction_hash": "Gqep6H2B3iE4id1qPG92q51LP20WXW7r53ujWlKekk8RBhYTfpFiD4iJBkK8UnGc",
-            "transaction_id": "0.0.48113503-1662470948-432078184",
-            "transfers": [],
-            "valid_duration_seconds": "120",
-            "valid_start_timestamp": "1662470948.432078184"
-        }],
+        [
+            {
+                "bytes": null,
+                "charged_tx_fee": 160800000,
+                "consensus_timestamp": "1662470957.014478705",
+                "entity_id": "0.0.48193749",
+                "high_volume": false,
+                "max_fee": "200000000",
+                "memo_base64": "",
+                "name": TransactionType.CONTRACTCALL,
+                "nft_transfers": [],
+                "node": "0.0.5",
+                "nonce": 0,
+                "parent_consensus_timestamp": null,
+                "result": "SUCCESS",
+                "scheduled": false,
+                "staking_reward_transfers": [],
+                "token_transfers": [],
+                "transaction_hash": "jthcv17LsslWUAzQkuIzeVMFpwJ3Uf5g6sSp1aZ8qqSWTz52XhPaMGAzt/5UgYob",
+                "transaction_id": "0.0.48113503-1662470948-432078184",
+                "transfers": [
+                    {"account": "0.0.98", "amount": 160800000, "is_approval": false},
+                    {"account": "0.0.48113503", "amount": -5160800000, "is_approval": false},
+                    {"account": "0.0.48193749", "amount": 5000000000, "is_approval": false}
+                ],
+                "valid_duration_seconds": "120",
+                "valid_start_timestamp": "1662470948.432078184"
+            },
+            {
+                "bytes": null,
+                "charged_tx_fee": 0,
+                "consensus_timestamp": "1662470957.014478706",
+                "entity_id": "0.0.48193741",
+                "high_volume": false,
+                "max_fee": "0",
+                "memo_base64": "",
+                "name": TransactionType.TOKENMINT,
+                "nft_transfers": [{
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48113503",
+                    "sender_account_id": null,
+                    "serial_number": 1,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48113503",
+                    "sender_account_id": null,
+                    "serial_number": 2,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48113503",
+                    "sender_account_id": null,
+                    "serial_number": 3,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48113503",
+                    "sender_account_id": null,
+                    "serial_number": 4,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48113503",
+                    "sender_account_id": null,
+                    "serial_number": 5,
+                    "token_id": "0.0.48193741"
+                }],
+                "node": null,
+                "nonce": 1,
+                "parent_consensus_timestamp": "1662470957.014478705",
+                "result": "SUCCESS",
+                "scheduled": false,
+                "staking_reward_transfers": [],
+                "token_transfers": [],
+                "transaction_hash": "gLobKtgAWqka6N/3K5o2TS8XKeQIafH8wxkzZfycRJcOfJ7vccaR/6drUU8j6Xci",
+                "transaction_id": "0.0.48113503-1662470948-432078184",
+                "transfers": [],
+                "valid_duration_seconds": "120",
+                "valid_start_timestamp": "1662470948.432078184"
+            },
+            {
+                "bytes": null,
+                "charged_tx_fee": 0,
+                "consensus_timestamp": "1662470957.014478707",
+                "entity_id": null,
+                "high_volume": false,
+                "max_fee": "0",
+                "memo_base64": "",
+                "name": TransactionType.CRYPTOTRANSFER,
+                "nft_transfers": [{
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48193739",
+                    "sender_account_id": "0.0.48113503",
+                    "serial_number": 1,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48193739",
+                    "sender_account_id": "0.0.48113503",
+                    "serial_number": 2,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48193739",
+                    "sender_account_id": "0.0.48113503",
+                    "serial_number": 3,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48193739",
+                    "sender_account_id": "0.0.48113503",
+                    "serial_number": 4,
+                    "token_id": "0.0.48193741"
+                }, {
+                    "is_approval": false,
+                    "receiver_account_id": "0.0.48193739",
+                    "sender_account_id": "0.0.48113503",
+                    "serial_number": 5,
+                    "token_id": "0.0.48193741"
+                }],
+                "node": null,
+                "nonce": 2,
+                "parent_consensus_timestamp": "1662470957.014478705",
+                "result": "SUCCESS",
+                "scheduled": false,
+                "staking_reward_transfers": [],
+                "token_transfers": [],
+                "transaction_hash": "Gqep6H2B3iE4id1qPG92q51LP20WXW7r53ujWlKekk8RBhYTfpFiD4iJBkK8UnGc",
+                "transaction_id": "0.0.48113503-1662470948-432078184",
+                "transfers": [],
+                "valid_duration_seconds": "120",
+                "valid_start_timestamp": "1662470948.432078184"
+            }
+        ],
     "links": {
         next: null
     }
 }
+
+export const SAMPLE_BLOCK_TRANSACTIONS: TransactionResponse = {...SAMPLE_PARENT_CHILD_TRANSACTIONS}
 
 export const SAMPLE_PARENT_CHILD_AND_UNRELATED_TRANSACTIONS: TransactionByIdResponse = {
     "transactions": [

--- a/_frontend/tests/unit/utils/cache/TransactionGroupByBlockCache.spec.ts
+++ b/_frontend/tests/unit/utils/cache/TransactionGroupByBlockCache.spec.ts
@@ -1,56 +1,172 @@
 // SPDX-License-Identifier: Apache-2.0
 
-
 import {describe, expect, test} from 'vitest'
 import {TransactionGroupByBlockCache} from "@/utils/cache/TransactionGroupByBlockCache";
-import {SAMPLE_BLOCK, SAMPLE_PARENT_CHILD_TRANSACTIONS} from "../../Mocks";
+import {SAMPLE_BLOCK, SAMPLE_BLOCK_TRANSACTIONS} from "../../Mocks";
 import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios, {AxiosRequestConfig} from "axios";
 import {TransactionByHashCache} from "@/utils/cache/TransactionByHashCache";
 import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache";
+import {TransactionResponse} from "@/schemas/MirrorNodeSchemas";
+import {fetchGetURLs} from "../../MockUtils.ts";
 
 describe("TransactionGroupByBlockCache", () => {
 
-    test("TransactionGroupByBlockCache", async () => {
+    test("fetches transactions using both gte and lte timestamps, caches result", async () => {
 
         expect(TransactionGroupByBlockCache.instance.isEmpty()).toBeTruthy()
 
-
         const mock = new MockAdapter(axios as any);
 
-        const matcher1 = "/api/v1/blocks/" + SAMPLE_BLOCK.number
-        mock.onGet(matcher1).reply(200, SAMPLE_BLOCK);
+        mock.onGet("/api/v1/blocks/" + SAMPLE_BLOCK.number).reply(200, SAMPLE_BLOCK);
 
-        const matcher2 = "/api/v1/transactions"
-        mock.onGet(matcher2).reply(((config: AxiosRequestConfig) => {
-            if (config.params.timestamp == "lte:" + SAMPLE_BLOCK.timestamp.to
-                && config.params.limit == SAMPLE_BLOCK.count) {
-                return [200, SAMPLE_PARENT_CHILD_TRANSACTIONS]
+        mock.onGet("/api/v1/transactions").reply(((config: AxiosRequestConfig) => {
+            const ts: string[] = config.params.timestamp
+            if (Array.isArray(ts)
+                && ts[0] === "gte:" + SAMPLE_BLOCK.timestamp!.from
+                && ts[1] === "lte:" + SAMPLE_BLOCK.timestamp!.to
+                && config.params.limit === SAMPLE_BLOCK.count) {
+                return [200, SAMPLE_BLOCK_TRANSACTIONS]
             } else {
                 return [404]
             }
         }) as any)
 
         // lookup() triggers http requests
-        const blockNumber = SAMPLE_BLOCK.number
+        const blockNumber = SAMPLE_BLOCK.number!
         const transactions = await TransactionGroupByBlockCache.instance.lookup(blockNumber)
         await flushPromises()
-        expect(transactions).toStrictEqual(SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions)
-        expect(mock.history.get.length).toBe(2)
+        expect(transactions).toStrictEqual(SAMPLE_BLOCK_TRANSACTIONS.transactions)
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/blocks/" + blockNumber,
+            "api/v1/transactions",
+        ])
 
-        // lookup() triggers no http requests
+        // lookup() triggers no http requests (cached)
         mock.resetHistory()
         const transactions2 = await TransactionGroupByBlockCache.instance.lookup(blockNumber)
         await flushPromises()
-        expect(transactions2).toStrictEqual(SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions)
+        expect(transactions2).toStrictEqual(SAMPLE_BLOCK_TRANSACTIONS.transactions)
         expect(mock.history.get.length).toBe(0)
 
-        // Checks that TransactionByHashCache and TransactionByTsCache has been populated
-        for (const t of SAMPLE_PARENT_CHILD_TRANSACTIONS.transactions!) {
+        // Checks that TransactionByHashCache and TransactionByTsCache have been populated
+        for (const t of SAMPLE_BLOCK_TRANSACTIONS.transactions!) {
             expect(TransactionByHashCache.instance.contains(t.transaction_hash)).toBeTruthy()
             expect(TransactionByTsCache.instance.contains(t.consensus_timestamp)).toBeTruthy()
         }
+
+        mock.restore()
+    })
+
+    test("returns null when block is not found (404)", async () => {
+        const mock = new MockAdapter(axios as any);
+        mock.onGet("/api/v1/blocks/99999999").reply(404);
+
+        const transactions = await TransactionGroupByBlockCache.instance.lookup(99999999)
+        await flushPromises()
+        expect(transactions).toBeNull()
+
+        mock.restore()
+    })
+
+    test("returns null when block timestamp.from is missing", async () => {
+        const block = {...SAMPLE_BLOCK, timestamp: {from: undefined, to: SAMPLE_BLOCK.timestamp!.to}}
+        const mock = new MockAdapter(axios as any);
+        mock.onGet("/api/v1/blocks/" + SAMPLE_BLOCK.number).reply(200, block);
+
+        const transactions = await TransactionGroupByBlockCache.instance.lookup(SAMPLE_BLOCK.number!)
+        await flushPromises()
+        expect(transactions).toBeNull()
+        // transactions endpoint must not have been called
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/blocks/" + block.number!
+        ])
+
+        mock.restore()
+    })
+
+    test("returns null when block timestamp.to is missing", async () => {
+        const block = {...SAMPLE_BLOCK, timestamp: {from: SAMPLE_BLOCK.timestamp!.from, to: null}}
+        const mock = new MockAdapter(axios as any);
+        mock.onGet("/api/v1/blocks/" + SAMPLE_BLOCK.number).reply(200, block);
+
+        const transactions = await TransactionGroupByBlockCache.instance.lookup(SAMPLE_BLOCK.number!)
+        await flushPromises()
+        expect(transactions).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/blocks/" + block.number!
+        ])
+
+        mock.restore()
+    })
+
+    test("returns null when block count is missing", async () => {
+        const block = {...SAMPLE_BLOCK, count: undefined}
+        const mock = new MockAdapter(axios as any);
+        mock.onGet("/api/v1/blocks/" + SAMPLE_BLOCK.number).reply(200, block);
+
+        const transactions = await TransactionGroupByBlockCache.instance.lookup(SAMPLE_BLOCK.number!)
+        await flushPromises()
+        expect(transactions).toBeNull()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/blocks/" + block.number!
+        ])
+
+        mock.restore()
+    })
+
+    test("caps request limit at 100 when block count exceeds 100", async () => {
+        const bigBlock = {...SAMPLE_BLOCK, count: 150}
+        const mock = new MockAdapter(axios as any);
+        mock.onGet("/api/v1/blocks/" + SAMPLE_BLOCK.number).reply(200, bigBlock);
+
+        let capturedLimit: number | undefined
+        mock.onGet("/api/v1/transactions").reply(((config: AxiosRequestConfig) => {
+            capturedLimit = config.params.limit
+            return [200, SAMPLE_BLOCK_TRANSACTIONS]
+        }) as any)
+
+        await TransactionGroupByBlockCache.instance.lookup(SAMPLE_BLOCK.number!)
+        await flushPromises()
+        expect(capturedLimit).toBe(100)
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/blocks/" + bigBlock.number!,
+            "api/v1/transactions",
+        ])
+
+        mock.restore()
+    })
+
+    test("follows pagination links to collect all transactions", async () => {
+        const block = SAMPLE_BLOCK
+        const [t0, t1, t2] = SAMPLE_BLOCK_TRANSACTIONS.transactions!
+        const page1: TransactionResponse = {
+            transactions: [t0, t1],
+            links: {next: "/api/v1/transactions?timestamp=gte:X&timestamp=lt:Y&limit=2"}
+        }
+        const page2: TransactionResponse = {transactions: [t2], links: {next: null}}
+
+        const mock = new MockAdapter(axios as any);
+        mock.onGet("/api/v1/blocks/" + SAMPLE_BLOCK.number).reply(200, block);
+
+        let callCount = 0
+        // Use regex to match both the initial request and the pagination URL (which embeds query params inline)
+        mock.onGet(/\/api\/v1\/transactions/).reply((() => {
+            callCount++
+            return callCount === 1 ? [200, page1] : [200, page2]
+        }) as any)
+
+        const transactions = await TransactionGroupByBlockCache.instance.lookup(SAMPLE_BLOCK.number!)
+        await flushPromises()
+        expect(transactions).toStrictEqual([t0, t1, t2])
+        // block fetch + first page + second page
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/blocks/" + block.number!,
+            "api/v1/transactions",
+            "/api/v1/transactions?timestamp=gte:X&timestamp=lt:Y&limit=2",
+        ])
 
         mock.restore()
     })


### PR DESCRIPTION
**Description**:

`TransactionsByBlockCache` now uses block timestamp range (`gte:block.timestamp.from` and `lte:block.timestamp.to`) in the initial MN query, and then `drainTransactions()` with a limit set to the block.count in order to obtain all transactions in the block.

Refactor TransactionsByBlockCache to get rid of lint error related to complexity.

Add tests to `TransactionGroupByBlockCache.spec.ts‎`

**Related issue(s)**:

Fixes #2511

Deployed on staging. 
Check with:  `<server-url>/mainnet/block/95286477`
