### PR TITLE
chore: Update CODEOWNERS to include new maintainer 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hiero-ledger/github-maintainers
-/.github/workflows/                             @hiero-ledger/github-maintainers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-mirror-node-explorer-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers


### PR DESCRIPTION
## Description

This pull request makes a small update to the `.github/CODEOWNERS` file. The change adds `@hiero-ledger/hiero-mirror-node-explorer-maintainers` as code owners for the `.github/workflows/` directory, ensuring that both teams must approve changes to GitHub Actions workflows.

## Related Issue(s)

- Closes #2594 