### PR TITLE
feat: support delegation_address field for accounts

### DIFF
--- a/_frontend/src/pages/AccountDetails_Summary.vue
+++ b/_frontend/src/pages/AccountDetails_Summary.vue
@@ -201,6 +201,14 @@
           <StringValue :string-value="account?.ethereum_nonce?.toString()"/>
         </template>
       </Property>
+      <template v-if="delegationAddress">
+        <Property id="delegationAddress">
+          <template #name>Delegation Address</template>
+          <template #value>
+            <EVMAddress :address="delegationAddress" show-id compact/>
+          </template>
+        </Property>
+      </template>
       <template v-if="nbOfHooks">
         <Property id="numOfHooks">
           <template #name>Number of Hooks</template>
@@ -407,6 +415,7 @@ const nodeId = accountLocParser.nodeId
 const ethereumAddress = accountLocParser.ethereumAddress
 const stakePeriodStart = accountLocParser.stakePeriodStart
 const stakedAccountId = accountLocParser.stakedAccountId
+const delegationAddress = accountLocParser.delegationAddress
 const stakedNodeDescription = stakedNodeAnalyzer.nodeDescription
 
 </script>

--- a/_frontend/src/schemas/MirrorNodeSchemas.ts
+++ b/_frontend/src/schemas/MirrorNodeSchemas.ts
@@ -18,6 +18,7 @@ export interface AccountInfo {
     auto_renew_period: number | null
     balance: Balance | null
     created_timestamp: string | null
+    delegation_address: string | null | undefined   // A network entity encoded as an EVM address in hex. '0x' when unset.
     deleted: boolean | null
     expiry_timestamp: string | null
     key: Key | null

--- a/_frontend/src/utils/parser/AccountLocParser.ts
+++ b/_frontend/src/utils/parser/AccountLocParser.ts
@@ -130,6 +130,12 @@ export class AccountLocParser {
             : this.isInactiveEvmAddress.value ? this.accountLocObj.value?.toString() : null
     })
 
+    public readonly delegationAddress = computed(() => {
+        const address = this.accountInfo.value?.delegation_address
+        return address != null && address !== '0x' ? address : null
+    })
+
+    // eslint-disable-next-line complexity
     public readonly errorNotification: ComputedRef<string | null> = computed(() => {
         let result: string | null
         const l = this.accountLoc.value

--- a/_frontend/tests/unit/account/AccountDetails.spec.ts
+++ b/_frontend/tests/unit/account/AccountDetails.spec.ts
@@ -193,6 +193,40 @@ describe("AccountDetails.vue", () => {
         expect(wrapper.get("#stakedToName").text()).toBe("Staked to")
         expect(wrapper.get("#stakedToValue").text()).toBe("None")
 
+        expect(wrapper.find("#delegationAddress").exists()).toBe(false)
+
+        mock.restore()
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("AccountDetails default tab should display delegation address", async () => {
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios as any);
+
+        const account = {...SAMPLE_ACCOUNT, delegation_address: "0x00000000000000000000000000000000000b2608"}
+        const accountId = account.account
+
+        mock.onGet("/api/v1/accounts/" + accountId).reply(200, account);
+
+        const wrapper = mount(AccountDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                accountId: accountId
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        const delegationText = wrapper.get("#delegationAddressValue").text()
+        expect(delegationText).toContain("0x00…0b2608")
+        expect(delegationText).toContain("0.0.730632")
+
         mock.restore()
         wrapper.unmount()
         await flushPromises()


### PR DESCRIPTION
**Description**:

Display additional property DELEGATION ADDRESS in AccountDetails > Summary view when the delegation_address field is present in AccountInfo. As usual the value is the (copyable) 20 byte EVM address followed by a link to the corresponding entity ID (if found).

**Related issue(s)**:

Fixes #2560 

**Notes for reviewer**:
<img width="1312" height="653" alt="Screenshot 2026-07-07 at 11 26 36" src="https://github.com/user-attachments/assets/92ef6e3a-2676-471f-a0a6-eb3a51edcccc" />

