### PR TITLE
chore: hiero-mirror-node-linux-large to release docker container

### DIFF
--- a/.github/workflows/zxc-release-explorer-docker-container.yaml
+++ b/.github/workflows/zxc-release-explorer-docker-container.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   container:
     name: Container
-    runs-on: hiero-mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-large
     defaults:
       run:
         working-directory: ./_frontend


### PR DESCRIPTION
**Description**:

Use `hiero-mirror-node-linux-large` to run `zxc-release-explorer-docker-container.yaml` workflow, like already done for `zxc-compile-explorer-code.yaml`